### PR TITLE
feat(api): implement artists management with CRUD operations

### DIFF
--- a/apps/api/src/features/artists/artists.controller.ts
+++ b/apps/api/src/features/artists/artists.controller.ts
@@ -1,6 +1,42 @@
-import { Controller } from '@nestjs/common';
+import { CurrentUser } from '@/common/decorators/current-user.decorator';
+import { JwtAuthGuard } from '@/shared/guards/jwt-auth.guard';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ZodArtist } from '@repo/contracts';
+import { CreateArtistCommand } from './commands/impl/create-artist.command';
+import { CreateArtistRequestDto } from './dto/create-artist.request.dto';
+import { GetPrivateArtistsResponseDto } from './dto/get-private-artists.response.dto';
+import { GetPrivateArtistsQuery } from './queries/impl/get-private-artists.query';
 
 @Controller('artists')
 export class ArtistsController {
-  constructor() { }
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) { }
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Create a new artist in private library' })
+  async createArtist(
+    @Body() request: CreateArtistRequestDto,
+    @CurrentUser('id') userId: string,
+  ): Promise<ZodArtist> {
+    const command = new CreateArtistCommand(request, userId);
+    return this.commandBus.execute(command);
+  }
+
+  @Get('private')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get all private artists' })
+  @ApiResponse({
+    status: 200,
+    description: 'Private artists retrieved successfully',
+    type: GetPrivateArtistsResponseDto,
+  })
+  async getPrivateArtists(@CurrentUser('id') userId: string): Promise<ZodArtist[]> {
+    const query = new GetPrivateArtistsQuery(userId);
+    return this.queryBus.execute(query);
+  }
 }

--- a/apps/api/src/features/artists/artists.controller.ts
+++ b/apps/api/src/features/artists/artists.controller.ts
@@ -1,12 +1,14 @@
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '@/shared/guards/jwt-auth.guard';
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ZodArtist } from '@repo/contracts';
 import { CreateArtistCommand } from './commands/impl/create-artist.command';
+import { DeleteArtistCommand } from './commands/impl/delete-artist.command';
 import { UpdateArtistCommand } from './commands/impl/update-artist.command';
 import { CreateArtistRequestDto } from './dto/create-artist.request.dto';
+import { DeleteArtistResponseDto } from './dto/delete-artist.response.dto';
 import { GetPrivateArtistsResponseDto } from './dto/get-private-artists.response.dto';
 import { UpdateArtistRequestDto } from './dto/update-artist.request.dto';
 import { GetPrivateArtistsQuery } from './queries/impl/get-private-artists.query';
@@ -51,6 +53,22 @@ export class ArtistsController {
     @CurrentUser('id') userId: string,
   ): Promise<ZodArtist> {
     const command = new UpdateArtistCommand(id, request, userId);
+    return this.commandBus.execute(command);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Delete a private artist' })
+  @ApiResponse({
+    status: 200,
+    description: 'Artist deleted successfully',
+    type: DeleteArtistResponseDto,
+  })
+  async deleteArtist(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+  ): Promise<ZodArtist> {
+    const command = new DeleteArtistCommand(id, userId);
     return this.commandBus.execute(command);
   }
 }

--- a/apps/api/src/features/artists/artists.controller.ts
+++ b/apps/api/src/features/artists/artists.controller.ts
@@ -1,12 +1,14 @@
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
 import { JwtAuthGuard } from '@/shared/guards/jwt-auth.guard';
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ZodArtist } from '@repo/contracts';
 import { CreateArtistCommand } from './commands/impl/create-artist.command';
+import { UpdateArtistCommand } from './commands/impl/update-artist.command';
 import { CreateArtistRequestDto } from './dto/create-artist.request.dto';
 import { GetPrivateArtistsResponseDto } from './dto/get-private-artists.response.dto';
+import { UpdateArtistRequestDto } from './dto/update-artist.request.dto';
 import { GetPrivateArtistsQuery } from './queries/impl/get-private-artists.query';
 
 @Controller('artists')
@@ -14,7 +16,7 @@ export class ArtistsController {
   constructor(
     private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
-  ) { }
+  ) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
@@ -38,5 +40,17 @@ export class ArtistsController {
   async getPrivateArtists(@CurrentUser('id') userId: string): Promise<ZodArtist[]> {
     const query = new GetPrivateArtistsQuery(userId);
     return this.queryBus.execute(query);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Update private artist detail' })
+  async updateArtist(
+    @Param('id') id: string,
+    @Body() request: UpdateArtistRequestDto,
+    @CurrentUser('id') userId: string,
+  ): Promise<ZodArtist> {
+    const command = new UpdateArtistCommand(id, request, userId);
+    return this.commandBus.execute(command);
   }
 }

--- a/apps/api/src/features/artists/artists.controller.ts
+++ b/apps/api/src/features/artists/artists.controller.ts
@@ -1,0 +1,6 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('artists')
+export class ArtistsController {
+  constructor() { }
+}

--- a/apps/api/src/features/artists/artists.controller.ts
+++ b/apps/api/src/features/artists/artists.controller.ts
@@ -1,18 +1,22 @@
 import { CurrentUser } from '@/common/decorators/current-user.decorator';
+import { ApiErrorResponseDto } from '@/common/dto/api-error.response.dto';
 import { JwtAuthGuard } from '@/shared/guards/jwt-auth.guard';
 import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ZodArtist } from '@repo/contracts';
 import { CreateArtistCommand } from './commands/impl/create-artist.command';
 import { DeleteArtistCommand } from './commands/impl/delete-artist.command';
 import { UpdateArtistCommand } from './commands/impl/update-artist.command';
 import { CreateArtistRequestDto } from './dto/create-artist.request.dto';
+import { CreateArtistResponseDto } from './dto/create-artist.response.dto';
 import { DeleteArtistResponseDto } from './dto/delete-artist.response.dto';
 import { GetPrivateArtistsResponseDto } from './dto/get-private-artists.response.dto';
 import { UpdateArtistRequestDto } from './dto/update-artist.request.dto';
+import { UpdateArtistResponseDto } from './dto/update-artist.response.dto';
 import { GetPrivateArtistsQuery } from './queries/impl/get-private-artists.query';
 
+@ApiTags('Artists')
 @Controller('artists')
 export class ArtistsController {
   constructor(
@@ -23,6 +27,31 @@ export class ArtistsController {
   @Post()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Create a new artist in private library' })
+  @ApiResponse({
+    status: 201,
+    description: 'Artist created successfully',
+    type: CreateArtistResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Artist name is already taken',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 412,
+    description: 'User private profile not found',
+    type: ApiErrorResponseDto,
+  })
   async createArtist(
     @Body() request: CreateArtistRequestDto,
     @CurrentUser('id') userId: string,
@@ -39,6 +68,16 @@ export class ArtistsController {
     description: 'Private artists retrieved successfully',
     type: GetPrivateArtistsResponseDto,
   })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden',
+    type: ApiErrorResponseDto,
+  })
   async getPrivateArtists(@CurrentUser('id') userId: string): Promise<ZodArtist[]> {
     const query = new GetPrivateArtistsQuery(userId);
     return this.queryBus.execute(query);
@@ -47,6 +86,36 @@ export class ArtistsController {
   @Patch(':id')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Update private artist detail' })
+  @ApiResponse({
+    status: 200,
+    description: 'Artist details updated successfully',
+    type: UpdateArtistResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Artist not found',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Artist name is already taken',
+    type: ApiErrorResponseDto,
+  })
   async updateArtist(
     @Param('id') id: string,
     @Body() request: UpdateArtistRequestDto,
@@ -63,6 +132,21 @@ export class ArtistsController {
     status: 200,
     description: 'Artist deleted successfully',
     type: DeleteArtistResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Artist not found',
+    type: ApiErrorResponseDto,
   })
   async deleteArtist(
     @Param('id') id: string,

--- a/apps/api/src/features/artists/artists.module.ts
+++ b/apps/api/src/features/artists/artists.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { ArtistsController } from './artists.controller';
+import { CreateArtistHandler } from './commands/handlers/create-artist.handler';
+import { GetPrivateArtistsHandler } from './queries/handlers/get-private-artists.handler';
 
 @Module({
-  imports: [],
+  imports: [CqrsModule],
   controllers: [ArtistsController],
-  providers: [],
+  providers: [CreateArtistHandler, GetPrivateArtistsHandler],
   exports: [],
 })
 export class ArtistsModule { }

--- a/apps/api/src/features/artists/artists.module.ts
+++ b/apps/api/src/features/artists/artists.module.ts
@@ -4,6 +4,7 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { ArtistsController } from './artists.controller';
 import { CreateArtistHandler } from './commands/handlers/create-artist.handler';
+import { DeleteArtistHandler } from './commands/handlers/delete-artist.handler';
 import { UpdateArtistHandler } from './commands/handlers/update-artist.handler';
 import { GetPrivateArtistsHandler } from './queries/handlers/get-private-artists.handler';
 
@@ -13,6 +14,7 @@ import { GetPrivateArtistsHandler } from './queries/handlers/get-private-artists
   providers: [
     CreateArtistHandler,
     UpdateArtistHandler,
+    DeleteArtistHandler,
     GetPrivateArtistsHandler,
     ArtistRepository,
     PrivateProfileRepository,

--- a/apps/api/src/features/artists/artists.module.ts
+++ b/apps/api/src/features/artists/artists.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ArtistsController } from './artists.controller';
+
+@Module({
+  imports: [],
+  controllers: [ArtistsController],
+  providers: [],
+  exports: [],
+})
+export class ArtistsModule { }

--- a/apps/api/src/features/artists/artists.module.ts
+++ b/apps/api/src/features/artists/artists.module.ts
@@ -1,13 +1,22 @@
+import { ArtistRepository } from '@/shared/repositories/artist.repository';
+import { PrivateProfileRepository } from '@/shared/repositories/private-profile.repository';
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { ArtistsController } from './artists.controller';
 import { CreateArtistHandler } from './commands/handlers/create-artist.handler';
+import { UpdateArtistHandler } from './commands/handlers/update-artist.handler';
 import { GetPrivateArtistsHandler } from './queries/handlers/get-private-artists.handler';
 
 @Module({
   imports: [CqrsModule],
   controllers: [ArtistsController],
-  providers: [CreateArtistHandler, GetPrivateArtistsHandler],
+  providers: [
+    CreateArtistHandler,
+    UpdateArtistHandler,
+    GetPrivateArtistsHandler,
+    ArtistRepository,
+    PrivateProfileRepository,
+  ],
   exports: [],
 })
-export class ArtistsModule { }
+export class ArtistsModule {}

--- a/apps/api/src/features/artists/commands/handlers/create-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/create-artist.handler.ts
@@ -1,0 +1,57 @@
+import { ArtistRepository } from '@/shared/repositories/artist.repository';
+import { PrivateProfileRepository } from '@/shared/repositories/private-profile.repository';
+import {
+  ConflictException,
+  InternalServerErrorException,
+  PreconditionFailedException,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { ArtistSchema, ZodArtist } from '@repo/contracts';
+import { CreateArtistCommand } from '../impl/create-artist.command';
+
+@CommandHandler(CreateArtistCommand)
+export class CreateArtistHandler implements ICommandHandler<CreateArtistCommand> {
+  constructor(
+    private readonly artistRepository: ArtistRepository,
+    private readonly privateProfileRepository: PrivateProfileRepository,
+  ) { }
+
+  async execute(command: CreateArtistCommand): Promise<ZodArtist> {
+    const { request, userId } = command;
+
+    const userPrivateProfile = await this.privateProfileRepository.getByUserId(userId);
+
+    if (!userPrivateProfile) {
+      throw new PreconditionFailedException('User private profile not found');
+    }
+
+    console.log(request.name);
+
+    const existingArtist = await this.artistRepository.getByNameAndOwnerId(
+      request.name,
+      userPrivateProfile.id,
+    );
+
+    if (existingArtist) {
+      throw new ConflictException('This artist name is already taken');
+    }
+
+    const artist = await this.artistRepository.create({
+      name: request.name,
+      description: request.description,
+      privateArtistProfile: {
+        create: {
+          userPrivateProfileId: userPrivateProfile.id,
+        },
+      },
+    });
+
+    const parsed = ArtistSchema.safeParse(artist);
+
+    if (!parsed.success) {
+      throw new InternalServerErrorException('Failed to parse artist');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/artists/commands/handlers/create-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/create-artist.handler.ts
@@ -14,7 +14,7 @@ export class CreateArtistHandler implements ICommandHandler<CreateArtistCommand>
   constructor(
     private readonly artistRepository: ArtistRepository,
     private readonly privateProfileRepository: PrivateProfileRepository,
-  ) { }
+  ) {}
 
   async execute(command: CreateArtistCommand): Promise<ZodArtist> {
     const { request, userId } = command;

--- a/apps/api/src/features/artists/commands/handlers/delete-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/delete-artist.handler.ts
@@ -1,9 +1,9 @@
 import { ArtistRepository } from '@/shared/repositories/artist.repository';
 import { PrivateProfileRepository } from '@/shared/repositories/private-profile.repository';
 import {
-    InternalServerErrorException,
-    NotFoundException,
-    PreconditionFailedException,
+  InternalServerErrorException,
+  NotFoundException,
+  PreconditionFailedException,
 } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { ArtistSchema, ZodArtist } from '@repo/contracts';

--- a/apps/api/src/features/artists/commands/handlers/delete-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/delete-artist.handler.ts
@@ -1,0 +1,47 @@
+import { ArtistRepository } from '@/shared/repositories/artist.repository';
+import { PrivateProfileRepository } from '@/shared/repositories/private-profile.repository';
+import {
+    InternalServerErrorException,
+    NotFoundException,
+    PreconditionFailedException,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { ArtistSchema, ZodArtist } from '@repo/contracts';
+import { DeleteArtistCommand } from '../impl/delete-artist.command';
+
+@CommandHandler(DeleteArtistCommand)
+export class DeleteArtistHandler implements ICommandHandler<DeleteArtistCommand> {
+  constructor(
+    private readonly artistRepository: ArtistRepository,
+    private readonly privateProfileRepository: PrivateProfileRepository,
+  ) {}
+
+  async execute(command: DeleteArtistCommand): Promise<ZodArtist> {
+    const { artistId, userId } = command;
+
+    const userPrivateProfile = await this.privateProfileRepository.getByUserId(userId);
+
+    if (!userPrivateProfile) {
+      throw new PreconditionFailedException('User private profile not found');
+    }
+
+    const artist = await this.artistRepository.getByIdAndOwnerId(artistId, userPrivateProfile.id);
+
+    if (!artist) {
+      throw new NotFoundException('Artist not found or you do not have permission to delete it');
+    }
+
+    // SOFT DELETE
+    const deletedArtist = await this.artistRepository.update(artistId, {
+      deletedAt: new Date(),
+    });
+
+    const parsed = ArtistSchema.safeParse(deletedArtist);
+
+    if (!parsed.success) {
+      throw new InternalServerErrorException('Failed to parse deleted artist');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/artists/commands/handlers/update-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/update-artist.handler.ts
@@ -1,0 +1,59 @@
+import { ArtistRepository } from '@/shared/repositories/artist.repository';
+import { PrivateProfileRepository } from '@/shared/repositories/private-profile.repository';
+import {
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+  PreconditionFailedException,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { ArtistSchema, ZodArtist } from '@repo/contracts';
+import { UpdateArtistCommand } from '../impl/update-artist.command';
+
+@CommandHandler(UpdateArtistCommand)
+export class UpdateArtistHandler implements ICommandHandler<UpdateArtistCommand> {
+  constructor(
+    private readonly artistRepository: ArtistRepository,
+    private readonly privateProfileRepository: PrivateProfileRepository,
+  ) {}
+
+  async execute(command: UpdateArtistCommand): Promise<ZodArtist> {
+    const { artistId, request, userId } = command;
+
+    const userPrivateProfile = await this.privateProfileRepository.getByUserId(userId);
+
+    if (!userPrivateProfile) {
+      throw new PreconditionFailedException('User private profile not found');
+    }
+
+    const artist = await this.artistRepository.getById(artistId);
+
+    if (!artist) {
+      throw new NotFoundException('Artist not found');
+    }
+
+    if (request.name && request.name !== artist.name) {
+      const existingArtistWithName = await this.artistRepository.getByNameAndOwnerId(
+        request.name,
+        userPrivateProfile.id,
+      );
+
+      if (existingArtistWithName) {
+        throw new ConflictException('This artist name is already taken');
+      }
+    }
+
+    const updatedArtist = await this.artistRepository.update(artistId, {
+      name: request.name,
+      description: request.description,
+    });
+
+    const parsed = ArtistSchema.safeParse(updatedArtist);
+
+    if (!parsed.success) {
+      throw new InternalServerErrorException('Failed to parse updated artist');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/artists/commands/handlers/update-artist.handler.ts
+++ b/apps/api/src/features/artists/commands/handlers/update-artist.handler.ts
@@ -26,7 +26,7 @@ export class UpdateArtistHandler implements ICommandHandler<UpdateArtistCommand>
       throw new PreconditionFailedException('User private profile not found');
     }
 
-    const artist = await this.artistRepository.getById(artistId);
+    const artist = await this.artistRepository.getByIdAndOwnerId(artistId, userPrivateProfile.id);
 
     if (!artist) {
       throw new NotFoundException('Artist not found');

--- a/apps/api/src/features/artists/commands/impl/create-artist.command.ts
+++ b/apps/api/src/features/artists/commands/impl/create-artist.command.ts
@@ -4,5 +4,5 @@ export class CreateArtistCommand {
   constructor(
     public readonly request: CreateArtistRequest,
     public readonly userId: string,
-  ) { }
+  ) {}
 }

--- a/apps/api/src/features/artists/commands/impl/create-artist.command.ts
+++ b/apps/api/src/features/artists/commands/impl/create-artist.command.ts
@@ -1,0 +1,8 @@
+import { CreateArtistRequest } from '@repo/contracts';
+
+export class CreateArtistCommand {
+  constructor(
+    public readonly request: CreateArtistRequest,
+    public readonly userId: string,
+  ) { }
+}

--- a/apps/api/src/features/artists/commands/impl/delete-artist.command.ts
+++ b/apps/api/src/features/artists/commands/impl/delete-artist.command.ts
@@ -1,0 +1,6 @@
+export class DeleteArtistCommand {
+  constructor(
+    public readonly artistId: string,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/artists/commands/impl/update-artist.command.ts
+++ b/apps/api/src/features/artists/commands/impl/update-artist.command.ts
@@ -1,0 +1,9 @@
+import { UpdateArtistRequest } from '@repo/contracts';
+
+export class UpdateArtistCommand {
+  constructor(
+    public readonly artistId: string,
+    public readonly request: UpdateArtistRequest,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/artists/dto/create-artist.request.dto.ts
+++ b/apps/api/src/features/artists/dto/create-artist.request.dto.ts
@@ -1,0 +1,4 @@
+import { CreateArtistRequestSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class CreateArtistRequestDto extends createZodDto(CreateArtistRequestSchema) { }

--- a/apps/api/src/features/artists/dto/create-artist.request.dto.ts
+++ b/apps/api/src/features/artists/dto/create-artist.request.dto.ts
@@ -1,4 +1,4 @@
 import { CreateArtistRequestSchema } from '@repo/contracts';
 import { createZodDto } from 'nestjs-zod';
 
-export class CreateArtistRequestDto extends createZodDto(CreateArtistRequestSchema) { }
+export class CreateArtistRequestDto extends createZodDto(CreateArtistRequestSchema) {}

--- a/apps/api/src/features/artists/dto/create-artist.response.dto.ts
+++ b/apps/api/src/features/artists/dto/create-artist.response.dto.ts
@@ -1,0 +1,4 @@
+import { CreateArtistResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class CreateArtistResponseDto extends createZodDto(CreateArtistResponseSchema) {}

--- a/apps/api/src/features/artists/dto/delete-artist.response.dto.ts
+++ b/apps/api/src/features/artists/dto/delete-artist.response.dto.ts
@@ -1,0 +1,4 @@
+import { DeleteArtistResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class DeleteArtistResponseDto extends createZodDto(DeleteArtistResponseSchema) {}

--- a/apps/api/src/features/artists/dto/get-private-artists.response.dto.ts
+++ b/apps/api/src/features/artists/dto/get-private-artists.response.dto.ts
@@ -1,0 +1,4 @@
+import { GetPrivateArtistsResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class GetPrivateArtistsResponseDto extends createZodDto(GetPrivateArtistsResponseSchema) { }

--- a/apps/api/src/features/artists/dto/get-private-artists.response.dto.ts
+++ b/apps/api/src/features/artists/dto/get-private-artists.response.dto.ts
@@ -1,4 +1,4 @@
 import { GetPrivateArtistsResponseSchema } from '@repo/contracts';
 import { createZodDto } from 'nestjs-zod';
 
-export class GetPrivateArtistsResponseDto extends createZodDto(GetPrivateArtistsResponseSchema) { }
+export class GetPrivateArtistsResponseDto extends createZodDto(GetPrivateArtistsResponseSchema) {}

--- a/apps/api/src/features/artists/dto/update-artist.request.dto.ts
+++ b/apps/api/src/features/artists/dto/update-artist.request.dto.ts
@@ -1,0 +1,4 @@
+import { UpdateArtistRequestSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class UpdateArtistRequestDto extends createZodDto(UpdateArtistRequestSchema) {}

--- a/apps/api/src/features/artists/dto/update-artist.response.dto.ts
+++ b/apps/api/src/features/artists/dto/update-artist.response.dto.ts
@@ -1,0 +1,4 @@
+import { UpdateArtistResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class UpdateArtistResponseDto extends createZodDto(UpdateArtistResponseSchema) {}

--- a/apps/api/src/features/artists/queries/handlers/get-private-artists.handler.ts
+++ b/apps/api/src/features/artists/queries/handlers/get-private-artists.handler.ts
@@ -6,7 +6,7 @@ import { GetPrivateArtistsQuery } from '../impl/get-private-artists.query';
 
 @QueryHandler(GetPrivateArtistsQuery)
 export class GetPrivateArtistsHandler implements IQueryHandler<GetPrivateArtistsQuery> {
-  constructor(private readonly artistRepository: ArtistRepository) { }
+  constructor(private readonly artistRepository: ArtistRepository) {}
 
   async execute(query: GetPrivateArtistsQuery): Promise<ZodArtist[]> {
     const { userId } = query;

--- a/apps/api/src/features/artists/queries/handlers/get-private-artists.handler.ts
+++ b/apps/api/src/features/artists/queries/handlers/get-private-artists.handler.ts
@@ -1,0 +1,26 @@
+import { ArtistRepository } from '@/shared/repositories/artist.repository';
+import { InternalServerErrorException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { ArtistSchema, ZodArtist } from '@repo/contracts';
+import { GetPrivateArtistsQuery } from '../impl/get-private-artists.query';
+
+@QueryHandler(GetPrivateArtistsQuery)
+export class GetPrivateArtistsHandler implements IQueryHandler<GetPrivateArtistsQuery> {
+  constructor(private readonly artistRepository: ArtistRepository) { }
+
+  async execute(query: GetPrivateArtistsQuery): Promise<ZodArtist[]> {
+    const { userId } = query;
+
+    const artists = await this.artistRepository.getPrivateByUserId(userId);
+
+    const parsed = artists.map((artist) => {
+      const result = ArtistSchema.safeParse(artist);
+      if (!result.success) {
+        throw new InternalServerErrorException('Failed to parse artist from database');
+      }
+      return result.data;
+    });
+
+    return parsed;
+  }
+}

--- a/apps/api/src/features/artists/queries/impl/get-private-artists.query.ts
+++ b/apps/api/src/features/artists/queries/impl/get-private-artists.query.ts
@@ -1,3 +1,3 @@
 export class GetPrivateArtistsQuery {
-  constructor(public readonly userId: string) { }
+  constructor(public readonly userId: string) {}
 }

--- a/apps/api/src/features/artists/queries/impl/get-private-artists.query.ts
+++ b/apps/api/src/features/artists/queries/impl/get-private-artists.query.ts
@@ -1,0 +1,3 @@
+export class GetPrivateArtistsQuery {
+  constructor(public readonly userId: string) { }
+}

--- a/apps/api/src/features/features.module.ts
+++ b/apps/api/src/features/features.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { ArtistsModule } from './artists/artists.module';
 import { AuthModule } from './auth/auth.module';
 import { LibraryModule } from './library/library.module';
 import { PrivateProfileModule } from './private-profile/private-profile.module';
 
 @Module({
-  imports: [AuthModule, LibraryModule, PrivateProfileModule],
+  imports: [AuthModule, LibraryModule, PrivateProfileModule, ArtistsModule],
   controllers: [],
   providers: [],
   exports: [],

--- a/apps/api/src/shared/repositories/artist.repository.ts
+++ b/apps/api/src/shared/repositories/artist.repository.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Artist,
+  ArtistCreateInput,
+  ArtistCreateManyInput,
+  ArtistOrderByWithRelationInput,
+  ArtistUpdateInput,
+  ArtistWhereInput,
+} from '@repo/db';
+import { PrismaService } from '../services/prisma.service';
+
+@Injectable()
+export class ArtistRepository {
+  constructor(private readonly prisma: PrismaService) { }
+
+  // ─────────────────────────────────────────────────────────────
+  // QUERIES
+  // ─────────────────────────────────────────────────────────────
+
+  async getById(id: string): Promise<Artist | null> {
+    return await this.prisma.client.artist.findUnique({ where: { id } });
+  }
+
+  async getByName(name: string): Promise<Artist | null> {
+    return await this.prisma.client.artist.findFirst({ where: { name } });
+  }
+
+  async getByNameAndOwnerId(name: string, ownerId: string): Promise<Artist | null> {
+    return await this.prisma.client.artist.findFirst({
+      where: {
+        name,
+        deletedAt: null,
+        OR: [
+          { artistProfile: { id: ownerId } },
+          { communityProfile: { id: ownerId } },
+          {
+            privateArtistProfile: {
+              userPrivateProfile: {
+                id: ownerId,
+              },
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  async getPrivateByUserId(userId: string): Promise<Artist[]> {
+    return await this.prisma.client.artist.findMany({
+      where: {
+        privateArtistProfile: {
+          userPrivateProfile: {
+            userId,
+          },
+        },
+        deletedAt: null,
+      },
+    });
+  }
+
+  async getPaginated(
+    page: number,
+    limit: number,
+    filter?: ArtistWhereInput,
+    orderBy?: ArtistOrderByWithRelationInput,
+  ): Promise<Artist[]> {
+    return await this.prisma.client.artist.findMany({
+      take: limit,
+      skip: (page - 1) * limit,
+      where: filter,
+      orderBy,
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // EXISTS & COUNT
+  // ─────────────────────────────────────────────────────────────
+
+  async exists(id: string): Promise<boolean> {
+    const count = await this.prisma.client.artist.count({ where: { id } });
+    return count > 0;
+  }
+
+  async count(filter?: ArtistWhereInput): Promise<number> {
+    return await this.prisma.client.artist.count({ where: filter });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // CREATE
+  // ─────────────────────────────────────────────────────────────
+
+  async create(data: ArtistCreateInput): Promise<Artist> {
+    return await this.prisma.client.artist.create({ data });
+  }
+
+  async createMany(data: ArtistCreateManyInput[]): Promise<Artist[]> {
+    return await this.prisma.client.artist.createManyAndReturn({ data });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // UPDATE
+  // ─────────────────────────────────────────────────────────────
+
+  async update(id: string, data: ArtistUpdateInput): Promise<Artist> {
+    return await this.prisma.client.artist.update({ where: { id }, data });
+  }
+
+  async updateMany(updates: { id: string; data: ArtistUpdateInput }[]): Promise<Artist[]> {
+    return await this.prisma.mainClient.$transaction(
+      updates.map(({ id, data }) => this.prisma.client.artist.update({ where: { id }, data })),
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // DELETE
+  // ─────────────────────────────────────────────────────────────
+
+  async delete(id: string): Promise<Artist> {
+    return await this.prisma.client.artist.delete({ where: { id } });
+  }
+
+  async deleteMany(filter: ArtistWhereInput): Promise<Artist[]> {
+    const artistsToDelete = await this.prisma.client.artist.findMany({
+      where: filter,
+    });
+    await this.prisma.client.artist.deleteMany({ where: filter });
+    return artistsToDelete;
+  }
+}

--- a/apps/api/src/shared/repositories/artist.repository.ts
+++ b/apps/api/src/shared/repositories/artist.repository.ts
@@ -45,6 +45,26 @@ export class ArtistRepository {
     });
   }
 
+  async getByIdAndOwnerId(id: string, ownerId: string): Promise<Artist | null> {
+    return await this.prisma.client.artist.findFirst({
+      where: {
+        id,
+        deletedAt: null,
+        OR: [
+          { artistProfile: { id: ownerId } },
+          { communityProfile: { id: ownerId } },
+          {
+            privateArtistProfile: {
+              userPrivateProfile: {
+                id: ownerId,
+              },
+            },
+          },
+        ],
+      },
+    });
+  }
+
   async getPrivateByUserId(userId: string): Promise<Artist[]> {
     return await this.prisma.client.artist.findMany({
       where: {

--- a/apps/api/src/shared/repositories/artist.repository.ts
+++ b/apps/api/src/shared/repositories/artist.repository.ts
@@ -11,7 +11,7 @@ import { PrismaService } from '../services/prisma.service';
 
 @Injectable()
 export class ArtistRepository {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(private readonly prisma: PrismaService) {}
 
   // ─────────────────────────────────────────────────────────────
   // QUERIES

--- a/apps/api/src/shared/shared.module.ts
+++ b/apps/api/src/shared/shared.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { ArtistRepository } from './repositories/artist.repository';
 import { EmailAddressRepository } from './repositories/email-address.repository';
 import { LibraryRepository } from './repositories/library.repository';
 import { PrivateProfileRepository } from './repositories/private-profile.repository';
@@ -26,6 +27,7 @@ import { UnitOfWorkService } from './services/unit-of-work.service';
     RefreshTokenRepository,
     LibraryRepository,
     PrivateProfileRepository,
+    ArtistRepository,
     // guards
     JwtAuthGuard,
   ],
@@ -41,6 +43,7 @@ import { UnitOfWorkService } from './services/unit-of-work.service';
     RefreshTokenRepository,
     LibraryRepository,
     PrivateProfileRepository,
+    ArtistRepository,
     // guards
     JwtAuthGuard,
   ],

--- a/packages/contracts/src/artists/create-artist.ts
+++ b/packages/contracts/src/artists/create-artist.ts
@@ -1,10 +1,19 @@
-import z from "zod";
+import { z } from "zod";
 import { createApiResponseSchema } from "../api";
 import { ArtistSchema } from "../schemas";
+import { zodRequiredString } from "../utils/zod-shared";
 
 export const CreateArtistRequestSchema = z.object({
-  name: z.string().min(1).max(255),
-  description: z.string().max(2048).optional(),
+  name: zodRequiredString("Artist name is required").pipe(
+    z
+      .string()
+      .min(1, "Artist name is required")
+      .max(255, "Artist name must be 255 characters or less"),
+  ),
+  description: z
+    .string()
+    .max(2048, "Description must be 2048 characters or less")
+    .optional(),
 });
 
 export type CreateArtistRequest = z.infer<typeof CreateArtistRequestSchema>;

--- a/packages/contracts/src/artists/create-artist.ts
+++ b/packages/contracts/src/artists/create-artist.ts
@@ -1,0 +1,14 @@
+import z from "zod";
+import { createApiResponseSchema } from "../api";
+import { ArtistSchema } from "../schemas";
+
+export const CreateArtistRequest = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2048).optional(),
+});
+
+export type CreateArtistRequest = z.infer<typeof CreateArtistRequest>;
+
+export const CreateArtistResponse = createApiResponseSchema(ArtistSchema);
+
+export type CreateArtistResponse = z.infer<typeof CreateArtistResponse>;

--- a/packages/contracts/src/artists/create-artist.ts
+++ b/packages/contracts/src/artists/create-artist.ts
@@ -2,13 +2,13 @@ import z from "zod";
 import { createApiResponseSchema } from "../api";
 import { ArtistSchema } from "../schemas";
 
-export const CreateArtistRequest = z.object({
+export const CreateArtistRequestSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(2048).optional(),
 });
 
-export type CreateArtistRequest = z.infer<typeof CreateArtistRequest>;
+export type CreateArtistRequest = z.infer<typeof CreateArtistRequestSchema>;
 
-export const CreateArtistResponse = createApiResponseSchema(ArtistSchema);
+export const CreateArtistResponseSchema = createApiResponseSchema(ArtistSchema);
 
-export type CreateArtistResponse = z.infer<typeof CreateArtistResponse>;
+export type CreateArtistResponse = z.infer<typeof CreateArtistResponseSchema>;

--- a/packages/contracts/src/artists/delete-artist.ts
+++ b/packages/contracts/src/artists/delete-artist.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../api";
+import { ArtistSchema } from "../schemas";
+
+export const DeleteArtistResponseSchema = createApiResponseSchema(ArtistSchema);
+
+export type DeleteArtistResponse = z.infer<typeof DeleteArtistResponseSchema>;

--- a/packages/contracts/src/artists/get-private-artists.ts
+++ b/packages/contracts/src/artists/get-private-artists.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../api";
+import { ArtistSchema } from "../schemas";
+
+export const GetPrivateArtistsResponseSchema = createApiResponseSchema(
+  z.array(ArtistSchema),
+);
+
+export type GetPrivateArtistsResponse = z.infer<
+  typeof GetPrivateArtistsResponseSchema
+>;

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-artist";

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -1,3 +1,5 @@
 export * from "./create-artist";
+export * from "./delete-artist";
 export * from "./get-private-artists";
 export * from "./update-artist";
+

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -2,4 +2,3 @@ export * from "./create-artist";
 export * from "./delete-artist";
 export * from "./get-private-artists";
 export * from "./update-artist";
-

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -1,4 +1,3 @@
 export * from "./create-artist";
 export * from "./get-private-artists";
 export * from "./update-artist";
-

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -1,3 +1,4 @@
 export * from "./create-artist";
 export * from "./get-private-artists";
+export * from "./update-artist";
 

--- a/packages/contracts/src/artists/index.ts
+++ b/packages/contracts/src/artists/index.ts
@@ -1,1 +1,3 @@
 export * from "./create-artist";
+export * from "./get-private-artists";
+

--- a/packages/contracts/src/artists/update-artist.ts
+++ b/packages/contracts/src/artists/update-artist.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../api";
+import { ArtistSchema } from "../schemas";
+
+export const UpdateArtistRequestSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Artist name cannot be empty")
+    .max(255, "Artist name must be 255 characters or less")
+    .optional(),
+  description: z
+    .string()
+    .max(2048, "Description must be 2048 characters or less")
+    .optional(),
+});
+
+export type UpdateArtistRequest = z.infer<typeof UpdateArtistRequestSchema>;
+
+export const UpdateArtistResponseSchema = createApiResponseSchema(ArtistSchema);
+
+export type UpdateArtistResponse = z.infer<typeof UpdateArtistResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./schemas";
 
+export * from "./artists";
 export * from "./auth";
 export * from "./library";
 export * from "./private-profile";


### PR DESCRIPTION
# Artists Module Implementation

## Features Added

### API Endpoints
- Added artists controller with CRUD operations
- Implemented JWT authentication for all endpoints
- Added comprehensive Swagger documentation

### Artist Management
- Created POST /artists endpoint to create new artists in private library
- Added GET /artists/private endpoint to retrieve user's private artists
- Implemented PATCH /artists/:id endpoint to update artist details
- Added DELETE /artists/:id endpoint for removing private artists

### CQRS Implementation
- Implemented command and query handlers for artist operations
- Added validation and error handling for all operations
- Integrated with CommandBus and QueryBus for clean architecture

### Repository Layer
- Added ArtistRepository with comprehensive data access methods
- Implemented methods for retrieving artists by ID, name, and owner
- Added support for paginated queries and bulk operations
- Implemented soft delete functionality

### Contract Schemas
- Added Zod schemas for artist-related operations
- Created validation rules for artist name and description
- Implemented response schemas for all endpoints
- Added type definitions for request/response contracts

### Data Transfer Objects
- Created DTOs for all artist operations
- Implemented validation using Zod schemas
- Added response DTOs with proper typing

This PR implements the complete artists module with proper validation, error handling, and authentication to manage artists in a user's private library.