### PR TITLE
refactor(web): improve code formatting in useRegisterForm test

### DIFF
--- a/apps/web/src/hooks/forms/useRegisterForm.test.ts
+++ b/apps/web/src/hooks/forms/useRegisterForm.test.ts
@@ -393,20 +393,22 @@ describe('useRegisterForm', () => {
       result.current.handleChange('gender', 'male');
     });
 
-    const safeParseSpy = vi.spyOn(RegisterRequestSchema, 'safeParse').mockImplementation((data: unknown) => {
-      const input = data as RegisterRequest;
-      if (input.password) {
+    const safeParseSpy = vi
+      .spyOn(RegisterRequestSchema, 'safeParse')
+      .mockImplementation((data: unknown) => {
+        const input = data as RegisterRequest;
+        if (input.password) {
+          return {
+            success: false,
+            error: new z.ZodError([]),
+          } as z.ZodSafeParseResult<RegisterRequest>;
+        }
         return {
-          success: false,
-          error: new z.ZodError([]),
+          success: true,
+          data: input,
         } as z.ZodSafeParseResult<RegisterRequest>;
-      }
-      return {
-        success: true,
-        data: input,
-      } as z.ZodSafeParseResult<RegisterRequest>;
-    });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+      });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     let submitResult;
     act(() => {


### PR DESCRIPTION
### TL;DR

Improved code formatting in the `useRegisterForm.test.ts` file.

### What changed?

- Reformatted the `safeParseSpy` mock implementation with proper indentation
- Fixed spacing in the `consoleSpy` mock implementation
- Applied consistent code style throughout the test file

### How to test?

Run the existing tests to ensure they still pass:
```
npm test -- useRegisterForm
```

### Why make this change?

This change improves code readability and maintains consistent formatting standards across the codebase. Properly formatted code is easier to review, maintain, and understand.