### PR TITLE
feat(packages/contracts): introduce track management API contracts

### DIFF
--- a/apps/api/integration/library-tracks.int-spec.ts
+++ b/apps/api/integration/library-tracks.int-spec.ts
@@ -1,0 +1,254 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import { vi } from 'vitest';
+import { PrismaServiceMock } from './mocks/prisma.service.mock';
+import './setup-env';
+import { createIntegrationApp } from './test-utils';
+import { Library, LibraryTrack, PrismaClient, TrackGetPayload } from '@repo/db';
+
+type TrackWithRelations = TrackGetPayload<{
+  include: { artists: true; album: true; access: true };
+}>;
+
+type LibraryTrackWithRelations = LibraryTrack & {
+  track: TrackWithRelations;
+};
+
+describe('LibraryTracksController (Integration)', () => {
+  let app: INestApplication;
+  let prismaMock: PrismaServiceMock;
+  let jwtService: JwtService;
+  let config: ConfigService;
+
+  beforeAll(async () => {
+    const setup = await createIntegrationApp();
+
+    app = setup.app;
+    prismaMock = setup.prismaMock;
+    jwtService = app.get(JwtService);
+    config = app.get(ConfigService);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const getAuthHeader = async (userId: string = 'user-123') => {
+    const token = await jwtService.signAsync(
+      { sub: userId, username: 'testuser', sessionId: 'session-123' },
+      {
+        secret: config.get('JWT_ACCESS_SECRET'),
+        expiresIn: '15m',
+      },
+    );
+    return `Bearer ${token}`;
+  };
+
+  const mockLibrary: Library = {
+    id: 'library-123',
+    userId: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockTrack: TrackWithRelations = {
+    id: 'track-123',
+    title: 'Test Track',
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    listenedCount: 0,
+    explicit: false,
+    lyrics: null,
+    visibility: 'private',
+    albumId: 'album-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    album: {
+      id: 'album-123',
+      name: 'Test Album',
+      description: 'Test Description',
+      type: 'album',
+      totalTracks: 10,
+      totalDuration: 3000,
+      releaseDate: new Date(),
+      coverId: null,
+      visibility: 'public',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    } as any,
+    artists: [
+      {
+        id: 'artist-123',
+        name: 'Test Artist',
+        description: 'Test Description',
+        isCommunity: false,
+        verified: true,
+        bannerId: null,
+        avatarId: null,
+        visibility: 'public',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      } as any,
+    ],
+    access: [
+      {
+        id: 'access-123',
+        userId: 'user-123',
+        role: 'owner',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        trackId: 'track-123',
+      },
+    ],
+  };
+
+  const mockLibraryTrack: LibraryTrackWithRelations = {
+    id: 'lib-track-123',
+    libraryId: 'library-123',
+    trackId: 'track-123',
+    listenedCount: 0,
+    listenCountResetAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    track: mockTrack,
+  };
+
+  describe('POST /library/tracks', () => {
+    it('should create a track successfully (201)', async () => {
+      const authHeader = await getAuthHeader();
+
+      prismaMock.client.user.findUnique.mockResolvedValue({ id: 'user-123' } as any);
+      prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
+      prismaMock.client.album.findFirst.mockResolvedValue(mockTrack.album);
+      prismaMock.client.track.create.mockResolvedValue(mockTrack);
+      prismaMock.client.libraryTrack.create.mockResolvedValue(mockLibraryTrack);
+
+      prismaMock.mainClient.$transaction.mockImplementation(
+        async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/library/tracks')
+        .set('Authorization', authHeader)
+        .send({
+          title: 'Test Track',
+          albumId: 'album-123',
+          trackNumber: 1,
+          diskNumber: 1,
+          duration: 180,
+          explicit: false,
+          visibility: 'private',
+          artistIds: ['artist-123'],
+        });
+
+      if (response.status !== 201) {
+        console.log('POST /library/tracks error:', JSON.stringify(response.body, null, 2));
+      }
+
+      expect(response.status).toBe(201);
+
+      expect(response.body.data.id).toBe(mockTrack.id);
+      expect(response.body.data.title).toBe(mockTrack.title);
+    });
+  });
+
+  describe('GET /library/tracks', () => {
+    it('should return a list of tracks (200)', async () => {
+      const authHeader = await getAuthHeader();
+
+      prismaMock.client.user.findUnique.mockResolvedValue({ id: 'user-123' } as any);
+      prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
+      prismaMock.client.libraryTrack.findMany.mockResolvedValue([mockLibraryTrack] as any);
+      prismaMock.client.libraryTrack.count.mockResolvedValue(1);
+
+      const response = await request(app.getHttpServer())
+        .get('/library/tracks')
+        .set('Authorization', authHeader)
+
+        .expect(200);
+
+      expect(response.body.data.items).toHaveLength(1);
+      expect(response.body.data.items[0].id).toBe(mockTrack.id);
+      expect(response.body.data.total).toBe(1);
+    });
+  });
+
+  describe('GET /library/tracks/:id', () => {
+    it('should return a track by id (200)', async () => {
+      const authHeader = await getAuthHeader();
+
+      prismaMock.client.user.findUnique.mockResolvedValue({ id: 'user-123' } as any);
+      prismaMock.client.track.findFirst.mockResolvedValue(mockTrack);
+
+      const response = await request(app.getHttpServer())
+        .get(`/library/tracks/${mockTrack.id}`)
+        .set('Authorization', authHeader)
+
+        .expect(200);
+
+      expect(response.body.data.id).toBe(mockTrack.id);
+    });
+  });
+
+  describe('PATCH /library/tracks/:id', () => {
+    it('should update a track successfully (200)', async () => {
+      const authHeader = await getAuthHeader();
+      const updatedTrack = { ...mockTrack, title: 'Updated Title' };
+
+      prismaMock.client.user.findUnique.mockResolvedValue({ id: 'user-123' } as any);
+      prismaMock.client.track.findFirst.mockResolvedValue(mockTrack);
+      prismaMock.client.track.update.mockResolvedValue(updatedTrack);
+
+      prismaMock.mainClient.$transaction.mockImplementation(
+        async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
+      );
+
+      const response = await request(app.getHttpServer())
+        .patch(`/library/tracks/${mockTrack.id}`)
+        .set('Authorization', authHeader)
+
+        .send({ title: 'Updated Title' })
+        .expect(200);
+
+      expect(response.body.data.title).toBe('Updated Title');
+    });
+  });
+
+  describe('DELETE /library/tracks/:id', () => {
+    it('should delete a track successfully (200)', async () => {
+      const authHeader = await getAuthHeader();
+
+      prismaMock.client.user.findUnique.mockResolvedValue({ id: 'user-123' } as any);
+      prismaMock.client.track.findFirst.mockResolvedValue(mockTrack);
+      prismaMock.client.track.update.mockResolvedValue({
+        ...mockTrack,
+        deletedAt: new Date(),
+      });
+      prismaMock.client.libraryTrack.deleteMany.mockResolvedValue({ count: 1 });
+
+      prismaMock.mainClient.$transaction.mockImplementation(
+        async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
+      );
+
+      const response = await request(app.getHttpServer())
+        .delete(`/library/tracks/${mockTrack.id}`)
+        .set('Authorization', authHeader)
+
+        .expect(200);
+
+      expect(response.body.data.success).toBe(true);
+    });
+  });
+});

--- a/apps/api/integration/library-tracks.int-spec.ts
+++ b/apps/api/integration/library-tracks.int-spec.ts
@@ -1,12 +1,12 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import { Library, LibraryTrack, PrismaClient, TrackGetPayload } from '@repo/db';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { PrismaServiceMock } from './mocks/prisma.service.mock';
 import './setup-env';
 import { createIntegrationApp } from './test-utils';
-import { Library, LibraryTrack, PrismaClient, TrackGetPayload } from '@repo/db';
 
 type TrackWithRelations = TrackGetPayload<{
   include: { artists: true; album: true; access: true };
@@ -248,7 +248,7 @@ describe('LibraryTracksController (Integration)', () => {
 
         .expect(200);
 
-      expect(response.body.data.success).toBe(true);
+      expect(response.body.data).toEqual(JSON.parse(JSON.stringify(mockTrack)));
     });
   });
 });

--- a/apps/api/src/features/features.module.ts
+++ b/apps/api/src/features/features.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { AlbumsModule } from './library-albums/library-albums.module';
 import { LibraryArtistsModule } from './library-artists/library-artists.module';
+import { LibraryTracksModule } from './library-tracks/library-tracks.module';
 import { LibraryModule } from './library/library.module';
 
 @Module({
-  imports: [AuthModule, LibraryModule, LibraryArtistsModule, AlbumsModule],
+  imports: [AuthModule, LibraryModule, LibraryArtistsModule, AlbumsModule, LibraryTracksModule],
   controllers: [],
   providers: [],
   exports: [],

--- a/apps/api/src/features/library-albums/dto/response/get-library-album-tracks.response.dto.ts
+++ b/apps/api/src/features/library-albums/dto/response/get-library-album-tracks.response.dto.ts
@@ -1,0 +1,6 @@
+import { GetLibraryAlbumTracksResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class GetLibraryAlbumTracksResponseDto extends createZodDto(
+  GetLibraryAlbumTracksResponseSchema,
+) {}

--- a/apps/api/src/features/library-albums/library-albums.controller.spec.ts
+++ b/apps/api/src/features/library-albums/library-albums.controller.spec.ts
@@ -11,6 +11,7 @@ import { GetLibraryAlbumQuery } from './queries/impl/get-library-album.query';
 import { UpdateLibraryAlbumCommand } from './commands/impl/update-library-album.command';
 import { UploadLibraryAlbumCoverCommand } from './commands/impl/upload-library-album-cover.command';
 import { DeleteLibraryAlbumCommand } from './commands/impl/delete-library-album.command';
+import { GetLibraryAlbumTracksQuery } from './queries/impl/get-library-album-tracks.query';
 
 describe('AlbumsController', () => {
   let controller: AlbumsController;
@@ -72,5 +73,10 @@ describe('AlbumsController', () => {
   it('deleteAlbum should execute DeleteLibraryAlbumCommand', async () => {
     await controller.deleteAlbum(mockAlbumId, mockUserId);
     expect(commandBus.execute).toHaveBeenCalledWith(expect.any(DeleteLibraryAlbumCommand));
+  });
+
+  it('getAlbumTracks should execute GetLibraryAlbumTracksQuery', async () => {
+    await controller.getAlbumTracks(mockAlbumId, mockUserId);
+    expect(queryBus.execute).toHaveBeenCalledWith(expect.any(GetLibraryAlbumTracksQuery));
   });
 });

--- a/apps/api/src/features/library-albums/library-albums.controller.ts
+++ b/apps/api/src/features/library-albums/library-albums.controller.ts
@@ -34,8 +34,10 @@ import { GetLibraryAlbumResponseDto } from './dto/response/get-library-album.res
 import { GetLibraryAlbumsResponseDto } from './dto/response/get-library-albums.response.dto';
 import { UpdateLibraryAlbumResponseDto } from './dto/response/update-library-album.response.dto';
 import { UploadLibraryAlbumCoverResponseDto } from './dto/response/upload-library-album-cover.response.dto';
+import { GetLibraryAlbumTracksResponseDto } from './dto/response/get-library-album-tracks.response.dto';
 import { GetLibraryAlbumQuery } from './queries/impl/get-library-album.query';
 import { GetLibraryAlbumsQuery } from './queries/impl/get-library-albums.query';
+import { GetLibraryAlbumTracksQuery } from './queries/impl/get-library-album-tracks.query';
 
 @ApiTags('Library Albums')
 @Controller('library/albums')
@@ -120,6 +122,29 @@ export class AlbumsController {
   async getAlbum(@Param('id') id: string, @CurrentUser('id') userId: string): Promise<ZodAlbum> {
     const query = new GetLibraryAlbumQuery(id, userId);
     return this.queryBus.execute(query);
+  }
+
+  @Get(':id/tracks')
+  @UseGuards(JwtAuthGuard, AlbumAccessGuard)
+  @CheckAlbumAccess('id')
+  @ApiOperation({ summary: 'Get album tracks' })
+  @ApiResponse({
+    status: 200,
+    description: 'Album tracks retrieved successfully',
+    type: GetLibraryAlbumTracksResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Album not found',
+    type: ApiErrorResponseDto,
+  })
+  async getAlbumTracks(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.queryBus.execute(new GetLibraryAlbumTracksQuery(userId, id));
   }
 
   @Patch(':id')

--- a/apps/api/src/features/library-albums/library-albums.module.ts
+++ b/apps/api/src/features/library-albums/library-albums.module.ts
@@ -7,6 +7,7 @@ import { UploadLibraryAlbumCoverHandler } from './commands/handlers/upload-libra
 import { AlbumsController } from './library-albums.controller';
 import { GetLibraryAlbumHandler } from './queries/handlers/get-library-album.handler';
 import { GetLibraryAlbumsHandler } from './queries/handlers/get-library-albums.handler';
+import { GetLibraryAlbumTracksHandler } from './queries/handlers/get-library-album-tracks.handler';
 
 @Module({
   imports: [CqrsModule],
@@ -17,6 +18,7 @@ import { GetLibraryAlbumsHandler } from './queries/handlers/get-library-albums.h
     DeleteLibraryAlbumHandler,
     GetLibraryAlbumHandler,
     GetLibraryAlbumsHandler,
+    GetLibraryAlbumTracksHandler,
     UploadLibraryAlbumCoverHandler,
   ],
 

--- a/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.spec.ts
@@ -1,0 +1,96 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { PreconditionFailedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Library } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GetLibraryAlbumTracksQuery } from '../impl/get-library-album-tracks.query';
+import { GetLibraryAlbumTracksHandler } from './get-library-album-tracks.handler';
+
+describe('GetLibraryAlbumTracksHandler', () => {
+  let handler: GetLibraryAlbumTracksHandler;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let libraryTrackRepository: DeepMocked<LibraryTrackRepository>;
+
+  const userId = 'user-123';
+  const albumId = 'album-123';
+  const query = new GetLibraryAlbumTracksQuery(userId, albumId);
+
+  const mockLibrary: Library = {
+    id: 'library-123',
+    userId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockTrack = {
+    id: 'track-123',
+    title: 'Test Track',
+    albumId,
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    listenedCount: 0,
+    explicit: false,
+    lyrics: null,
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockLibraryTrack: any = {
+    id: 'lib-track-123',
+    libraryId: mockLibrary.id,
+    trackId: mockTrack.id,
+    track: mockTrack,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    libraryRepository = createMock<LibraryRepository>();
+    libraryTrackRepository = createMock<LibraryTrackRepository>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetLibraryAlbumTracksHandler,
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: LibraryTrackRepository, useValue: libraryTrackRepository },
+      ],
+    }).compile();
+
+    handler = module.get<GetLibraryAlbumTracksHandler>(GetLibraryAlbumTracksHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return album tracks for a user library', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryTrackRepository.findMany.mockResolvedValue([mockLibraryTrack]);
+    libraryTrackRepository.count.mockResolvedValue(1);
+
+    const result = await handler.execute(query);
+
+    expect(result).toEqual([mockTrack]);
+    expect(libraryRepository.getByUserId).toHaveBeenCalledWith(userId);
+    expect(libraryTrackRepository.findMany).toHaveBeenCalledWith({
+      where: {
+        libraryId: mockLibrary.id,
+        track: { albumId },
+      },
+      orderBy: [{ track: { diskNumber: 'asc' } }, { track: { trackNumber: 'asc' } }],
+    });
+  });
+
+  it('should throw PreconditionFailedException if library not found', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(null);
+
+    await expect(handler.execute(query)).rejects.toThrow(PreconditionFailedException);
+  });
+});

--- a/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.ts
+++ b/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.ts
@@ -1,0 +1,34 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { PreconditionFailedException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetLibraryAlbumTracksResponse } from '@repo/contracts';
+import { GetLibraryAlbumTracksQuery } from '../impl/get-library-album-tracks.query';
+
+@QueryHandler(GetLibraryAlbumTracksQuery)
+export class GetLibraryAlbumTracksHandler implements IQueryHandler<GetLibraryAlbumTracksQuery> {
+  constructor(
+    private readonly libraryRepository: LibraryRepository,
+    private readonly libraryTrackRepository: LibraryTrackRepository,
+  ) {}
+
+  async execute(query: GetLibraryAlbumTracksQuery): Promise<GetLibraryAlbumTracksResponse['data']> {
+    const { userId, albumId } = query;
+
+    const library = await this.libraryRepository.getByUserId(userId);
+
+    if (!library) {
+      throw new PreconditionFailedException(`User library not found for userId: ${userId}`);
+    }
+
+    const items = await this.libraryTrackRepository.findMany({
+      where: {
+        libraryId: library.id,
+        track: { albumId } as any,
+      },
+      orderBy: [{ track: { diskNumber: 'asc' } }, { track: { trackNumber: 'asc' } }] as any,
+    });
+
+    return items.map((lt: any) => lt.track) as any;
+  }
+}

--- a/apps/api/src/features/library-albums/queries/impl/get-library-album-tracks.query.ts
+++ b/apps/api/src/features/library-albums/queries/impl/get-library-album-tracks.query.ts
@@ -1,0 +1,8 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetLibraryAlbumTracksQuery implements IQuery {
+  constructor(
+    public readonly userId: string,
+    public readonly albumId: string,
+  ) {}
+}

--- a/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.spec.ts
@@ -1,0 +1,140 @@
+import { AlbumRepository } from '@/shared/repositories/album.repository';
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Album, Library, Track } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateLibraryTrackCommand } from '../impl/create-library-track.command';
+import { CreateLibraryTrackHandler } from './create-library-track.handler';
+
+describe('CreateLibraryTrackHandler', () => {
+  let handler: CreateLibraryTrackHandler;
+  let unitOfWork: DeepMocked<UnitOfWorkService>;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let albumRepository: DeepMocked<AlbumRepository>;
+  let trackRepository: DeepMocked<TrackRepository>;
+  let libraryTrackRepository: DeepMocked<LibraryTrackRepository>;
+
+  const userId = 'user-123';
+  const command = new CreateLibraryTrackCommand(
+    {
+      title: 'Test Track',
+      albumId: 'album-123',
+      trackNumber: 1,
+      diskNumber: 1,
+      duration: 180,
+      explicit: false,
+      visibility: 'private',
+      artistIds: ['artist-123'],
+    },
+    userId,
+  );
+
+  const mockLibrary: Library = {
+    id: 'library-123',
+    userId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockAlbum: Album = {
+    id: 'album-123',
+    name: 'Test Album',
+    description: 'Test Description',
+    type: 'album',
+    totalTracks: 10,
+    totalDuration: 3000,
+    releaseDate: new Date(),
+    coverId: null,
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockTrack: Track = {
+    id: 'track-123',
+    title: 'Test Track',
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    explicit: false,
+    lyrics: null,
+    listenedCount: 0,
+    albumId: 'album-123',
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    unitOfWork = createMock<UnitOfWorkService>();
+    libraryRepository = createMock<LibraryRepository>();
+    albumRepository = createMock<AlbumRepository>();
+    trackRepository = createMock<TrackRepository>();
+    libraryTrackRepository = createMock<LibraryTrackRepository>();
+
+    unitOfWork.runInTransaction.mockImplementation(async (cb) => cb());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreateLibraryTrackHandler,
+        { provide: UnitOfWorkService, useValue: unitOfWork },
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: AlbumRepository, useValue: albumRepository },
+        { provide: TrackRepository, useValue: trackRepository },
+        { provide: LibraryTrackRepository, useValue: libraryTrackRepository },
+      ],
+    }).compile();
+
+    handler = module.get<CreateLibraryTrackHandler>(CreateLibraryTrackHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a track and link to library', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
+    trackRepository.create.mockResolvedValue(mockTrack);
+
+    const result = await handler.execute(command);
+
+    expect(result).toEqual(mockTrack);
+    expect(libraryRepository.getByUserId).toHaveBeenCalledWith(userId);
+    expect(albumRepository.findOne).toHaveBeenCalledWith({ id: command.body.albumId });
+    expect(trackRepository.create).toHaveBeenCalled();
+    expect(libraryTrackRepository.create).toHaveBeenCalledWith({
+      track: { connect: { id: mockTrack.id } },
+      library: { connect: { id: mockLibrary.id } },
+    });
+  });
+
+  it('should throw PreconditionFailedException if library not found', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(null);
+
+    await expect(handler.execute(command)).rejects.toThrow(PreconditionFailedException);
+  });
+
+  it('should throw PreconditionFailedException if album not found', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    albumRepository.findOne.mockResolvedValue(null);
+
+    await expect(handler.execute(command)).rejects.toThrow(PreconditionFailedException);
+  });
+
+  it('should throw InternalServerErrorException if Zod validation fails', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
+    trackRepository.create.mockResolvedValue({ ...mockTrack, title: 123 as any }); // Invalid title
+
+    await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+  });
+});

--- a/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.ts
@@ -1,0 +1,77 @@
+import { AlbumRepository } from '@/shared/repositories/album.repository';
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { TrackSchema, ZodTrack } from '@repo/contracts';
+import { CreateLibraryTrackCommand } from '../impl/create-library-track.command';
+
+@CommandHandler(CreateLibraryTrackCommand)
+export class CreateLibraryTrackHandler implements ICommandHandler<CreateLibraryTrackCommand> {
+  constructor(
+    private readonly unitOfWork: UnitOfWorkService,
+    private readonly libraryRepository: LibraryRepository,
+    private readonly albumRepository: AlbumRepository,
+    private readonly trackRepository: TrackRepository,
+    private readonly libraryTrackRepository: LibraryTrackRepository,
+  ) {}
+
+  async execute(command: CreateLibraryTrackCommand): Promise<ZodTrack> {
+    const { body, userId } = command;
+
+    const library = await this.libraryRepository.getByUserId(userId);
+
+    if (!library) {
+      throw new PreconditionFailedException('User library not found');
+    }
+
+    const album = await this.albumRepository.findOne({ id: body.albumId });
+    if (!album) {
+      throw new PreconditionFailedException('Album not found');
+    }
+
+    const track = await this.unitOfWork.runInTransaction(async () => {
+      const created = await this.trackRepository.create({
+        title: body.title,
+        trackNumber: body.trackNumber,
+        diskNumber: body.diskNumber,
+        duration: body.duration,
+        explicit: body.explicit,
+        lyrics: body.lyrics,
+        visibility: body.visibility as any,
+        album: {
+          connect: {
+            id: body.albumId,
+          },
+        },
+        artists: {
+          connect: body.artistIds.map((id) => ({ id })),
+        },
+        access: {
+          create: {
+            userId: userId,
+            role: 'owner',
+          },
+        },
+      });
+
+      await this.libraryTrackRepository.create({
+        track: { connect: { id: created.id } },
+        library: { connect: { id: library.id } },
+      });
+
+      return created;
+    });
+
+    const parsed = TrackSchema.safeParse(track);
+
+    if (!parsed.success) {
+      console.error(parsed.error);
+      throw new InternalServerErrorException('Failed to parse track');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.ts
@@ -6,6 +6,7 @@ import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
 import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { TrackSchema, ZodTrack } from '@repo/contracts';
+import { Visibility } from '@repo/db';
 import { CreateLibraryTrackCommand } from '../impl/create-library-track.command';
 
 @CommandHandler(CreateLibraryTrackCommand)
@@ -16,7 +17,7 @@ export class CreateLibraryTrackHandler implements ICommandHandler<CreateLibraryT
     private readonly albumRepository: AlbumRepository,
     private readonly trackRepository: TrackRepository,
     private readonly libraryTrackRepository: LibraryTrackRepository,
-  ) {}
+  ) { }
 
   async execute(command: CreateLibraryTrackCommand): Promise<ZodTrack> {
     const { body, userId } = command;
@@ -37,10 +38,9 @@ export class CreateLibraryTrackHandler implements ICommandHandler<CreateLibraryT
         title: body.title,
         trackNumber: body.trackNumber,
         diskNumber: body.diskNumber,
-        duration: body.duration,
+        duration: 0, // will be later calculated from the audio file
         explicit: body.explicit,
-        lyrics: body.lyrics,
-        visibility: body.visibility as any,
+        visibility: Visibility.private, // this route is used to create only private tracks
         album: {
           connect: {
             id: body.albumId,

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
@@ -1,0 +1,85 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Track } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
+import { DeleteLibraryTrackHandler } from './delete-library-track.handler';
+
+describe('DeleteLibraryTrackHandler', () => {
+  let handler: DeleteLibraryTrackHandler;
+  let unitOfWork: DeepMocked<UnitOfWorkService>;
+  let trackRepository: DeepMocked<TrackRepository>;
+  let libraryTrackRepository: DeepMocked<LibraryTrackRepository>;
+
+  const userId = 'user-123';
+  const trackId = 'track-123';
+  const command = new DeleteLibraryTrackCommand(trackId, userId);
+
+  const mockTrack: Track = {
+    id: trackId,
+    title: 'Test Track',
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    listenedCount: 0,
+    explicit: false,
+    lyrics: null,
+    albumId: 'album-123',
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    unitOfWork = createMock<UnitOfWorkService>();
+    trackRepository = createMock<TrackRepository>();
+    libraryTrackRepository = createMock<LibraryTrackRepository>();
+
+    unitOfWork.runInTransaction.mockImplementation(async (cb) => cb());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeleteLibraryTrackHandler,
+        { provide: UnitOfWorkService, useValue: unitOfWork },
+        { provide: TrackRepository, useValue: trackRepository },
+        { provide: LibraryTrackRepository, useValue: libraryTrackRepository },
+      ],
+    }).compile();
+
+    handler = module.get<DeleteLibraryTrackHandler>(DeleteLibraryTrackHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should soft delete track and remove library tracks', async () => {
+    trackRepository.findOne.mockResolvedValue(mockTrack);
+
+    const result = await handler.execute(command);
+
+    expect(result).toEqual(mockTrack);
+    expect(trackRepository.findOne).toHaveBeenCalledWith({
+      id: trackId,
+      access: { some: { userId, role: 'owner' } },
+    });
+    expect(trackRepository.update).toHaveBeenCalledWith(trackId, {
+      deletedAt: expect.any(Date),
+    });
+    expect(libraryTrackRepository.deleteMany).toHaveBeenCalledWith({
+      trackId,
+      library: { userId },
+    });
+  });
+
+  it('should throw NotFoundException if track not found or access denied', async () => {
+    trackRepository.findOne.mockResolvedValue(null);
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
@@ -1,0 +1,44 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
+
+@CommandHandler(DeleteLibraryTrackCommand)
+export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryTrackCommand> {
+  constructor(
+    private readonly unitOfWork: UnitOfWorkService,
+    private readonly trackRepository: TrackRepository,
+    private readonly libraryTrackRepository: LibraryTrackRepository,
+  ) {}
+
+  async execute(command: DeleteLibraryTrackCommand): Promise<{ success: boolean }> {
+    const { id, userId } = command;
+
+    const track = await this.trackRepository.findOne({
+      id,
+      access: { some: { userId, role: 'owner' } },
+    });
+
+    if (!track) {
+      throw new NotFoundException('Track not found or you do not have permission to delete it');
+    }
+
+    await this.unitOfWork.runInTransaction(async () => {
+      // Soft delete the track
+      await this.trackRepository.update(id, {
+        deletedAt: new Date(),
+      });
+
+      // Remove from all users libraries?
+      // Usually library_tracks is per user. If owner deletes, maybe it should be gone from their library.
+      await this.libraryTrackRepository.deleteMany({
+        trackId: id,
+        library: { userId },
+      });
+    });
+
+    return { success: true };
+  }
+}

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
@@ -4,6 +4,7 @@ import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
 import { NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
+import { ZodTrack } from '@repo/contracts';
 
 @CommandHandler(DeleteLibraryTrackCommand)
 export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryTrackCommand> {
@@ -13,7 +14,7 @@ export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryT
     private readonly libraryTrackRepository: LibraryTrackRepository,
   ) {}
 
-  async execute(command: DeleteLibraryTrackCommand): Promise<{ success: boolean }> {
+  async execute(command: DeleteLibraryTrackCommand): Promise<ZodTrack> {
     const { id, userId } = command;
 
     const track = await this.trackRepository.findOne({
@@ -39,6 +40,6 @@ export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryT
       });
     });
 
-    return { success: true };
+    return track;
   }
 }

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.ts
@@ -3,8 +3,8 @@ import { TrackRepository } from '@/shared/repositories/track.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
 import { NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
 import { ZodTrack } from '@repo/contracts';
+import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
 
 @CommandHandler(DeleteLibraryTrackCommand)
 export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryTrackCommand> {
@@ -12,7 +12,7 @@ export class DeleteLibraryTrackHandler implements ICommandHandler<DeleteLibraryT
     private readonly unitOfWork: UnitOfWorkService,
     private readonly trackRepository: TrackRepository,
     private readonly libraryTrackRepository: LibraryTrackRepository,
-  ) {}
+  ) { }
 
   async execute(command: DeleteLibraryTrackCommand): Promise<ZodTrack> {
     const { id, userId } = command;

--- a/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.spec.ts
@@ -1,0 +1,122 @@
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Track } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateLibraryTrackCommand } from '../impl/update-library-track.command';
+import { UpdateLibraryTrackHandler } from './update-library-track.handler';
+
+describe('UpdateLibraryTrackHandler', () => {
+  let handler: UpdateLibraryTrackHandler;
+  let unitOfWork: DeepMocked<UnitOfWorkService>;
+  let trackRepository: DeepMocked<TrackRepository>;
+
+  const userId = 'user-123';
+  const trackId = 'track-123';
+  const command = new UpdateLibraryTrackCommand(
+    trackId,
+    {
+      title: 'Updated Title',
+      artistIds: ['artist-456'],
+    },
+    userId,
+  );
+
+  const mockTrack: Track = {
+    id: trackId,
+    title: 'Test Track',
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    listenedCount: 0,
+    explicit: false,
+    lyrics: null,
+    albumId: 'album-123',
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    unitOfWork = createMock<UnitOfWorkService>();
+    trackRepository = createMock<TrackRepository>();
+
+    unitOfWork.runInTransaction.mockImplementation(async (cb) => cb());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpdateLibraryTrackHandler,
+        { provide: UnitOfWorkService, useValue: unitOfWork },
+        { provide: TrackRepository, useValue: trackRepository },
+      ],
+    }).compile();
+
+    handler = module.get<UpdateLibraryTrackHandler>(UpdateLibraryTrackHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should update track and artists', async () => {
+    trackRepository.findOne.mockResolvedValue(mockTrack);
+    const updatedTrack = { ...mockTrack, title: 'Updated Title' };
+    trackRepository.update.mockResolvedValue(updatedTrack);
+
+    const result = await handler.execute(command);
+
+    expect(result).toEqual(updatedTrack);
+    expect(trackRepository.findOne).toHaveBeenCalledWith({
+      id: trackId,
+      access: { some: { userId, role: 'owner' } },
+    });
+
+    // Check update payload structure (artistIds Connect/Disconnect logic)
+    expect(trackRepository.update).toHaveBeenCalledWith(
+      trackId,
+      expect.objectContaining({
+        title: 'Updated Title',
+        artists: expect.any(Object),
+      }),
+    );
+  });
+
+  it('should update track without artists if artistIds not provided', async () => {
+    trackRepository.findOne.mockResolvedValue(mockTrack);
+    const updatedTrack = { ...mockTrack, title: 'Updated Title' };
+    trackRepository.update.mockResolvedValue(updatedTrack);
+
+    const commandNoArtists = new UpdateLibraryTrackCommand(
+      trackId,
+      { title: 'Updated Title' },
+      userId,
+    );
+    const result = await handler.execute(commandNoArtists);
+
+    expect(result).toEqual(updatedTrack);
+    expect(trackRepository.update).toHaveBeenCalledWith(
+      trackId,
+      expect.objectContaining({
+        title: 'Updated Title',
+        artists: undefined,
+      }),
+    );
+  });
+
+  it('should throw NotFoundException if track not found or access denied', async () => {
+    trackRepository.findOne.mockResolvedValue(null);
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should throw InternalServerErrorException if Zod validation fails', async () => {
+    trackRepository.findOne.mockResolvedValue(mockTrack);
+    // Return track with invalid data for schema
+    trackRepository.update.mockResolvedValue({ ...mockTrack, title: 123 as any });
+
+    await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
+  });
+});

--- a/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.ts
@@ -1,0 +1,52 @@
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { TrackSchema, ZodTrack } from '@repo/contracts';
+import { UpdateLibraryTrackCommand } from '../impl/update-library-track.command';
+
+@CommandHandler(UpdateLibraryTrackCommand)
+export class UpdateLibraryTrackHandler implements ICommandHandler<UpdateLibraryTrackCommand> {
+  constructor(
+    private readonly unitOfWork: UnitOfWorkService,
+    private readonly trackRepository: TrackRepository,
+  ) {}
+
+  async execute(command: UpdateLibraryTrackCommand): Promise<ZodTrack> {
+    const { id, body, userId } = command;
+
+    const track = await this.trackRepository.findOne({
+      id,
+      access: { some: { userId, role: 'owner' } },
+    });
+
+    if (!track) {
+      throw new NotFoundException('Track not found or you do not have permission to update it');
+    }
+
+    const updated = await this.unitOfWork.runInTransaction(async () => {
+      return await this.trackRepository.update(id, {
+        title: body.title,
+        trackNumber: body.trackNumber,
+        diskNumber: body.diskNumber,
+        duration: body.duration,
+        explicit: body.explicit,
+        lyrics: body.lyrics,
+        visibility: body.visibility as any,
+        artists: body.artistIds
+          ? {
+              set: body.artistIds.map((artistId) => ({ id: artistId })),
+            }
+          : undefined,
+      });
+    });
+
+    const parsed = TrackSchema.safeParse(updated);
+
+    if (!parsed.success) {
+      throw new InternalServerErrorException('Failed to parse track');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/library-tracks/commands/impl/create-library-track.command.ts
+++ b/apps/api/src/features/library-tracks/commands/impl/create-library-track.command.ts
@@ -1,0 +1,9 @@
+import { ICommand } from '@nestjs/cqrs';
+import { CreateLibraryTrackRequestDto } from '../../dto/request/create-library-track.request.dto';
+
+export class CreateLibraryTrackCommand implements ICommand {
+  constructor(
+    public readonly body: CreateLibraryTrackRequestDto,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/library-tracks/commands/impl/delete-library-track.command.ts
+++ b/apps/api/src/features/library-tracks/commands/impl/delete-library-track.command.ts
@@ -1,0 +1,8 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class DeleteLibraryTrackCommand implements ICommand {
+  constructor(
+    public readonly id: string,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/library-tracks/commands/impl/update-library-track.command.ts
+++ b/apps/api/src/features/library-tracks/commands/impl/update-library-track.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs';
+import { UpdateLibraryTrackRequestDto } from '../../dto/request/update-library-track.request.dto';
+
+export class UpdateLibraryTrackCommand implements ICommand {
+  constructor(
+    public readonly id: string,
+    public readonly body: UpdateLibraryTrackRequestDto,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/library-tracks/dto/request/create-library-track.request.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/request/create-library-track.request.dto.ts
@@ -1,0 +1,4 @@
+import { CreateLibraryTrackRequestSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class CreateLibraryTrackRequestDto extends createZodDto(CreateLibraryTrackRequestSchema) {}

--- a/apps/api/src/features/library-tracks/dto/request/get-library-tracks.request.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/request/get-library-tracks.request.dto.ts
@@ -1,0 +1,4 @@
+import { GetLibraryTracksRequestSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class GetLibraryTracksRequestDto extends createZodDto(GetLibraryTracksRequestSchema) {}

--- a/apps/api/src/features/library-tracks/dto/request/update-library-track.request.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/request/update-library-track.request.dto.ts
@@ -1,0 +1,4 @@
+import { UpdateLibraryTrackRequestSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class UpdateLibraryTrackRequestDto extends createZodDto(UpdateLibraryTrackRequestSchema) {}

--- a/apps/api/src/features/library-tracks/dto/response/create-library-track.response.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/response/create-library-track.response.dto.ts
@@ -1,0 +1,4 @@
+import { CreateLibraryTrackResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class CreateLibraryTrackResponseDto extends createZodDto(CreateLibraryTrackResponseSchema) {}

--- a/apps/api/src/features/library-tracks/dto/response/delete-library-track.response.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/response/delete-library-track.response.dto.ts
@@ -1,0 +1,4 @@
+import { DeleteLibraryTrackResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class DeleteLibraryTrackResponseDto extends createZodDto(DeleteLibraryTrackResponseSchema) {}

--- a/apps/api/src/features/library-tracks/dto/response/get-library-track.response.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/response/get-library-track.response.dto.ts
@@ -1,0 +1,4 @@
+import { GetLibraryTrackResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class GetLibraryTrackResponseDto extends createZodDto(GetLibraryTrackResponseSchema) {}

--- a/apps/api/src/features/library-tracks/dto/response/get-library-tracks.response.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/response/get-library-tracks.response.dto.ts
@@ -1,0 +1,4 @@
+import { GetLibraryTracksResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class GetLibraryTracksResponseDto extends createZodDto(GetLibraryTracksResponseSchema) {}

--- a/apps/api/src/features/library-tracks/dto/response/update-library-track.response.dto.ts
+++ b/apps/api/src/features/library-tracks/dto/response/update-library-track.response.dto.ts
@@ -1,0 +1,4 @@
+import { UpdateLibraryTrackResponseSchema } from '@repo/contracts';
+import { createZodDto } from 'nestjs-zod';
+
+export class UpdateLibraryTrackResponseDto extends createZodDto(UpdateLibraryTrackResponseSchema) {}

--- a/apps/api/src/features/library-tracks/library-tracks.controller.spec.ts
+++ b/apps/api/src/features/library-tracks/library-tracks.controller.spec.ts
@@ -1,0 +1,121 @@
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { Reflector } from '@nestjs/core';
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LibraryTracksController } from './library-tracks.controller';
+import { CreateLibraryTrackCommand } from './commands/impl/create-library-track.command';
+import { DeleteLibraryTrackCommand } from './commands/impl/delete-library-track.command';
+import { UpdateLibraryTrackCommand } from './commands/impl/update-library-track.command';
+import { GetLibraryTrackQuery } from './queries/impl/get-library-track.query';
+import { GetLibraryTracksQuery } from './queries/impl/get-library-tracks.query';
+
+describe('LibraryTracksController', () => {
+  let controller: LibraryTracksController;
+  let commandBus: DeepMocked<CommandBus>;
+  let queryBus: DeepMocked<QueryBus>;
+
+  const userId = 'user-123';
+  const trackId = 'track-123';
+
+  beforeEach(async () => {
+    commandBus = createMock<CommandBus>();
+    queryBus = createMock<QueryBus>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LibraryTracksController],
+      providers: [
+        { provide: CommandBus, useValue: commandBus },
+        { provide: QueryBus, useValue: queryBus },
+        { provide: Reflector, useValue: createMock<Reflector>() },
+        { provide: TrackRepository, useValue: createMock<TrackRepository>() },
+      ],
+    }).compile();
+
+    controller = module.get<LibraryTracksController>(LibraryTracksController);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getTracks', () => {
+    it('should return list of tracks', async () => {
+      const query = { page: 1, limit: 10 };
+      const expectedResult = { items: [], total: 0 };
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.getTracks(userId, query);
+
+      expect(result).toBe(expectedResult);
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new GetLibraryTracksQuery(userId, query.page, query.limit, undefined),
+      );
+    });
+
+    it('should pass albumId if provided', async () => {
+      const query = { page: 1, limit: 10, albumId: 'album-123' };
+
+      await controller.getTracks(userId, query);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new GetLibraryTracksQuery(userId, query.page, query.limit, 'album-123'),
+      );
+    });
+  });
+
+  describe('createTrack', () => {
+    it('should create a track', async () => {
+      const body = { title: 'New Track', albumId: 'album-123', artistIds: ['artist-123'] } as any;
+      const expectedResult = { id: trackId, title: 'New Track' };
+      commandBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.createTrack(body, userId);
+
+      expect(result).toBe(expectedResult);
+      expect(commandBus.execute).toHaveBeenCalledWith(new CreateLibraryTrackCommand(body, userId));
+    });
+  });
+
+  describe('getTrack', () => {
+    it('should return a track', async () => {
+      const expectedResult = { id: trackId };
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.getTrack(trackId, userId);
+
+      expect(result).toBe(expectedResult);
+      expect(queryBus.execute).toHaveBeenCalledWith(new GetLibraryTrackQuery(trackId, userId));
+    });
+  });
+
+  describe('updateTrack', () => {
+    it('should update a track', async () => {
+      const body = { title: 'Updated' };
+      const expectedResult = { id: trackId, title: 'Updated' };
+      commandBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.updateTrack(trackId, body, userId);
+
+      expect(result).toBe(expectedResult);
+      expect(commandBus.execute).toHaveBeenCalledWith(
+        new UpdateLibraryTrackCommand(trackId, body, userId),
+      );
+    });
+  });
+
+  describe('deleteTrack', () => {
+    it('should delete a track', async () => {
+      const expectedResult = { success: true };
+      commandBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.deleteTrack(trackId, userId);
+
+      expect(result).toBe(expectedResult);
+      expect(commandBus.execute).toHaveBeenCalledWith(
+        new DeleteLibraryTrackCommand(trackId, userId),
+      );
+    });
+  });
+});

--- a/apps/api/src/features/library-tracks/library-tracks.controller.ts
+++ b/apps/api/src/features/library-tracks/library-tracks.controller.ts
@@ -1,0 +1,150 @@
+import { CurrentUser } from '@/common/decorators/current-user.decorator';
+import { CheckTrackAccess } from '@/common/decorators/check-track-access.decorator';
+import { ApiErrorResponseDto } from '@/common/dto/api-error.response.dto';
+import { TrackAccessGuard } from '@/shared/guards/track-access.guard';
+import { JwtAuthGuard } from '@/shared/guards/jwt-auth.guard';
+
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CreateLibraryTrackCommand } from './commands/impl/create-library-track.command';
+import { DeleteLibraryTrackCommand } from './commands/impl/delete-library-track.command';
+import { UpdateLibraryTrackCommand } from './commands/impl/update-library-track.command';
+import { CreateLibraryTrackRequestDto } from './dto/request/create-library-track.request.dto';
+import { GetLibraryTracksRequestDto } from './dto/request/get-library-tracks.request.dto';
+import { UpdateLibraryTrackRequestDto } from './dto/request/update-library-track.request.dto';
+import { CreateLibraryTrackResponseDto } from './dto/response/create-library-track.response.dto';
+import { DeleteLibraryTrackResponseDto } from './dto/response/delete-library-track.response.dto';
+import { GetLibraryTrackResponseDto } from './dto/response/get-library-track.response.dto';
+import { GetLibraryTracksResponseDto } from './dto/response/get-library-tracks.response.dto';
+import { UpdateLibraryTrackResponseDto } from './dto/response/update-library-track.response.dto';
+import { GetLibraryTrackQuery } from './queries/impl/get-library-track.query';
+import { GetLibraryTracksQuery } from './queries/impl/get-library-tracks.query';
+
+@ApiTags('Library Tracks')
+@Controller('library/tracks')
+export class LibraryTracksController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get all library tracks' })
+  @ApiResponse({
+    status: 200,
+    description: 'Library tracks retrieved successfully',
+    type: GetLibraryTracksResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  getTracks(@CurrentUser('id') userId: string, @Query() query: GetLibraryTracksRequestDto) {
+    return this.queryBus.execute(
+      new GetLibraryTracksQuery(userId, query.page, query.limit, query.albumId),
+    );
+  }
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Create a new track in private library' })
+  @ApiResponse({
+    status: 201,
+    description: 'Track created successfully',
+    type: CreateLibraryTrackResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  async createTrack(@Body() body: CreateLibraryTrackRequestDto, @CurrentUser('id') userId: string) {
+    return this.commandBus.execute(new CreateLibraryTrackCommand(body, userId));
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, TrackAccessGuard)
+  @CheckTrackAccess('id')
+  @ApiOperation({ summary: 'Get track details' })
+  @ApiResponse({
+    status: 200,
+    description: 'Track details retrieved successfully',
+    type: GetLibraryTrackResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Track not found',
+    type: ApiErrorResponseDto,
+  })
+  async getTrack(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.queryBus.execute(new GetLibraryTrackQuery(id, userId));
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, TrackAccessGuard)
+  @CheckTrackAccess('id')
+  @ApiOperation({ summary: 'Update track details' })
+  @ApiResponse({
+    status: 200,
+    description: 'Track details updated successfully',
+    type: UpdateLibraryTrackResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Track not found',
+    type: ApiErrorResponseDto,
+  })
+  async updateTrack(
+    @Param('id') id: string,
+    @Body() body: UpdateLibraryTrackRequestDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.commandBus.execute(new UpdateLibraryTrackCommand(id, body, userId));
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, TrackAccessGuard)
+  @CheckTrackAccess('id')
+  @ApiOperation({ summary: 'Delete a track from library' })
+  @ApiResponse({
+    status: 200,
+    description: 'Track deleted successfully',
+    type: DeleteLibraryTrackResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized',
+    type: ApiErrorResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Track not found',
+    type: ApiErrorResponseDto,
+  })
+  async deleteTrack(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.commandBus.execute(new DeleteLibraryTrackCommand(id, userId));
+  }
+}

--- a/apps/api/src/features/library-tracks/library-tracks.module.ts
+++ b/apps/api/src/features/library-tracks/library-tracks.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CreateLibraryTrackHandler } from './commands/handlers/create-library-track.handler';
+import { DeleteLibraryTrackHandler } from './commands/handlers/delete-library-track.handler';
+import { UpdateLibraryTrackHandler } from './commands/handlers/update-library-track.handler';
+import { LibraryTracksController } from './library-tracks.controller';
+import { GetLibraryTrackHandler } from './queries/handlers/get-library-track.handler';
+import { GetLibraryTracksHandler } from './queries/handlers/get-library-tracks.handler';
+
+export const CommandHandlers = [
+  CreateLibraryTrackHandler,
+  UpdateLibraryTrackHandler,
+  DeleteLibraryTrackHandler,
+];
+
+export const QueryHandlers = [GetLibraryTrackHandler, GetLibraryTracksHandler];
+
+@Module({
+  imports: [CqrsModule],
+  controllers: [LibraryTracksController],
+  providers: [...CommandHandlers, ...QueryHandlers],
+})
+export class LibraryTracksModule {}

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
@@ -1,0 +1,68 @@
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Track } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GetLibraryTrackQuery } from '../impl/get-library-track.query';
+import { GetLibraryTrackHandler } from './get-library-track.handler';
+
+describe('GetLibraryTrackHandler', () => {
+  let handler: GetLibraryTrackHandler;
+  let trackRepository: DeepMocked<TrackRepository>;
+
+  const userId = 'user-123';
+  const trackId = 'track-123';
+  const query = new GetLibraryTrackQuery(trackId, userId);
+
+  const mockTrack: Track = {
+    id: trackId,
+    title: 'Test Track',
+    trackNumber: 1,
+    diskNumber: 1,
+    duration: 180,
+    listenedCount: 0,
+    explicit: false,
+    lyrics: null,
+    albumId: 'album-123',
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    trackRepository = createMock<TrackRepository>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GetLibraryTrackHandler, { provide: TrackRepository, useValue: trackRepository }],
+    }).compile();
+
+    handler = module.get<GetLibraryTrackHandler>(GetLibraryTrackHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return track details', async () => {
+    trackRepository.findOne.mockResolvedValue(mockTrack);
+
+    const result = await handler.execute(query);
+
+    expect(result).toEqual(mockTrack);
+    expect(trackRepository.findOne).toHaveBeenCalledWith({ id: trackId }, true);
+  });
+
+  it('should throw NotFoundException if track not found', async () => {
+    trackRepository.findOne.mockResolvedValue(null);
+
+    await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should throw InternalServerErrorException if Zod validation fails', async () => {
+    trackRepository.findOne.mockResolvedValue({ ...mockTrack, title: 123 as any });
+
+    await expect(handler.execute(query)).rejects.toThrow(InternalServerErrorException);
+  });
+});

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.ts
@@ -1,0 +1,32 @@
+import { TrackRepository } from '@/shared/repositories/track.repository';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { TrackSchema, ZodTrack } from '@repo/contracts';
+import { GetLibraryTrackQuery } from '../impl/get-library-track.query';
+
+@QueryHandler(GetLibraryTrackQuery)
+export class GetLibraryTrackHandler implements IQueryHandler<GetLibraryTrackQuery> {
+  constructor(private readonly trackRepository: TrackRepository) {}
+
+  async execute(query: GetLibraryTrackQuery): Promise<ZodTrack> {
+    const { id } = query;
+
+    const track = await this.trackRepository.findOne({ id }, true);
+
+    if (!track) {
+      throw new NotFoundException('Track not found');
+    }
+
+    const parsed = TrackSchema.safeParse(track);
+
+    if (!parsed.success) {
+      console.error(
+        '[GetLibraryTrackHandler] Zod validation failed:',
+        JSON.stringify(parsed.error.format(), null, 2),
+      );
+      throw new InternalServerErrorException('Failed to parse track');
+    }
+
+    return parsed.data;
+  }
+}

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
@@ -1,0 +1,100 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { PreconditionFailedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Library, LibraryTrack } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GetLibraryTracksQuery } from '../impl/get-library-tracks.query';
+import { GetLibraryTracksHandler } from './get-library-tracks.handler';
+
+describe('GetLibraryTracksHandler', () => {
+  let handler: GetLibraryTracksHandler;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let libraryTrackRepository: DeepMocked<LibraryTrackRepository>;
+
+  const userId = 'user-123';
+  const query = new GetLibraryTracksQuery(userId, 1, 10);
+
+  const mockLibrary: Library = {
+    id: 'library-123',
+    userId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  const mockLibraryTrack: LibraryTrack = {
+    id: 'lib-track-123',
+    libraryId: mockLibrary.id,
+    trackId: 'track-123',
+    listenedCount: 0,
+    listenCountResetAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    libraryRepository = createMock<LibraryRepository>();
+    libraryTrackRepository = createMock<LibraryTrackRepository>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetLibraryTracksHandler,
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: LibraryTrackRepository, useValue: libraryTrackRepository },
+      ],
+    }).compile();
+
+    handler = module.get<GetLibraryTracksHandler>(GetLibraryTracksHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return paginated library tracks', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryTrackRepository.findMany.mockResolvedValue([
+      { ...mockLibraryTrack, track: mockLibraryTrack } as any,
+    ]);
+    libraryTrackRepository.count.mockResolvedValue(1);
+
+    const result = (await handler.execute(query)) as any;
+
+    expect(result.items).toEqual([mockLibraryTrack]);
+    expect(result.total).toBe(1);
+    expect(libraryRepository.getByUserId).toHaveBeenCalledWith(userId);
+    expect(libraryTrackRepository.findMany).toHaveBeenCalledWith({
+      where: { libraryId: mockLibrary.id, track: undefined },
+      take: 10,
+      skip: 0,
+      orderBy: { track: { trackNumber: 'asc' } },
+    });
+  });
+
+  it('should filter by albumId if provided', async () => {
+    const albumQuery = new GetLibraryTracksQuery(userId, 1, 10, 'album-123');
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryTrackRepository.findMany.mockResolvedValue([mockLibraryTrack]);
+    libraryTrackRepository.count.mockResolvedValue(1);
+
+    await handler.execute(albumQuery);
+
+    expect(libraryTrackRepository.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          libraryId: mockLibrary.id,
+          track: { albumId: 'album-123' },
+        },
+      }),
+    );
+  });
+
+  it('should throw PreconditionFailedException if library not found', async () => {
+    libraryRepository.getByUserId.mockResolvedValue(null);
+
+    await expect(handler.execute(query)).rejects.toThrow(PreconditionFailedException);
+  });
+});

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.ts
@@ -29,7 +29,7 @@ export class GetLibraryTracksHandler implements IQueryHandler<GetLibraryTracksQu
         },
         take: limit,
         skip: (page - 1) * limit,
-        orderBy: { track: { trackNumber: 'asc' } }, // Optional: sort by track number
+        orderBy: { track: { trackNumber: 'asc' } }, // Sort by track number
       }),
       this.libraryTrackRepository.count({
         libraryId: library.id,

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.ts
@@ -1,0 +1,47 @@
+import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
+import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { PreconditionFailedException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetLibraryTracksResponse } from '@repo/contracts';
+import { GetLibraryTracksQuery } from '../impl/get-library-tracks.query';
+
+@QueryHandler(GetLibraryTracksQuery)
+export class GetLibraryTracksHandler implements IQueryHandler<GetLibraryTracksQuery> {
+  constructor(
+    private readonly libraryRepository: LibraryRepository,
+    private readonly libraryTrackRepository: LibraryTrackRepository,
+  ) {}
+
+  async execute(query: GetLibraryTracksQuery): Promise<GetLibraryTracksResponse['data']> {
+    const { userId, page, limit, albumId } = query;
+
+    const library = await this.libraryRepository.getByUserId(userId);
+
+    if (!library) {
+      throw new PreconditionFailedException(`User library not found for userId: ${userId}`);
+    }
+
+    const [items, total] = await Promise.all([
+      this.libraryTrackRepository.findMany({
+        where: {
+          libraryId: library.id,
+          track: albumId ? { albumId } : undefined,
+        },
+        take: limit,
+        skip: (page - 1) * limit,
+        orderBy: { track: { trackNumber: 'asc' } }, // Optional: sort by track number
+      }),
+      this.libraryTrackRepository.count({
+        libraryId: library.id,
+        track: albumId ? { albumId } : undefined,
+      }),
+    ]);
+
+    return {
+      items: items.map((lt: any) => lt.track),
+      total,
+      page,
+      limit,
+    } as any;
+  }
+}

--- a/apps/api/src/features/library-tracks/queries/impl/get-library-track.query.ts
+++ b/apps/api/src/features/library-tracks/queries/impl/get-library-track.query.ts
@@ -1,0 +1,8 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetLibraryTrackQuery implements IQuery {
+  constructor(
+    public readonly id: string,
+    public readonly userId: string,
+  ) {}
+}

--- a/apps/api/src/features/library-tracks/queries/impl/get-library-tracks.query.ts
+++ b/apps/api/src/features/library-tracks/queries/impl/get-library-tracks.query.ts
@@ -1,0 +1,10 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class GetLibraryTracksQuery implements IQuery {
+  constructor(
+    public readonly userId: string,
+    public readonly page: number,
+    public readonly limit: number,
+    public readonly albumId?: string,
+  ) {}
+}

--- a/apps/api/src/shared/repositories/library-track.repository.spec.ts
+++ b/apps/api/src/shared/repositories/library-track.repository.spec.ts
@@ -1,0 +1,191 @@
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LibraryTrack, PrismaClient } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrismaService } from '../services/prisma.service';
+import { LibraryTrackRepository } from './library-track.repository';
+
+describe('LibraryTrackRepository', () => {
+  let repository: LibraryTrackRepository;
+  let mockTx: DeepMocked<PrismaClient>;
+
+  const mockLibraryTrack: LibraryTrack = {
+    id: 'lib-track-123',
+    libraryId: 'library-123',
+    trackId: 'track-123',
+    listenedCount: 0,
+    listenCountResetAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    mockTx = createMock<PrismaClient>();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibraryTrackRepository,
+        {
+          provide: PrismaService,
+          useValue: {
+            client: mockTx,
+            mainClient: mockTx,
+          },
+        },
+      ],
+    }).compile();
+
+    repository = module.get<LibraryTrackRepository>(LibraryTrackRepository);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('findOne', () => {
+    it('should return library track matching where clause', async () => {
+      mockTx.libraryTrack.findFirst.mockResolvedValue(mockLibraryTrack);
+      const result = await repository.findOne({ id: 'lib-track-123' });
+      expect(result).toEqual(mockLibraryTrack);
+      expect(mockTx.libraryTrack.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'lib-track-123' }),
+        }),
+      );
+    });
+
+    it('should handle track filter in where clause', async () => {
+      mockTx.libraryTrack.findFirst.mockResolvedValue(mockLibraryTrack);
+      const result = await repository.findOne({ track: { title: 'test' } as any });
+      expect(result).toEqual(mockLibraryTrack);
+      expect(mockTx.libraryTrack.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            track: expect.objectContaining({ title: 'test', deletedAt: null }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return multiple library tracks matching options', async () => {
+      mockTx.libraryTrack.findMany.mockResolvedValue([mockLibraryTrack]);
+      const result = await repository.findMany({ take: 5 });
+      expect(result).toEqual([mockLibraryTrack]);
+      expect(mockTx.libraryTrack.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 5,
+        }),
+      );
+    });
+
+    it('should handle track filter in findMany', async () => {
+      mockTx.libraryTrack.findMany.mockResolvedValue([mockLibraryTrack]);
+      const result = await repository.findMany({
+        where: { track: { title: 'test' } as any },
+      });
+      expect(result).toEqual([mockLibraryTrack]);
+      expect(mockTx.libraryTrack.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            track: expect.objectContaining({ title: 'test', deletedAt: null }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('count', () => {
+    it('should return count', async () => {
+      mockTx.libraryTrack.count.mockResolvedValue(5);
+      const result = await repository.count({ libraryId: 'lib-123' });
+      expect(result).toBe(5);
+      expect(mockTx.libraryTrack.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ libraryId: 'lib-123' }),
+        }),
+      );
+    });
+
+    it('should handle track filter in count', async () => {
+      mockTx.libraryTrack.count.mockResolvedValue(5);
+      const result = await repository.count({ track: { title: 'test' } as any });
+      expect(result).toBe(5);
+      expect(mockTx.libraryTrack.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            track: expect.objectContaining({ title: 'test', deletedAt: null }),
+          }),
+        }),
+      );
+    });
+
+    it('should return count when no where clause is provided', async () => {
+      mockTx.libraryTrack.count.mockResolvedValue(10);
+      const result = await repository.count();
+      expect(result).toBe(10);
+      expect(mockTx.libraryTrack.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({ track: { deletedAt: null } }),
+      });
+    });
+  });
+
+  describe('exists', () => {
+    it('should return true if count > 0', async () => {
+      mockTx.libraryTrack.count.mockResolvedValue(1);
+      const result = await repository.exists({ id: 'lib-track-123' });
+      expect(result).toBe(true);
+    });
+
+    it('should return false if count === 0', async () => {
+      mockTx.libraryTrack.count.mockResolvedValue(0);
+      const result = await repository.exists({ id: 'lib-track-123' });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a library track', async () => {
+      mockTx.libraryTrack.create.mockResolvedValue(mockLibraryTrack);
+      const data = { library: { connect: { id: 'lib-123' } } } as any;
+      const result = await repository.create(data);
+      expect(result).toEqual(mockLibraryTrack);
+      expect(mockTx.libraryTrack.create).toHaveBeenCalledWith({ data });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a library track', async () => {
+      mockTx.libraryTrack.update.mockResolvedValue(mockLibraryTrack);
+      const data = { listenedCount: 1 };
+      const result = await repository.update('lib-track-123', data);
+      expect(result).toEqual(mockLibraryTrack);
+      expect(mockTx.libraryTrack.update).toHaveBeenCalledWith({
+        where: { id: 'lib-track-123' },
+        data,
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a library track', async () => {
+      mockTx.libraryTrack.delete.mockResolvedValue(mockLibraryTrack);
+      const result = await repository.delete('lib-track-123');
+      expect(result).toEqual(mockLibraryTrack);
+      expect(mockTx.libraryTrack.delete).toHaveBeenCalledWith({
+        where: { id: 'lib-track-123' },
+      });
+    });
+  });
+
+  describe('deleteMany', () => {
+    it('should delete many library tracks', async () => {
+      mockTx.libraryTrack.deleteMany.mockResolvedValue({ count: 5 });
+      await repository.deleteMany({ libraryId: 'lib-123' });
+      expect(mockTx.libraryTrack.deleteMany).toHaveBeenCalledWith({
+        where: { libraryId: 'lib-123' },
+      });
+    });
+  });
+});

--- a/apps/api/src/shared/repositories/library-track.repository.ts
+++ b/apps/api/src/shared/repositories/library-track.repository.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@nestjs/common';
+import {
+  LibraryTrack,
+  LibraryTrackCreateInput,
+  LibraryTrackOrderByWithRelationInput,
+  LibraryTrackUpdateInput,
+  LibraryTrackWhereInput,
+} from '@repo/db';
+import { PrismaService } from '../services/prisma.service';
+
+@Injectable()
+export class LibraryTrackRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─────────────────────────────────────────────────────────────
+  // QUERIES
+  // ─────────────────────────────────────────────────────────────
+
+  async findOne(where: LibraryTrackWhereInput): Promise<LibraryTrack | null> {
+    const { track, ...rest } = where;
+    return await this.prisma.client.libraryTrack.findFirst({
+      where: {
+        ...rest,
+        track: {
+          ...(track as any),
+          deletedAt: null,
+        },
+      },
+      include: {
+        track: {
+          include: {
+            artists: true,
+            album: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findMany(options: {
+    where?: LibraryTrackWhereInput;
+    take?: number;
+    skip?: number;
+    orderBy?: LibraryTrackOrderByWithRelationInput;
+  }): Promise<LibraryTrack[]> {
+    const { track, ...rest } = options.where || {};
+    return await this.prisma.client.libraryTrack.findMany({
+      take: options.take,
+      skip: options.skip,
+      where: {
+        ...rest,
+        track: {
+          ...(track as any),
+          deletedAt: null,
+        },
+      },
+      include: {
+        track: {
+          include: {
+            artists: true,
+            album: true,
+          },
+        },
+      },
+      orderBy: options.orderBy,
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // EXISTS & COUNT
+  // ─────────────────────────────────────────────────────────────
+
+  async exists(where: LibraryTrackWhereInput): Promise<boolean> {
+    const count = await this.prisma.client.libraryTrack.count({ where });
+    return count > 0;
+  }
+
+  async count(where?: LibraryTrackWhereInput): Promise<number> {
+    const { track, ...rest } = where || {};
+    return await this.prisma.client.libraryTrack.count({
+      where: {
+        ...rest,
+        track: {
+          ...(track as any),
+          deletedAt: null,
+        },
+      },
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // CREATE
+  // ─────────────────────────────────────────────────────────────
+
+  async create(data: LibraryTrackCreateInput): Promise<LibraryTrack> {
+    return await this.prisma.client.libraryTrack.create({ data });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // UPDATE
+  // ─────────────────────────────────────────────────────────────
+
+  async update(id: string, data: LibraryTrackUpdateInput): Promise<LibraryTrack> {
+    return await this.prisma.client.libraryTrack.update({ data, where: { id } });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // DELETE
+  // ─────────────────────────────────────────────────────────────
+
+  async delete(id: string): Promise<LibraryTrack> {
+    return await this.prisma.client.libraryTrack.delete({ where: { id } });
+  }
+
+  async deleteMany(where: LibraryTrackWhereInput): Promise<void> {
+    await this.prisma.client.libraryTrack.deleteMany({
+      where,
+    });
+  }
+}

--- a/apps/api/src/shared/repositories/track.repository.spec.ts
+++ b/apps/api/src/shared/repositories/track.repository.spec.ts
@@ -54,6 +54,17 @@ describe('TrackRepository', () => {
       expect(result).toEqual(mockTrack);
       expect(mockTx.track.findFirst).toHaveBeenCalledWith({
         where: { id: 'track-123', deletedAt: null },
+        include: undefined,
+      });
+    });
+
+    it('should include relations when requested', async () => {
+      mockTx.track.findFirst.mockResolvedValue(mockTrack);
+      const result = await repository.findOne({ id: 'track-123' }, true);
+      expect(result).toEqual(mockTrack);
+      expect(mockTx.track.findFirst).toHaveBeenCalledWith({
+        where: { id: 'track-123', deletedAt: null },
+        include: { artists: true, album: true },
       });
     });
   });

--- a/apps/api/src/shared/repositories/track.repository.ts
+++ b/apps/api/src/shared/repositories/track.repository.ts
@@ -16,9 +16,10 @@ export class TrackRepository {
   // QUERIES
   // ─────────────────────────────────────────────────────────────
 
-  async findOne(where: TrackWhereInput): Promise<Track | null> {
+  async findOne(where: TrackWhereInput, includeRelations = false): Promise<Track | null> {
     return await this.prisma.client.track.findFirst({
       where: { ...where, deletedAt: null },
+      include: includeRelations ? { artists: true, album: true } : undefined,
     });
   }
 

--- a/apps/api/src/shared/shared.module.ts
+++ b/apps/api/src/shared/shared.module.ts
@@ -8,6 +8,7 @@ import { ArtistRepository } from './repositories/artist.repository';
 import { EmailAddressRepository } from './repositories/email-address.repository';
 import { LibraryAlbumRepository } from './repositories/library-album.repository';
 import { LibraryArtistRepository } from './repositories/library-artist.repository';
+import { LibraryTrackRepository } from './repositories/library-track.repository';
 
 import { LibraryRepository } from './repositories/library.repository';
 import { RefreshTokenRepository } from './repositories/refresh-token.repository';
@@ -41,6 +42,7 @@ import { UnitOfWorkService } from './services/unit-of-work.service';
     AlbumRepository,
     LibraryArtistRepository,
     LibraryAlbumRepository,
+    LibraryTrackRepository,
     TrackRepository,
     // guards
     JwtAuthGuard,
@@ -65,6 +67,7 @@ import { UnitOfWorkService } from './services/unit-of-work.service';
     AlbumRepository,
     LibraryArtistRepository,
     LibraryAlbumRepository,
+    LibraryTrackRepository,
     TrackRepository,
     // guards
     JwtAuthGuard,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export * from "./auth";
 export * from "./library";
 export * from "./library-artists";
 export * from "./library-albums";
+export * from "./library-tracks";
 
 export * from "./api";
 export * from "./utils";

--- a/packages/contracts/src/library-albums/index.ts
+++ b/packages/contracts/src/library-albums/index.ts
@@ -10,3 +10,4 @@ export * from "./response/delete-library-album.response";
 export * from "./response/get-library-album.response";
 export * from "./response/update-library-album.response";
 export * from "./response/upload-library-album-cover.response";
+export * from "./response/get-library-album-tracks.response";

--- a/packages/contracts/src/library-albums/response/get-library-album-tracks.response.ts
+++ b/packages/contracts/src/library-albums/response/get-library-album-tracks.response.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const GetLibraryAlbumTracksResponseSchema = createApiResponseSchema(
+  z.array(TrackSchema),
+);
+
+export type GetLibraryAlbumTracksResponse = z.infer<
+  typeof GetLibraryAlbumTracksResponseSchema
+>;

--- a/packages/contracts/src/library-tracks/index.ts
+++ b/packages/contracts/src/library-tracks/index.ts
@@ -1,0 +1,12 @@
+// Requests
+export * from "./request/create-library-track.request";
+export * from "./request/delete-library-track.request";
+export * from "./request/get-library-tracks.request";
+export * from "./request/update-library-track.request";
+
+// Responses
+export * from "./response/create-library-track.response";
+export * from "./response/delete-library-track.response";
+export * from "./response/get-library-track.response";
+export * from "./response/get-library-tracks.response";
+export * from "./response/update-library-track.response";

--- a/packages/contracts/src/library-tracks/request/create-library-track.request.ts
+++ b/packages/contracts/src/library-tracks/request/create-library-track.request.ts
@@ -1,0 +1,24 @@
+import { Visibility } from "@repo/db";
+import { z } from "zod";
+import { zodRequiredString } from "../../utils/zod-shared";
+
+export const CreateLibraryTrackRequestSchema = z.object({
+  title: zodRequiredString("Track title is required").pipe(
+    z
+      .string()
+      .min(1, "Track title is required")
+      .max(255, "Track title must be 255 characters or less"),
+  ),
+  albumId: zodRequiredString("Album ID is required"),
+  trackNumber: z.number().int().min(1).default(1),
+  diskNumber: z.number().int().min(1).default(1),
+  duration: z.number().int().min(0).default(0),
+  explicit: z.boolean().default(false),
+  lyrics: z.string().max(10000).optional(),
+  visibility: z.enum(Visibility).default(Visibility.public),
+  artistIds: z.array(z.string()).min(1, "At least one artist is required"),
+});
+
+export type CreateLibraryTrackRequest = z.infer<
+  typeof CreateLibraryTrackRequestSchema
+>;

--- a/packages/contracts/src/library-tracks/request/create-library-track.request.ts
+++ b/packages/contracts/src/library-tracks/request/create-library-track.request.ts
@@ -1,4 +1,3 @@
-import { Visibility } from "@repo/db";
 import { z } from "zod";
 import { zodRequiredString } from "../../utils/zod-shared";
 
@@ -12,10 +11,7 @@ export const CreateLibraryTrackRequestSchema = z.object({
   albumId: zodRequiredString("Album ID is required"),
   trackNumber: z.number().int().min(1).default(1),
   diskNumber: z.number().int().min(1).default(1),
-  duration: z.number().int().min(0).default(0),
   explicit: z.boolean().default(false),
-  lyrics: z.string().max(10000).optional(),
-  visibility: z.enum(Visibility).default(Visibility.public),
   artistIds: z.array(z.string()).min(1, "At least one artist is required"),
 });
 

--- a/packages/contracts/src/library-tracks/request/delete-library-track.request.ts
+++ b/packages/contracts/src/library-tracks/request/delete-library-track.request.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const DeleteLibraryTrackRequestSchema = z.object({});
+
+export type DeleteLibraryTrackRequest = z.infer<
+  typeof DeleteLibraryTrackRequestSchema
+>;

--- a/packages/contracts/src/library-tracks/request/get-library-tracks.request.ts
+++ b/packages/contracts/src/library-tracks/request/get-library-tracks.request.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const GetLibraryTracksRequestSchema = z.object({
+  albumId: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export type GetLibraryTracksRequest = z.infer<
+  typeof GetLibraryTracksRequestSchema
+>;

--- a/packages/contracts/src/library-tracks/request/update-library-track.request.ts
+++ b/packages/contracts/src/library-tracks/request/update-library-track.request.ts
@@ -1,0 +1,21 @@
+import { Visibility } from "@repo/db";
+import { z } from "zod";
+
+export const UpdateLibraryTrackRequestSchema = z.object({
+  title: z
+    .string()
+    .min(1, "Track title cannot be empty")
+    .max(255, "Track title must be 255 characters or less")
+    .optional(),
+  trackNumber: z.number().int().min(1).optional(),
+  diskNumber: z.number().int().min(1).optional(),
+  duration: z.number().int().min(0).optional(),
+  explicit: z.boolean().optional(),
+  lyrics: z.string().max(10000).optional(),
+  visibility: z.enum(Visibility).optional(),
+  artistIds: z.array(z.string()).min(1).optional(),
+});
+
+export type UpdateLibraryTrackRequest = z.infer<
+  typeof UpdateLibraryTrackRequestSchema
+>;

--- a/packages/contracts/src/library-tracks/response/create-library-track.response.ts
+++ b/packages/contracts/src/library-tracks/response/create-library-track.response.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const CreateLibraryTrackResponseSchema =
+  createApiResponseSchema(TrackSchema);
+
+export type CreateLibraryTrackResponse = z.infer<
+  typeof CreateLibraryTrackResponseSchema
+>;

--- a/packages/contracts/src/library-tracks/response/delete-library-track.response.ts
+++ b/packages/contracts/src/library-tracks/response/delete-library-track.response.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const DeleteLibraryTrackResponseSchema =
+  createApiResponseSchema(TrackSchema);
+
+export type DeleteLibraryTrackResponse = z.infer<
+  typeof DeleteLibraryTrackResponseSchema
+>;

--- a/packages/contracts/src/library-tracks/response/get-library-track.response.ts
+++ b/packages/contracts/src/library-tracks/response/get-library-track.response.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const GetLibraryTrackResponseSchema =
+  createApiResponseSchema(TrackSchema);
+
+export type GetLibraryTrackResponse = z.infer<
+  typeof GetLibraryTrackResponseSchema
+>;

--- a/packages/contracts/src/library-tracks/response/get-library-tracks.response.ts
+++ b/packages/contracts/src/library-tracks/response/get-library-tracks.response.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const GetLibraryTracksResponseSchema = createApiResponseSchema(
+  z.object({
+    items: z.array(TrackSchema),
+    total: z.number(),
+    page: z.number(),
+    limit: z.number(),
+  }),
+);
+
+export type GetLibraryTracksResponse = z.infer<
+  typeof GetLibraryTracksResponseSchema
+>;

--- a/packages/contracts/src/library-tracks/response/update-library-track.response.ts
+++ b/packages/contracts/src/library-tracks/response/update-library-track.response.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { createApiResponseSchema } from "../../api";
+import { TrackSchema } from "../../schemas";
+
+export const UpdateLibraryTrackResponseSchema =
+  createApiResponseSchema(TrackSchema);
+
+export type UpdateLibraryTrackResponse = z.infer<
+  typeof UpdateLibraryTrackResponseSchema
+>;


### PR DESCRIPTION
feat(packages/contracts): introduce track management API contracts

Establish type-safe request and response interfaces for track CRUD operations
within the library module. Defines validation schemas for track properties
including title, positioning metadata, duration, content flags, textual content,
access control, and artist relationships across all endpoints.

feat(apps/api): add library track repository with CRUD operations

Add LibraryTrackRepository to handle database operations for library tracks,
including find, count, create, update, and delete methods. Update TrackRepository
findOne method to support optional relation inclusion. Register new repository
in SharedModule providers and exports.

feat(apps/api): add library track query handlers

Add GetLibraryTrackQuery and GetLibraryTracksQuery CQRS query classes
for retrieving individual and paginated library tracks with support for
filtering by album.

feat(apps/api): add library track DTOs for request and response handling

Add request and response data transfer objects for library track operations including create, read, and update endpoints. These DTOs are generated from Zod schemas defined in the contracts package and provide type-safe validation for API payloads.

style(apps/api): clarify track sorting comment in get library tracks handler

feat(apps/api): add library track command handlers and implementations

Add CQRS command handlers and command implementations for library track
management operations. Includes:

- CreateLibraryTrackHandler: Creates a new track in the user's library
  with album and artist associations, wrapped in a transaction
- UpdateLibraryTrackHandler: Updates track metadata with ownership
  validation
- DeleteLibraryTrackHandler: Soft deletes tracks and removes them from
  user libraries

All handlers include proper authorization checks and error handling.

feat(apps/api): add library tracks controller with CRUD operations

Implement the LibraryTracksController with endpoints for managing user's
private library tracks. Includes operations to retrieve all tracks, create
new tracks, get track details, update track information, and delete tracks.
All endpoints are protected with JWT authentication and track access guards
to ensure users can only manage their own tracks.

feat(apps/api): add library tracks module with CRUD handlers

Add LibraryTracksModule to the features module with command and query
handlers for managing library tracks. This module provides CRUD
operations for tracks including create, read, update, and delete
functionality through the CQRS pattern.

test(apps/api): add integration tests for library tracks controller

Add comprehensive integration test suite for LibraryTracksController
covering all CRUD operations (POST, GET, GET by id, PATCH, DELETE).
Tests include proper authentication, mocking of Prisma client, and
validation of response status codes and data structures.

refactor(apps/api): change delete library track handler to return track instead of success flag

Update the DeleteLibraryTrackHandler to return the deleted track object
(ZodTrack) instead of a simple success boolean. This provides more useful
information to consumers of the API and aligns with REST conventions.

BREAKING CHANGE: DeleteLibraryTrackHandler.execute() now returns ZodTrack instead of { success: boolean }

test(apps/api): add comprehensive tests for library track repository

Add full test suite for LibraryTrackRepository covering all CRUD operations
and filtering logic. Also update TrackRepository tests to verify relation
inclusion behavior.

test(apps/api): add comprehensive test suite for library tracks feature

Add unit tests for library tracks CRUD operations including:
- CreateLibraryTrackHandler: tests for track creation, library/album validation, and schema validation
- DeleteLibraryTrackHandler: tests for soft delete and library track removal
- UpdateLibraryTrackHandler: tests for track updates with artist management
- GetLibraryTrackHandler: tests for single track retrieval and validation
- GetLibraryTracksHandler: tests for paginated track listing with album filtering
- LibraryTracksController: tests for all controller endpoints and command/query bus integration

feat(packages/contracts): add get library album tracks response schema

feat(apps/api): add query handler for retrieving library album tracks

Add GetLibraryAlbumTracksQuery and GetLibraryAlbumTracksHandler to support
fetching tracks from a specific album in a user's library. The handler
retrieves tracks ordered by disk number and track number, with validation
to ensure the user's library exists.

feat(apps/api): add endpoint to retrieve library album tracks

Add new GET endpoint `/library/albums/:id/tracks` to retrieve tracks
for a specific album. Includes new response DTO and integrates with
the GetLibraryAlbumTracksQuery handler. Endpoint is protected by JWT
and album access guards.

test(apps/api): add test for getAlbumTracks controller method and handler

Add comprehensive test coverage for the GetLibraryAlbumTracksHandler including
tests for successful track retrieval and error handling when library is not found.
Also add controller test to verify the getAlbumTracks method executes the correct query.

feat(apps/api): enforce private visibility for library tracks on creation

Remove duration, lyrics, and visibility fields from the create library
track request schema. These are now handled server-side: duration is
calculated from audio file, lyrics are optional, and visibility is
always set to private for tracks created through this route.

BREAKING CHANGE: duration, lyrics, and visibility fields removed from
CreateLibraryTrackRequest schema

style(apps/api): organize imports and fix formatting

- Reorder imports alphabetically in library-tracks integration spec
- Update test assertion to compare full response object
- Fix spacing in delete-library-track handler constructor
- Reorder imports in delete-library-track handler