### PR TITLE
feat(web): add support for different album types and circular artist avatars

### DIFF
--- a/apps/web/src/components/library/MediaCard.test.tsx
+++ b/apps/web/src/components/library/MediaCard.test.tsx
@@ -69,4 +69,16 @@ describe('MediaCard', () => {
 
     expect(screen.getByText('Unknown')).toBeInTheDocument();
   });
+  it('applies correct class for coverStyle', () => {
+    const { container: circleContainer } = render(
+      <MediaCard {...defaultProps} coverStyle="circle" coverUrl={undefined} />,
+    );
+    expect(circleContainer.querySelector('.rounded-full')).toBeInTheDocument();
+
+    const { container: squareContainer } = render(
+      <MediaCard {...defaultProps} coverStyle="square" coverUrl={undefined} />,
+    );
+    expect(squareContainer.querySelector('.rounded')).toBeInTheDocument();
+    expect(squareContainer.querySelector('.rounded-full')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/library/MediaCard.tsx
+++ b/apps/web/src/components/library/MediaCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils';
 import { DiscIcon } from '@phosphor-icons/react';
 import { Link } from '@tanstack/react-router';
 
@@ -7,6 +8,7 @@ export function MediaCard({
   subtitle,
   id,
   link,
+  coverStyle = 'square',
   placeholderIcon,
 }: {
   coverUrl: string | undefined;
@@ -14,6 +16,7 @@ export function MediaCard({
   subtitle: string | undefined;
   id: string;
   link: string;
+  coverStyle?: 'circle' | 'square';
   placeholderIcon?: React.ReactNode;
 }) {
   return (
@@ -23,7 +26,12 @@ export function MediaCard({
       params={{ id }}
       className="group/artist relative p-2 rounded-lg overflow-hidden transition-all transition-150 transform hover:scale-[1.02] active:scale-[1.00] hover:bg-stone-800/30 active:bg-stone-800/45 cursor-pointer"
     >
-      <div className="aspect-square w-full overflow-hidden bg-stone-800 rounded-md">
+      <div
+        className={cn(
+          'aspect-square w-full overflow-hidden bg-stone-800',
+          coverStyle === 'circle' ? 'rounded-full' : 'rounded',
+        )}
+      >
         {coverUrl ? (
           <img src={coverUrl} alt={title} className="size-full object-cover" />
         ) : (

--- a/apps/web/src/components/library/albums/CreateAlbumForm.tsx
+++ b/apps/web/src/components/library/albums/CreateAlbumForm.tsx
@@ -11,6 +11,7 @@ interface CreateAlbumFormProps {
   formData: FormData;
   isLoading: boolean;
   isValid: boolean;
+  type?: FormData['type'];
   onSubmit: (e: SyntheticEvent<HTMLFormElement>) => void | Promise<void>;
   onChange: <K extends keyof FormData>(field: K, value: FormData[K]) => void;
   onBlur: (field: keyof FormData) => void;
@@ -22,6 +23,7 @@ export function CreateAlbumForm({
   formData,
   isLoading,
   isValid,
+  type = 'album',
   onSubmit,
   onChange,
   onBlur,
@@ -30,6 +32,8 @@ export function CreateAlbumForm({
 }: CreateAlbumFormProps & { onFileSelect?: (file: File | null) => void }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const typeLabel = type.charAt(0).toUpperCase() + type.slice(1);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -89,7 +93,7 @@ export function CreateAlbumForm({
 
           <div className="flex-1 flex flex-col gap-6">
             <TextField
-              label="Album Title"
+              label={`${typeLabel} Title`}
               placeholder="e.g. Nevermind"
               value={formData.name}
               error={getFieldError('name')}
@@ -99,7 +103,7 @@ export function CreateAlbumForm({
 
             <TextAreaField
               label="Description"
-              placeholder="Tell something about this album..."
+              placeholder={`Tell something about this ${type}...`}
               value={formData.description || ''}
               error={getFieldError('description')}
               onChange={(value) => onChange('description', value)}
@@ -133,7 +137,7 @@ export function CreateAlbumForm({
           ) : (
             <>
               <PlusIcon className="mr-2 h-4 w-4 transition-transform group-hover:rotate-90" />
-              Create Album
+              Create {typeLabel}
             </>
           )}
         </Button>

--- a/apps/web/src/hooks/forms/useCreateAlbumForm.ts
+++ b/apps/web/src/hooks/forms/useCreateAlbumForm.ts
@@ -3,11 +3,14 @@ import { useCallback, useMemo, useState } from 'react';
 
 export type FormData = CreateLibraryAlbumRequest;
 
-export const useCreateAlbumForm = (artistId: string) => {
+export const useCreateAlbumForm = (
+  artistId: string,
+  initialType: CreateLibraryAlbumRequest['type'] = 'album',
+) => {
   const [formData, setFormData] = useState<FormData>({
     name: '',
     description: '',
-    type: 'album',
+    type: initialType,
     artistId: artistId,
     releaseDate: null,
   });

--- a/apps/web/src/routes/app/library/albums/$id/index.tsx
+++ b/apps/web/src/routes/app/library/albums/$id/index.tsx
@@ -95,7 +95,7 @@ function RouteComponent() {
                 className="absolute inset-0 size-48 rounded-2xl object-cover blur-lg opacity-35 scale-100 translate-y-4 saturate-150 pointer-events-none"
               />
             )}
-            <div className="relative size-48 p-0 rounded-2xl shadow-xl shrink-0 overflow-hidden bg-stone-800 flex items-center justify-center border border-white/10">
+            <div className="relative size-48 p-0 rounded-lg shadow-xl shrink-0 overflow-hidden bg-stone-800 flex items-center justify-center border border-white/10">
               {album.cover?.url ? (
                 <img src={album.cover.url} alt={album.name} className="size-full object-cover" />
               ) : (
@@ -152,14 +152,14 @@ function RouteComponent() {
         <div className="flex items-center gap-3">
           <Button
             size="lg"
-            className="h-12 rounded-xl gap-2 px-8 text-base font-bold shadow-md hover:shadow-primary/20 active:shadow-primary/35 active:scale-98 transition-all bg-primary text-primary-foreground"
+            className="h-12 rounded-lg gap-2 px-8 text-base font-bold shadow-md hover:shadow-primary/20 active:shadow-primary/35 active:scale-98 transition-all bg-primary text-primary-foreground"
           >
             <PlayIcon weight="fill" size={20} /> Play
           </Button>
           <Button
             variant="outline"
             size="lg"
-            className="h-12 rounded-xl gap-2 px-8 text-base font-bold border-border bg-stone-900/20 backdrop-blur-md hover:bg-stone-800/40 active:scale-98 transition-all"
+            className="h-12 rounded-lg gap-2 px-8 text-base font-bold border-border bg-stone-900/20 backdrop-blur-md hover:bg-stone-800/40 active:scale-98 transition-all"
           >
             <ShuffleIcon weight="bold" size={20} /> Shuffle
           </Button>
@@ -168,7 +168,7 @@ function RouteComponent() {
             <Button
               variant="ghost"
               size="icon"
-              className="size-10 text-muted-foreground hover:text-primary hover:bg-primary/10 transition-all"
+              className="size-10 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 active:scale-98 transition-all"
             >
               <HeartIcon size={24} />
             </Button>
@@ -178,7 +178,7 @@ function RouteComponent() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="size-10 text-muted-foreground hover:text-primary hover:bg-primary/10 transition-all"
+                  className="size-10 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 active:scale-98 transition-all"
                 >
                   <DotsThreeIcon size={24} weight="bold" />
                 </Button>

--- a/apps/web/src/routes/app/library/albums/index.tsx
+++ b/apps/web/src/routes/app/library/albums/index.tsx
@@ -45,7 +45,10 @@ function RouteComponent() {
             key={album.id}
             id={album.id}
             title={album.name}
-            subtitle={album.artists?.map((artist) => artist.name).join(', ')}
+            subtitle={
+              (album.artists?.map((artist) => artist.name).join(', ') ?? 'Unknown artist') +
+              ` - ${album.type}`
+            }
             coverUrl={album.cover?.url ?? undefined}
             link="/app/library/albums/$id"
             placeholderIcon={<DiscIcon className="size-1/2 text-stone-400" weight="duotone" />}

--- a/apps/web/src/routes/app/library/artists/$id/add-content/album.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/add-content/album.tsx
@@ -78,6 +78,7 @@ function RouteComponent() {
         formData={formData}
         isLoading={isCreatingAlbum || isUploadingCover}
         isValid={isFormValid}
+        type="album"
         onSubmit={handleFormSubmit}
         onChange={handleChange}
         onBlur={handleBlur}

--- a/apps/web/src/routes/app/library/artists/$id/add-content/compilation.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/add-content/compilation.tsx
@@ -1,9 +1,90 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { CreateAlbumForm } from '@/components/library/albums/CreateAlbumForm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useCreateLibraryAlbum } from '@/hooks/api/library-albums/useCreateLibraryAlbum';
+import { useUploadLibraryAlbumCover } from '@/hooks/api/library-albums/useUploadLibraryAlbumCover';
+import { useCreateAlbumForm } from '@/hooks/forms/useCreateAlbumForm';
+import { InfoIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/app/library/artists/$id/add-content/compilation')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <div>Hello "/app/library/artists/$id/add-content/compilation"!</div>;
+  const { id } = Route.useParams();
+  const navigate = useNavigate();
+
+  const [coverImage, setCoverImage] = useState<File | null>(null);
+
+  const {
+    mutateAsync: createAlbum,
+    isPending: isCreatingAlbum,
+    error: apiError,
+  } = useCreateLibraryAlbum();
+
+  const {
+    mutateAsync: uploadCover,
+    isPending: isUploadingCover,
+    error: uploadError,
+  } = useUploadLibraryAlbumCover();
+
+  const { formData, isFormValid, handleChange, handleBlur, handleSubmit, getFieldError } =
+    useCreateAlbumForm(id, 'compilation');
+
+  const handleFormSubmit = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const data = handleSubmit();
+    if (!data) return;
+
+    try {
+      const response = await createAlbum(data);
+      if (response.data) {
+        if (coverImage) {
+          await uploadCover({ id: response.data.id, file: coverImage });
+        }
+
+        await navigate({
+          to: '/app/library/artists/$id',
+          params: { id },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to create compilation or upload cover:', error);
+    }
+  };
+
+  const error = apiError || uploadError;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <Alert className="bg-primary/5 border-primary/20">
+        <InfoIcon size={20} className="text-primary" />
+        <AlertTitle className="text-primary">Local Compilation</AlertTitle>
+        <AlertDescription className="text-muted-foreground">
+          You will be able to add songs after creating the compilation.
+        </AlertDescription>
+      </Alert>
+
+      {error && error.status !== 409 && (
+        <Alert variant="destructive">
+          <WarningCircleIcon size={20} />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <CreateAlbumForm
+        formData={formData}
+        isLoading={isCreatingAlbum || isUploadingCover}
+        isValid={isFormValid}
+        type="compilation"
+        onSubmit={handleFormSubmit}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFileSelect={setCoverImage}
+        getFieldError={getFieldError}
+      />
+    </div>
+  );
 }

--- a/apps/web/src/routes/app/library/artists/$id/add-content/ep.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/add-content/ep.tsx
@@ -1,9 +1,90 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { CreateAlbumForm } from '@/components/library/albums/CreateAlbumForm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useCreateLibraryAlbum } from '@/hooks/api/library-albums/useCreateLibraryAlbum';
+import { useUploadLibraryAlbumCover } from '@/hooks/api/library-albums/useUploadLibraryAlbumCover';
+import { useCreateAlbumForm } from '@/hooks/forms/useCreateAlbumForm';
+import { InfoIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/app/library/artists/$id/add-content/ep')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <div>Hello "/app/library/artists/$id/add-content/ep"!</div>;
+  const { id } = Route.useParams();
+  const navigate = useNavigate();
+
+  const [coverImage, setCoverImage] = useState<File | null>(null);
+
+  const {
+    mutateAsync: createAlbum,
+    isPending: isCreatingAlbum,
+    error: apiError,
+  } = useCreateLibraryAlbum();
+
+  const {
+    mutateAsync: uploadCover,
+    isPending: isUploadingCover,
+    error: uploadError,
+  } = useUploadLibraryAlbumCover();
+
+  const { formData, isFormValid, handleChange, handleBlur, handleSubmit, getFieldError } =
+    useCreateAlbumForm(id, 'ep');
+
+  const handleFormSubmit = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const data = handleSubmit();
+    if (!data) return;
+
+    try {
+      const response = await createAlbum(data);
+      if (response.data) {
+        if (coverImage) {
+          await uploadCover({ id: response.data.id, file: coverImage });
+        }
+
+        await navigate({
+          to: '/app/library/artists/$id',
+          params: { id },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to create EP or upload cover:', error);
+    }
+  };
+
+  const error = apiError || uploadError;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <Alert className="bg-primary/5 border-primary/20">
+        <InfoIcon size={20} className="text-primary" />
+        <AlertTitle className="text-primary">Local EP</AlertTitle>
+        <AlertDescription className="text-muted-foreground">
+          You will be able to add songs after creating the EP.
+        </AlertDescription>
+      </Alert>
+
+      {error && error.status !== 409 && (
+        <Alert variant="destructive">
+          <WarningCircleIcon size={20} />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <CreateAlbumForm
+        formData={formData}
+        isLoading={isCreatingAlbum || isUploadingCover}
+        isValid={isFormValid}
+        type="ep"
+        onSubmit={handleFormSubmit}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFileSelect={setCoverImage}
+        getFieldError={getFieldError}
+      />
+    </div>
+  );
 }

--- a/apps/web/src/routes/app/library/artists/$id/add-content/single.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/add-content/single.tsx
@@ -1,9 +1,90 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { CreateAlbumForm } from '@/components/library/albums/CreateAlbumForm';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useCreateLibraryAlbum } from '@/hooks/api/library-albums/useCreateLibraryAlbum';
+import { useUploadLibraryAlbumCover } from '@/hooks/api/library-albums/useUploadLibraryAlbumCover';
+import { useCreateAlbumForm } from '@/hooks/forms/useCreateAlbumForm';
+import { InfoIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/app/library/artists/$id/add-content/single')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <div>Hello "/app/library/artists/$id/add-content/single"!</div>;
+  const { id } = Route.useParams();
+  const navigate = useNavigate();
+
+  const [coverImage, setCoverImage] = useState<File | null>(null);
+
+  const {
+    mutateAsync: createAlbum,
+    isPending: isCreatingAlbum,
+    error: apiError,
+  } = useCreateLibraryAlbum();
+
+  const {
+    mutateAsync: uploadCover,
+    isPending: isUploadingCover,
+    error: uploadError,
+  } = useUploadLibraryAlbumCover();
+
+  const { formData, isFormValid, handleChange, handleBlur, handleSubmit, getFieldError } =
+    useCreateAlbumForm(id, 'single');
+
+  const handleFormSubmit = async (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    const data = handleSubmit();
+    if (!data) return;
+
+    try {
+      const response = await createAlbum(data);
+      if (response.data) {
+        if (coverImage) {
+          await uploadCover({ id: response.data.id, file: coverImage });
+        }
+
+        await navigate({
+          to: '/app/library/artists/$id',
+          params: { id },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to create single or upload cover:', error);
+    }
+  };
+
+  const error = apiError || uploadError;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <Alert className="bg-primary/5 border-primary/20">
+        <InfoIcon size={20} className="text-primary" />
+        <AlertTitle className="text-primary">Local Single</AlertTitle>
+        <AlertDescription className="text-muted-foreground">
+          You will be able to add songs after creating the single.
+        </AlertDescription>
+      </Alert>
+
+      {error && error.status !== 409 && (
+        <Alert variant="destructive">
+          <WarningCircleIcon size={20} />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <CreateAlbumForm
+        formData={formData}
+        isLoading={isCreatingAlbum || isUploadingCover}
+        isValid={isFormValid}
+        type="single"
+        onSubmit={handleFormSubmit}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onFileSelect={setCoverImage}
+        getFieldError={getFieldError}
+      />
+    </div>
+  );
 }

--- a/apps/web/src/routes/app/library/artists/$id/index.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/index.tsx
@@ -56,7 +56,31 @@ function RouteComponent() {
     AlbumType.album,
   );
 
+  const { data: epsData, isLoading: isEpsLoading } = useLibraryArtistAlbums(
+    id,
+    1,
+    10,
+    AlbumType.ep,
+  );
+
+  const { data: singlesData, isLoading: isSinglesLoading } = useLibraryArtistAlbums(
+    id,
+    1,
+    10,
+    AlbumType.single,
+  );
+
+  const { data: compilationsData, isLoading: isCompilationsLoading } = useLibraryArtistAlbums(
+    id,
+    1,
+    10,
+    AlbumType.compilation,
+  );
+
   const albums = albumsData?.data?.items?.map((item) => item.album) || [];
+  const eps = epsData?.data?.items?.map((item) => item.album) || [];
+  const singles = singlesData?.data?.items?.map((item) => item.album) || [];
+  const compilations = compilationsData?.data?.items?.map((item) => item.album) || [];
 
   const handleDelete = async () => {
     try {
@@ -251,6 +275,150 @@ function RouteComponent() {
             </div>
           )}
         </div>
+
+        {/* EPs Section */}
+        {(isEpsLoading || eps.length > 0) && (
+          <div className="flex flex-col gap-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-bold text-white/90">EPs</h3>
+              {eps.length > 5 && (
+                <Button
+                  variant="link"
+                  className="text-muted-foreground hover:text-primary p-0 h-auto"
+                >
+                  Show all
+                </Button>
+              )}
+            </div>
+
+            {isEpsLoading ? (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="flex flex-col gap-3">
+                    <div className="aspect-square w-full rounded-xl bg-stone-800 animate-pulse" />
+                    <div className="h-4 w-3/4 rounded bg-stone-800 animate-pulse" />
+                    <div className="h-3 w-1/2 rounded bg-stone-800 animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
+                {eps.map((album) => {
+                  if (!album) return null;
+                  return (
+                    <MediaCard
+                      key={album.id}
+                      id={album.id}
+                      title={album.name}
+                      subtitle={album.releaseDate?.getFullYear().toString() ?? 'Unknown'}
+                      coverUrl={album.cover?.url ?? undefined}
+                      link={`/app/library/albums/${album.id}`}
+                      placeholderIcon={
+                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Singles Section */}
+        {(isSinglesLoading || singles.length > 0) && (
+          <div className="flex flex-col gap-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-bold text-white/90">Singles</h3>
+              {singles.length > 5 && (
+                <Button
+                  variant="link"
+                  className="text-muted-foreground hover:text-primary p-0 h-auto"
+                >
+                  Show all
+                </Button>
+              )}
+            </div>
+
+            {isSinglesLoading ? (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="flex flex-col gap-3">
+                    <div className="aspect-square w-full rounded-xl bg-stone-800 animate-pulse" />
+                    <div className="h-4 w-3/4 rounded bg-stone-800 animate-pulse" />
+                    <div className="h-3 w-1/2 rounded bg-stone-800 animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
+                {singles.map((album) => {
+                  if (!album) return null;
+                  return (
+                    <MediaCard
+                      key={album.id}
+                      id={album.id}
+                      title={album.name}
+                      subtitle={album.releaseDate?.getFullYear().toString() ?? 'Unknown'}
+                      coverUrl={album.cover?.url ?? undefined}
+                      link={`/app/library/albums/${album.id}`}
+                      placeholderIcon={
+                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Compilations Section */}
+        {(isCompilationsLoading || compilations.length > 0) && (
+          <div className="flex flex-col gap-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-bold text-white/90">Compilations</h3>
+              {compilations.length > 5 && (
+                <Button
+                  variant="link"
+                  className="text-muted-foreground hover:text-primary p-0 h-auto"
+                >
+                  Show all
+                </Button>
+              )}
+            </div>
+
+            {isCompilationsLoading ? (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="flex flex-col gap-3">
+                    <div className="aspect-square w-full rounded-xl bg-stone-800 animate-pulse" />
+                    <div className="h-4 w-3/4 rounded bg-stone-800 animate-pulse" />
+                    <div className="h-3 w-1/2 rounded bg-stone-800 animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
+                {compilations.map((album) => {
+                  if (!album) return null;
+                  return (
+                    <MediaCard
+                      key={album.id}
+                      id={album.id}
+                      title={album.name}
+                      subtitle={album.releaseDate?.getFullYear().toString() ?? 'Unknown'}
+                      coverUrl={album.cover?.url ?? undefined}
+                      link={`/app/library/albums/${album.id}`}
+                      placeholderIcon={
+                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/apps/web/src/routes/app/library/artists/$id/index.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/index.tsx
@@ -135,7 +135,7 @@ function RouteComponent() {
         {/* Avatar & Quick Info */}
         <div className="px-6 -mt-24 flex flex-col md:flex-row items-end gap-6 relative z-10">
           {/* Avatar */}
-          <div className="size-44 p-0 rounded-2xl shadow-2xl shadow-black shrink-0 overflow-hidden bg-stone-800 flex items-center justify-center border border-border">
+          <div className="size-44 p-0 rounded-full shadow-2xl shadow-black shrink-0 overflow-hidden bg-stone-800 flex items-center justify-center border border-border">
             {artist.avatar?.url || artist.avatarId ? (
               <img
                 src={artist.avatar?.url || `/api/images/${artist.avatarId}`}

--- a/apps/web/src/routes/app/library/artists/$id/index.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/index.tsx
@@ -20,6 +20,9 @@ import {
   DiscIcon,
   DotsThreeIcon,
   HeartIcon,
+  ListBulletsIcon,
+  MusicNoteIcon,
+  MusicNotesIcon,
   PencilIcon,
   PlayIcon,
   PlusIcon,
@@ -314,7 +317,7 @@ function RouteComponent() {
                       coverUrl={album.cover?.url ?? undefined}
                       link={`/app/library/albums/${album.id}`}
                       placeholderIcon={
-                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                        <MusicNotesIcon className="size-1/2 text-stone-400" weight="duotone" />
                       }
                     />
                   );
@@ -362,7 +365,7 @@ function RouteComponent() {
                       coverUrl={album.cover?.url ?? undefined}
                       link={`/app/library/albums/${album.id}`}
                       placeholderIcon={
-                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                        <MusicNoteIcon className="size-1/2 text-stone-400" weight="duotone" />
                       }
                     />
                   );
@@ -410,7 +413,7 @@ function RouteComponent() {
                       coverUrl={album.cover?.url ?? undefined}
                       link={`/app/library/albums/${album.id}`}
                       placeholderIcon={
-                        <DiscIcon className="size-1/2 text-stone-400" weight="duotone" />
+                        <ListBulletsIcon className="size-1/2 text-stone-400" weight="duotone" />
                       }
                     />
                   );

--- a/apps/web/src/routes/app/library/artists/$id/index.tsx
+++ b/apps/web/src/routes/app/library/artists/$id/index.tsx
@@ -162,14 +162,14 @@ function RouteComponent() {
         <div className="flex items-center gap-3">
           <Button
             size="lg"
-            className="h-12 rounded-xl gap-2 px-8 text-base font-bold shadow-md hover:shadow-primary/20 active:shadow-primary/35 active:scale-98 transition-all bg-primary text-primary-foreground"
+            className="h-12 rounded-lg gap-2 px-8 text-base font-bold shadow-md hover:shadow-primary/20 active:shadow-primary/35 active:scale-98 transition-all bg-primary text-primary-foreground"
           >
             <PlayIcon weight="fill" size={20} /> Play
           </Button>
           <Button
             variant="outline"
             size="lg"
-            className="h-12 rounded-xl gap-2 px-8 text-base font-bold border-border bg-stone-900/20 backdrop-blur-md hover:bg-stone-800/40 active:scale-98 transition-all"
+            className="h-12 rounded-lg gap-2 px-8 text-base font-bold border-border bg-stone-900/20 backdrop-blur-md hover:bg-stone-800/40 active:scale-98 transition-all"
           >
             <ShuffleIcon weight="bold" size={20} /> Shuffle
           </Button>
@@ -177,7 +177,7 @@ function RouteComponent() {
             <Button
               variant="ghost"
               size="icon"
-              className="size-10 text-muted-foreground hover:text-primary hover:bg-primary/10 transition-all"
+              className="size-10 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 active:scale-98 transition-all"
               aria-label="Add to favorites"
             >
               <HeartIcon size={24} />
@@ -187,7 +187,7 @@ function RouteComponent() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="size-10 text-muted-foreground hover:text-primary hover:bg-primary/10 transition-all"
+                  className="size-10 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 active:scale-98 transition-all"
                   aria-label="More options"
                 >
                   <DotsThreeIcon size={24} weight="bold" />

--- a/apps/web/src/routes/app/library/artists/index.tsx
+++ b/apps/web/src/routes/app/library/artists/index.tsx
@@ -1,8 +1,9 @@
+import { MediaCard } from '@/components/library/MediaCard';
 import { Spinner } from '@/components/ui/spinner';
 import { useLibraryArtists } from '@/hooks/api/library-artists/useLibraryArtists';
 import { useLibraryStore } from '@/stores/library.store';
 import { UserIcon } from '@phosphor-icons/react';
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import { useEffect } from 'react';
 
 export const Route = createFileRoute('/app/library/artists/')({
@@ -45,32 +46,16 @@ function RouteComponent() {
     <div className="flex flex-col gap-8">
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
         {artists.map((artist) => (
-          <Link
+          <MediaCard
             key={artist.id}
-            to="/app/library/artists/$id"
-            params={{ id: artist.id }}
-            className="group/artist relative p-2 rounded-lg overflow-hidden transition-all transition-150 transform hover:scale-[1.02] active:scale-[1.00] hover:bg-stone-800/30 active:bg-stone-800/45 cursor-pointer"
-          >
-            <div className="aspect-square w-full overflow-hidden bg-stone-800 rounded-md">
-              {artist.avatar?.url ? (
-                <img
-                  src={artist.avatar?.url}
-                  alt={artist.name}
-                  className="size-full object-cover"
-                />
-              ) : (
-                <div className="flex size-full items-center justify-center">
-                  <UserIcon className="size-1/2 text-stone-400" weight="duotone" />
-                </div>
-              )}
-            </div>
-            <div className="pt-4">
-              <h3 className="line-clamp-1 text-sm font-semibold">{artist.name}</h3>
-              <p className="line-clamp-1 text-xs text-muted-foreground">
-                {artist.isCommunity ? 'Community Artist' : 'Private Artist'}
-              </p>
-            </div>
-          </Link>
+            id={artist.id}
+            title={artist.name}
+            subtitle={artist.isCommunity ? 'Community Artist' : 'Private Artist'}
+            coverUrl={artist.avatar?.url ?? undefined}
+            link={`/app/library/artists/${artist.id}`}
+            coverStyle="circle"
+            placeholderIcon={<UserIcon className="size-1/2 text-stone-400" weight="duotone" />}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
# feat(apps/web): make CreateAlbumForm generic to support multiple content types

Add support for dynamic form type configuration in the album creation form
and hook. The form now accepts an optional `type` prop that determines the
label text throughout the component (e.g., "Album Title" vs "Playlist Title").

The `useCreateAlbumForm` hook now accepts an `initialType` parameter to set
the default form type, allowing the form to be reused for different content
types while maintaining consistent behavior.

# feat(apps/web): add type prop to CreateAlbumForm component

# feat(apps/web): implement album creation forms for compilation, ep, and single routes

Replace placeholder components with fully functional album creation pages for
compilation, EP, and single content types. Each route now includes form handling,
cover image upload, error management, and navigation after successful creation.

All three routes follow the same implementation pattern using shared hooks and
components for consistency.

# feat(apps/web): add EPs, singles, and compilations sections to artist page

Add three new sections to the artist detail page to display EPs, singles, and
compilations separately from regular albums. Each section includes:
- Lazy loading with skeleton placeholders
- Responsive grid layout matching the albums section
- "Show all" button for sections with more than 5 items
- Consistent MediaCard component usage with album metadata

# feat(apps/web): replace disc icon with context-specific icons on artist page

Replace generic DiscIcon with more appropriate icons for different album
sections: MusicNotesIcon for albums, MusicNoteIcon for singles, and
ListBulletsIcon for compilations/EPs. This improves visual clarity and
better represents the content type being displayed.

# feat(apps/web): add coverStyle prop to MediaCard component

Add optional `coverStyle` prop to MediaCard component to support both
square and circular cover image displays. The prop defaults to 'square'
and uses the `cn` utility to conditionally apply either `rounded-full`
or `rounded` classes based on the selected style.

# refactor(apps/web): replace Link with MediaCard component in artists list

- Replace custom Link-based artist card implementation with reusable
  MediaCard component
- Update artist avatar in detail page to use circular border-radius
- Remove redundant card styling and layout code
- Leverage MediaCard's built-in styling and icon placeholder support

# style(apps/web): update button border radius from rounded-xl to rounded-lg

Update border radius styling on album and artist page buttons and interactive elements from rounded-xl to rounded-lg for a more subtle appearance. Also add active:scale-98 transition to icon buttons for consistent interaction feedback.

# feat(apps/web): enhance album subtitle with artist fallback and type display

# test(apps/web): add test for MediaCard coverStyle class application