### PR TITLE
feat: implement cascade soft delete for artists and add album creation UI

### DIFF
--- a/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.spec.ts
@@ -47,14 +47,12 @@ describe('DeleteLibraryArtistHandler', () => {
     const mockDeletedArtist = { ...mockArtist, deletedAt: new Date() };
 
     artistRepository.findOne.mockResolvedValue(mockArtist as any);
-    artistRepository.update.mockResolvedValue(mockDeletedArtist as any);
+    artistRepository.softDeleteCascade.mockResolvedValue(mockDeletedArtist as any);
 
     const result = await handler.execute(command);
 
     expect(result).toEqual(mockDeletedArtist);
-    expect(artistRepository.update).toHaveBeenCalledWith(mockArtistId, {
-      deletedAt: expect.any(Date),
-    });
+    expect(artistRepository.softDeleteCascade).toHaveBeenCalledWith(mockArtistId);
   });
 
   it('should throw NotFoundException if artist is missing or permission denied', async () => {
@@ -67,7 +65,7 @@ describe('DeleteLibraryArtistHandler', () => {
   it('should throw InternalServerErrorException if parsing fails', async () => {
     const command = new DeleteLibraryArtistCommand(mockArtistId, mockUserId);
     artistRepository.findOne.mockResolvedValue(mockArtist as any);
-    artistRepository.update.mockResolvedValue({ invalid: 'data' } as any);
+    artistRepository.softDeleteCascade.mockResolvedValue({ invalid: 'data' } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
   });

--- a/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.ts
@@ -20,17 +20,19 @@ export class DeleteLibraryArtistHandler implements ICommandHandler<DeleteLibrary
       throw new NotFoundException('Artist not found or you do not have permission to delete it');
     }
 
-    // SOFT DELETE
-    const deletedArtist = await this.artistRepository.update(artistId, {
-      deletedAt: new Date(),
-    });
+    try {
+      const deletedArtist = await this.artistRepository.softDeleteCascade(artistId);
 
-    const parsed = ArtistSchema.safeParse(deletedArtist);
+      const parsed = ArtistSchema.safeParse(deletedArtist);
 
-    if (!parsed.success) {
-      throw new InternalServerErrorException('Failed to parse deleted artist');
+      if (!parsed.success) {
+        throw new InternalServerErrorException('Failed to parse deleted artist');
+      }
+
+      return parsed.data;
+    } catch (error) {
+      console.error('Failed to delete artist:', error);
+      throw new InternalServerErrorException('Failed to delete artist');
     }
-
-    return parsed.data;
   }
 }

--- a/apps/api/src/shared/repositories/artist.repository.spec.ts
+++ b/apps/api/src/shared/repositories/artist.repository.spec.ts
@@ -194,4 +194,51 @@ describe('ArtistRepository', () => {
       expect(mockTx.artist.deleteMany).toHaveBeenCalledWith({ where: filter });
     });
   });
+
+  describe('softDeleteCascade', () => {
+    it('should soft delete artist and cascade to albums and tracks', async () => {
+      const albumIds = ['album-1', 'album-2'];
+      const albums = [{ id: 'album-1' }, { id: 'album-2' }];
+
+      mockTx.album.findMany.mockResolvedValue(albums as any);
+
+      // Mock transaction response and individual calls
+      mockTx.$transaction.mockResolvedValue([mockArtist, { count: 2 }, { count: 10 }]);
+      mockTx.artist.update.mockResolvedValue(mockArtist);
+      mockTx.album.updateMany.mockResolvedValue({ count: 2 });
+      mockTx.track.updateMany.mockResolvedValue({ count: 10 });
+
+      const result = await repository.softDeleteCascade('artist-123');
+
+      expect(result).toEqual(mockArtist);
+
+      // Verify finding albums
+      expect(mockTx.album.findMany).toHaveBeenCalledWith({
+        where: {
+          artists: { some: { id: 'artist-123' } },
+          deletedAt: null,
+        },
+        select: { id: true },
+      });
+
+      // Verify transaction was called
+      expect(mockTx.$transaction).toHaveBeenCalled();
+
+      // Verify individual update calls were constructed
+      expect(mockTx.artist.update).toHaveBeenCalledWith({
+        where: { id: 'artist-123' },
+        data: { deletedAt: expect.any(Date) },
+      });
+
+      expect(mockTx.album.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: albumIds } },
+        data: { deletedAt: expect.any(Date) },
+      });
+
+      expect(mockTx.track.updateMany).toHaveBeenCalledWith({
+        where: { albumId: { in: albumIds } },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+  });
 });

--- a/apps/api/src/shared/repositories/artist.repository.ts
+++ b/apps/api/src/shared/repositories/artist.repository.ts
@@ -121,4 +121,35 @@ export class ArtistRepository {
     await this.prisma.client.artist.deleteMany({ where: filter });
     return artistsToDelete;
   }
+
+  async softDeleteCascade(id: string): Promise<Artist> {
+    // 1. Get albums to delete tracks first
+    const albums = await this.prisma.client.album.findMany({
+      where: {
+        artists: { some: { id } },
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+
+    const albumIds = albums.map((a) => a.id);
+
+    // 2. Transaction: Mark artist, albums, and tracks as deleted
+    const [deletedArtist] = await this.prisma.mainClient.$transaction([
+      this.prisma.client.artist.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      }),
+      this.prisma.client.album.updateMany({
+        where: { id: { in: albumIds } },
+        data: { deletedAt: new Date() },
+      }),
+      this.prisma.client.track.updateMany({
+        where: { albumId: { in: albumIds } },
+        data: { deletedAt: new Date() },
+      }),
+    ]);
+
+    return deletedArtist;
+  }
 }

--- a/apps/web/src/routes/app/library/albums/create.tsx
+++ b/apps/web/src/routes/app/library/albums/create.tsx
@@ -1,9 +1,209 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { CreateArtistForm } from '@/components/artists/CreateArtistForm';
+import { MediaCard } from '@/components/library/MediaCard';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useCreateLibraryArtist } from '@/hooks/api/library-artists/useCreateLibraryArtist';
+import { useLibraryArtists } from '@/hooks/api/library-artists/useLibraryArtists';
+import { useUploadLibraryArtistAvatar } from '@/hooks/api/library-artists/useUploadLibraryArtistAvatar';
+import { useLibraryStore } from '@/stores/library.store';
+import { InfoIcon, PlusIcon, UserIcon, UsersIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import { CreateLibraryArtistRequest } from '@repo/contracts';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/app/library/albums/create')({
   component: RouteComponent,
 });
 
+type View = 'selection' | 'pick' | 'create';
+
 function RouteComponent() {
-  return <div>Hello "/app/library/album/create"!</div>;
+  const navigate = useNavigate();
+  const [view, setView] = useState<View>('selection');
+  const { libraryId } = useLibraryStore();
+
+  const { isLoading: isLoadingArtists } = useLibraryArtists();
+  const artists = useLibraryStore((state) => state.privateArtists);
+
+  const {
+    mutateAsync: createArtist,
+    isPending: isCreatingArtist,
+    error: apiError,
+  } = useCreateLibraryArtist();
+
+  const { mutateAsync: uploadArtistAvatar, isPending: isUploadingAvatar } =
+    useUploadLibraryArtistAvatar();
+
+  const onArtistCreated = async (data: CreateLibraryArtistRequest, avatarFile?: File) => {
+    try {
+      const response = await createArtist(data);
+      if (response.data) {
+        if (avatarFile) {
+          await uploadArtistAvatar({ id: response.data.id, file: avatarFile });
+        }
+        await navigate({
+          to: '/app/library/artists/$id/add-content/album',
+          params: { id: response.data.id },
+        });
+      }
+    } catch (err) {
+      console.error('Failed to create artist or upload avatar', err);
+    }
+  };
+
+  if (view === 'selection') {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 gap-8">
+        <div className="flex flex-col items-center text-center gap-2 max-w-md">
+          <h2 className="text-2xl font-bold text-white">Who is the author?</h2>
+          <p className="text-muted-foreground text-sm">
+            To create an album, you first need to specify the artist. You can pick an existing one
+            from your library or create a brand new one.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-2xl">
+          <button
+            onClick={() => setView('pick')}
+            className="flex flex-col items-center gap-6 p-8 rounded-2xl bg-stone-900/40 border border-white/5 hover:border-primary/50 hover:bg-stone-800/40 transition-all group text-left"
+          >
+            <div className="p-4 rounded-full bg-primary/10 text-primary group-hover:scale-110 transition-transform">
+              <UsersIcon size={32} weight="duotone" />
+            </div>
+            <div className="flex flex-col items-center text-center gap-2">
+              <h3 className="text-lg font-semibold text-white">Pick existing artist</h3>
+              <p className="text-sm text-muted-foreground">
+                Choose an artist from your private collection to add a new album to.
+              </p>
+            </div>
+          </button>
+
+          <button
+            onClick={() => setView('create')}
+            className="flex flex-col items-center gap-6 p-8 rounded-2xl bg-stone-900/40 border border-white/5 hover:border-primary/50 hover:bg-stone-800/40 transition-all group text-left"
+          >
+            <div className="p-4 rounded-full bg-primary/10 text-primary group-hover:scale-110 transition-transform">
+              <PlusIcon size={32} weight="duotone" />
+            </div>
+            <div className="flex flex-col items-center text-center gap-2">
+              <h3 className="text-lg font-semibold text-white">Create new artist</h3>
+              <p className="text-sm text-muted-foreground">
+                Add a new artist to your library first, then proceed to album creation.
+              </p>
+            </div>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (view === 'pick') {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-white">Select Artist</h2>
+            <p className="text-muted-foreground text-sm">
+              Click on an artist to start adding an album.
+            </p>
+          </div>
+          <button
+            onClick={() => setView('selection')}
+            className="text-sm text-muted-foreground hover:text-white transition-colors"
+          >
+            Go back
+          </button>
+        </div>
+
+        {isLoadingArtists ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="aspect-square rounded-2xl bg-stone-900 animate-pulse" />
+            ))}
+          </div>
+        ) : artists.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 bg-stone-900/20 rounded-2xl border border-dashed border-white/5">
+            <UserIcon size={48} className="text-muted-foreground mb-4" weight="duotone" />
+            <p className="text-muted-foreground">No private artists found.</p>
+            <button
+              onClick={() => setView('create')}
+              className="mt-4 text-primary hover:underline text-sm font-medium"
+            >
+              Create your first artist
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+            {artists.map((artist) => (
+              <MediaCard
+                key={artist.id}
+                id={artist.id}
+                title={artist.name}
+                subtitle={artist.isCommunity ? 'Community' : 'Private'}
+                coverUrl={artist.avatar?.url ?? undefined}
+                link="/app/library/artists/$id/add-content/album"
+                coverStyle="circle"
+                placeholderIcon={<UserIcon className="size-1/2 text-stone-400" weight="duotone" />}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center py-10">
+      <div className="flex flex-col gap-6 w-full max-w-2xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-white">Create Artist</h2>
+            <p className="text-muted-foreground text-sm">
+              Fill in the details to add a new artist to your library.
+            </p>
+          </div>
+          <button
+            onClick={() => setView('selection')}
+            className="text-sm text-muted-foreground hover:text-white transition-colors"
+          >
+            Go back
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Alert className="bg-primary/5 border-primary/20">
+            <InfoIcon size={20} className="text-primary" />
+            <AlertTitle className="text-primary">Note on Local Artists</AlertTitle>
+            <AlertDescription className="text-muted-foreground">
+              Local artists are strictly tied to your private library. Once created, you&apos;ll go
+              straight to adding an album.
+            </AlertDescription>
+          </Alert>
+
+          {!libraryId && (
+            <Alert variant="destructive">
+              <WarningCircleIcon size={20} />
+              <AlertTitle>Library unavailable</AlertTitle>
+              <AlertDescription>
+                Your library is not ready yet. Please try again later.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {apiError && apiError.status !== 409 && (
+            <Alert variant="destructive">
+              <WarningCircleIcon size={20} />
+              <AlertTitle>Error Creating Artist</AlertTitle>
+              <AlertDescription>{apiError.message}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <CreateArtistForm
+          isLoading={isCreatingArtist || isUploadingAvatar}
+          serverErrors={apiError?.status === 409 ? { name: apiError.message } : undefined}
+          onSubmit={onArtistCreated}
+        />
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
# feat(apps/web): implement album creation flow with artist selection and creation

Add comprehensive album creation route with three-view workflow:
- Selection view: Choose between picking existing artist or creating new one
- Pick view: Browse and select from private library artists
- Create view: Form to add new artist with avatar upload

Includes artist creation with avatar upload, error handling for library
unavailability, and navigation to album content addition after artist creation.

# feat(apps/api): implement cascading soft delete for artists with albums and tracks

Add softDeleteCascade method to ArtistRepository that atomically soft deletes
an artist along with their associated albums and tracks in a single transaction.
Update DeleteLibraryArtistHandler to use the new method and add error handling
with logging for improved debugging and reliability.