### PR TITLE
feat(e2e): add Playwright E2E testing setup and update app titles

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -11,7 +11,7 @@
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Create TanStack App - admin</title>
+    <title>Playr Admin</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/artist/index.html
+++ b/apps/artist/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -11,7 +11,7 @@
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Create TanStack App - artist</title>
+    <title>Playr Artist</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -1,0 +1,1 @@
+playwright-report/**

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -1,1 +1,2 @@
 playwright-report/**
+test-results/**

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,7 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:codegen": "playwright codegen",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --fix"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.0",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -6,6 +6,15 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "devDependencies": {
+    "@playwright/test": "^1.58.0",
+    "@repo/configs": "workspace:*",
+    "@types/node": "catalog:",
+    "dotenv": "^17.2.3",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "typescript": "catalog:"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC"

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@repo/e2e",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from "@playwright/test";
+import * as dotenv from "dotenv";
+import path from "path";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./src",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [["list"], ["html", { open: "never" }]],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "web",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env.VITE_WEB_URL || "http://localhost:3000",
+      },
+      testMatch: /.*\/web\/.*\.spec\.ts/,
+    },
+    {
+      name: "admin",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env.VITE_ADMIN_URL || "http://localhost:3002",
+      },
+      testMatch: /.*\/admin\/.*\.spec\.ts/,
+    },
+    {
+      name: "artist",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: process.env.VITE_ARTIST_URL || "http://localhost:3001",
+      },
+      testMatch: /.*\/artist\/.*\.spec\.ts/,
+    },
+    {
+      name: "api",
+      use: {
+        baseURL: process.env.VITE_API_URL || "http://localhost:8000",
+      },
+      testMatch: /.*\/api\/.*\.spec\.ts/,
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: process.env.CI
+    ? {
+        command: "pnpm turbo run start", // Validation: Adjust this command if 'start' is not the correct one to run all apps
+        url: "http://localhost:8000/health", // Wait for API to be up? Or wait for all? Playwright webServer supports waiting.
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      }
+    : undefined,
+});

--- a/apps/e2e/src/web/example.spec.ts
+++ b/apps/e2e/src/web/example.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("has title", async ({ page }) => {
+  await page.goto("/");
+
+  // Expect a title "to contain" a substring.
+  // Note: Adjust this expectation based on your actual app title
+  await expect(page).toHaveTitle(/Playr/);
+});

--- a/apps/e2e/src/web/unit.spec.ts
+++ b/apps/e2e/src/web/unit.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "@playwright/test";
+
+test("basic environment check", async () => {
+  expect(1 + 1).toBe(2);
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@repo/configs/typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "include": ["src", "playwright.config.ts"]
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Web site created using create-tsrouter-app" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Create TanStack App - web</title>
+    <title>Playr Web</title>
   </head>
   <body>
     <div id="app"></div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,21 @@ settings:
 
 catalogs:
   default:
+    '@types/node':
+      specifier: ^22.19.7
+      version: 22.19.7
+    eslint:
+      specifier: ^9.39.2
+      version: 9.39.2
     prettier:
       specifier: ^3.8.1
       version: 3.8.1
+    react:
+      specifier: ^19.2.4
+      version: 19.2.4
+    react-dom:
+      specifier: ^19.2.4
+      version: 19.2.4
     typescript:
       specifier: 5.9.3
       version: 5.9.3
@@ -335,6 +347,30 @@ importers:
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
+
+  apps/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.0
+        version: 1.58.0
+      '@repo/configs':
+        specifier: workspace:*
+        version: link:../../packages/configs
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.7
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   apps/web:
     dependencies:
@@ -1283,6 +1319,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.58.0':
+    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/adapter-pg@7.3.0':
     resolution: {integrity: sha512-iuYQMbIPO6i9O45Fv8TB7vWu00BXhCaNAShenqF7gLExGDbnGp5BfFB4yz1K59zQ59jF6tQ9YHrg0P6/J3OoLg==}
@@ -2913,6 +2954,11 @@ packages:
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3860,6 +3906,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.0:
+    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.0:
+    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5557,6 +5613,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.58.0':
+    dependencies:
+      playwright: 1.58.0
 
   '@prisma/adapter-pg@7.3.0':
     dependencies:
@@ -7439,6 +7499,9 @@ snapshots:
 
   fs-monkey@1.1.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8333,6 +8396,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.58.0: {}
+
+  playwright@1.58.0:
+    dependencies:
+      playwright-core: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
# E2E Testing Setup and App Title Updates

This PR adds end-to-end testing capabilities to the project and updates application titles:

- Added a new `e2e` application with Playwright test configuration
- Set up proper test directory structure with initial example tests
- Configured multiple test projects for web, admin, artist, and API
- Added test runner scripts in package.json for various testing modes (headless, UI, debug)
- Updated HTML titles across all applications to use "Playr" branding
- Changed DOCTYPE declarations to lowercase in HTML files
- Added appropriate gitignore rules for test results and reports