### PR TITLE
feat(web): add player history, lyrics view, and drag-and-drop queue reordering

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,9 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@repo/contracts": "workspace:*",
     "@repo/db": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "framer-motion": "^12.34.2",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "catalog:",

--- a/apps/web/src/components/app/History.tsx
+++ b/apps/web/src/components/app/History.tsx
@@ -1,0 +1,110 @@
+import { Button } from '@/components/ui/button';
+import { usePlayerStore, type QueueItem } from '@/stores/player.store';
+import { cn } from '@/lib/utils';
+import { ArrowLeftIcon, MusicNotesIcon, PlayIcon, XIcon } from '@phosphor-icons/react';
+import React from 'react';
+
+interface HistoryProps {
+  isVisible: boolean;
+  onBack: () => void;
+}
+
+export function History({ isVisible, onBack }: HistoryProps) {
+  const { history, playTrack, toggleQueue } = usePlayerStore();
+  const [historyLimit, setHistoryLimit] = React.useState(20);
+
+  const handlePlayTrack = (track: QueueItem) => {
+    playTrack(track);
+  };
+
+  const handleLoadHistory = () => {
+    setHistoryLimit((prev) => Math.min(prev + 20, history.length));
+  };
+
+  return (
+    <div
+      className={cn(
+        'absolute inset-0 flex flex-col transition-all duration-300 ease-out',
+        isVisible
+          ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+          : 'opacity-0 scale-102 blur-xs pointer-events-none',
+      )}
+    >
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-white/50 hover:text-white -ml-2"
+            onClick={onBack}
+            title="Back to Queue"
+          >
+            <ArrowLeftIcon size={20} />
+          </Button>
+          <h2 className="text-lg font-semibold text-white">History</h2>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-white/50 hover:text-white md:hidden"
+            onClick={toggleQueue}
+          >
+            <XIcon size={20} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {history.length === 0 ? (
+          <div className="text-sm text-white/30 italic text-center py-8">No listening history</div>
+        ) : (
+          <div className="space-y-0.5">
+            {history.slice(0, historyLimit).map((track, i) => (
+              <div
+                key={`${track.uniqueId}-${i}`}
+                className="group flex items-center gap-3 p-2 rounded-md hover:bg-white/5 transition-colors cursor-pointer"
+                onClick={() => handlePlayTrack(track)}
+              >
+                <div className="relative h-10 w-10 shrink-0 rounded overflow-hidden bg-stone-800">
+                  {track.album?.cover?.url ? (
+                    <img
+                      src={track.album.cover.url}
+                      alt={track.title}
+                      className="h-full w-full object-cover group-hover:opacity-40 transition-opacity"
+                    />
+                  ) : (
+                    <div className="h-full w-full flex items-center justify-center group-hover:opacity-40 transition-opacity">
+                      <MusicNotesIcon className="text-white/20" size={16} />
+                    </div>
+                  )}
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                    <PlayIcon weight="fill" className="text-white" size={16} />
+                  </div>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-white/90 truncate group-hover:text-white">
+                    {track.title}
+                  </div>
+                  <div className="text-xs text-white/50 truncate">
+                    {track.artists?.map((a: { name: string }) => a.name).join(', ')}
+                  </div>
+                </div>
+                <div className="text-xs text-white/30 tabular-nums">
+                  {/* Could show played time here if we tracked it, but keeping simple for now */}
+                </div>
+              </div>
+            ))}
+            {historyLimit < history.length && (
+              <div className="flex justify-center py-4">
+                <Button variant="ghost" size="sm" onClick={handleLoadHistory} className="text-xs">
+                  Load more
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/Lyrics.tsx
+++ b/apps/web/src/components/app/Lyrics.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+import { XIcon } from '@phosphor-icons/react';
+import { usePlayerStore } from '@/stores/player.store';
+
+export function Lyrics() {
+  const { toggleQueue, currentTrack } = usePlayerStore();
+
+  return (
+    <div className="flex flex-col h-full bg-stone-900 border-l border-white/5 w-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
+        <h2 className="text-lg font-semibold text-white">Lyrics</h2>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white/50 hover:text-white md:hidden"
+          onClick={toggleQueue}
+        >
+          <XIcon size={20} />
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 flex items-center justify-center">
+        {currentTrack ? (
+          <div className="text-center space-y-4">
+            <h3 className="text-xl font-bold text-white">{currentTrack.title}</h3>
+            <p className="text-white/50">Lyrics not available yet.</p>
+          </div>
+        ) : (
+          <div className="text-white/30 italic">No track playing</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/Player.tsx
+++ b/apps/web/src/components/app/Player.tsx
@@ -1,349 +1,57 @@
 import { useIsMobile } from '@/hooks/use-mobile';
-import { cn } from '@/lib/utils';
-import { useAuthStore } from '@/stores/auth.store';
-import { usePlayerStore } from '@/stores/player.store';
-import {
-  DotsThreeIcon,
-  MusicNotesIcon,
-  PauseIcon,
-  PlayIcon,
-  QueueIcon,
-  QuotesIcon,
-  RepeatIcon,
-  ShuffleIcon,
-  SkipBackIcon,
-  SkipForwardIcon,
-  SpeakerHighIcon,
-  StarIcon,
-} from '@phosphor-icons/react';
-import { useEffect, useRef, useState } from 'react';
-import { Button } from '../ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import { Slider } from '../ui/slider';
+import { PlayerActions } from './player/PlayerActions';
+import { PlayerControls } from './player/PlayerControls';
+import { PlayerMobile } from './player/PlayerMobile';
+import { PlayerTrackInfo } from './player/PlayerTrackInfo';
+import { usePlayerAudio } from './player/use-player-audio';
 
 export function AppPlayer() {
   const isMobile = useIsMobile();
-  const audioRef = useRef<HTMLAudioElement>(null);
-  const [isHoveringSlider, setIsHoveringSlider] = useState(false);
-  const [isDraggingSlider, setIsDraggingSlider] = useState(false);
-
   const {
-    currentTrack,
-    isPlaying,
-    volume,
-    currentTime,
-    duration,
-    quality,
-    togglePlay,
-    setCurrentTime,
-    setDuration,
+    audioRef,
+    handleTimeUpdate,
+    handleLoadedMetadata,
+    getAudioUrl,
+    formatTime,
+    formatTimeLeft,
     nextTrack,
-    previousTrack,
-    setVolume,
-    isQueueOpen,
-    toggleQueue,
-  } = usePlayerStore();
+  } = usePlayerAudio();
 
-  const { accessToken } = useAuthStore();
-  const apiBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-
-  // Sync isPlaying with audio element
-  useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio || !audio.src) return;
-
-    const playPromise = async () => {
-      try {
-        if (isPlaying) {
-          if (audio.readyState === 0) {
-            audio.load();
-          }
-          await audio.play();
-        } else {
-          audio.pause();
-        }
-      } catch (err: unknown) {
-        if (err instanceof Error && err.name !== 'AbortError') {
-          console.error('[AppPlayer] Playback Error:', {
-            name: err.name,
-            message: err.message,
-            readyState: audio.readyState,
-          });
-        }
-      }
-    };
-
-    playPromise();
-  }, [isPlaying, currentTrack]);
-
-  // Sync volume
-  useEffect(() => {
+  const handleSeek = (time: number) => {
     if (audioRef.current) {
-      audioRef.current.volume = volume;
-    }
-  }, [volume]);
-
-  // Sync currentTime from store (for seeking)
-  useEffect(() => {
-    if (audioRef.current && Math.abs(audioRef.current.currentTime - currentTime) > 1) {
-      audioRef.current.currentTime = currentTime;
-    }
-  }, [currentTime]);
-
-  const handleTimeUpdate = () => {
-    if (audioRef.current) {
-      setCurrentTime(audioRef.current.currentTime);
+      audioRef.current.currentTime = time;
     }
   };
-
-  const handleLoadedMetadata = () => {
-    if (audioRef.current) {
-      setDuration(audioRef.current.duration);
-    }
-  };
-
-  const getAudioUrl = () => {
-    if (!currentTrack) return '';
-    return `${apiBaseUrl}/library/tracks/${currentTrack.id}/stream?quality=${quality}&token=${accessToken}`;
-  };
-
-  const formatTime = (time: number) => {
-    const mins = Math.floor(time / 60);
-    const secs = Math.floor(time % 60);
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
-  };
-
-  const formatTimeLeft = (time: number, total: number) => {
-    const timeLeft = total - time;
-    return `-${formatTime(timeLeft)}`;
-  };
-
-  const trackTitle = currentTrack?.title || 'No track selected';
-  const trackArtist = currentTrack?.artists?.map((a) => a.name).join(', ') || 'Unknown Artist';
-  const coverUrl = currentTrack?.album?.cover?.url;
-
-  if (isMobile) {
-    return (
-      <div className="w-full h-full flex items-center justify-between px-2">
-        <audio
-          ref={audioRef}
-          src={getAudioUrl()}
-          crossOrigin="anonymous"
-          onTimeUpdate={handleTimeUpdate}
-          onLoadedMetadata={handleLoadedMetadata}
-          onEnded={nextTrack}
-        />
-        <div className="flex items-center gap-3 overflow-hidden">
-          <div className="h-10 w-10 shrink-0 bg-stone-900 rounded-md flex items-center justify-center overflow-hidden border border-white/10 shadow-lg">
-            {coverUrl ? (
-              <img src={coverUrl} alt="" className="size-full object-cover" />
-            ) : (
-              <MusicNotesIcon size={20} className="text-stone-500" />
-            )}
-          </div>
-          <div className="flex flex-col min-w-0">
-            <div className="text-white font-semibold truncate text-sm">{trackTitle}</div>
-            <div className="text-white/50 text-xs truncate font-medium">{trackArtist}</div>
-          </div>
-        </div>
-        <Button
-          size="icon-lg"
-          variant="ghost"
-          className="active:scale-95 shrink-0"
-          onClick={togglePlay}
-        >
-          {isPlaying ? <PauseIcon weight="fill" /> : <PlayIcon weight="fill" />}
-        </Button>
-      </div>
-    );
-  }
 
   return (
-    <div className="w-full h-full flex items-center justify-center px-6 gap-2 bg-transparent">
+    <div className="w-full h-full flex items-center justify-center bg-transparent">
       <audio
         ref={audioRef}
         src={getAudioUrl()}
+        crossOrigin="anonymous"
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={handleLoadedMetadata}
         onEnded={nextTrack}
       />
 
-      {/* Island 1: Controls (Left) */}
-      <div
-        className="flex items-center gap-1.5 px-3 py-1.5 bg-stone-900 border border-white/8 shadow-lg h-14"
-        style={{ borderRadius: '2rem 0.75rem 0.75rem 2rem' }}
-      >
-        <Button
-          size="icon"
-          className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
-        >
-          <ShuffleIcon size={16} />
-        </Button>
-        <Button
-          size="icon"
-          className="text-white/60 hover:text-white bg-transparent hover:bg-white/5 active:bg-white/10 rounded-full h-9 w-9 active:scale-95 transition-all"
-          onClick={previousTrack}
-        >
-          <SkipBackIcon size={22} weight="fill" />
-        </Button>
-        <Button
-          size="icon"
-          className="bg-white/15 text-white hover:bg-white/20 active:bg-white/25 rounded-full h-11 w-11 flex items-center justify-center active:scale-95 transition-all"
-          onClick={togglePlay}
-        >
-          {isPlaying ? (
-            <PauseIcon size={24} weight="fill" />
-          ) : (
-            <PlayIcon size={24} weight="fill" className="ml-0.5" />
-          )}
-        </Button>
-        <Button
-          size="icon"
-          className="text-white/60 hover:text-white bg-transparent hover:bg-white/5 active:bg-white/10 rounded-full h-9 w-9 active:scale-95 transition-all"
-          onClick={nextTrack}
-        >
-          <SkipForwardIcon size={22} weight="fill" />
-        </Button>
-        <Button
-          size="icon"
-          className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
-        >
-          <RepeatIcon size={16} />
-        </Button>
-      </div>
+      {isMobile ? (
+        <PlayerMobile />
+      ) : (
+        <div className="flex w-full h-full items-center justify-center px-6 gap-2">
+          {/* Island 1: Controls (Left) */}
+          <PlayerControls />
 
-      {/* Island 2: Track Info & Progress (Center) - The Main "Island" */}
-      <div
-        className={cn(
-          'flex-1 max-w-[600px] border border-white/8 bg-stone-900 flex items-stretch relative overflow-hidden shadow-xl h-14',
-        )}
-        style={{ borderRadius: '0.75rem' }}
-      >
-        {/* Floating Rounded Square Artwork */}
-        <div className="p-1.5 shrink-0">
-          <div className="h-full aspect-square bg-stone-800 rounded-lg flex items-center justify-center overflow-hidden shadow-inner">
-            {coverUrl ? (
-              <img src={coverUrl} alt="" className="size-full object-cover" />
-            ) : (
-              <MusicNotesIcon size={20} className="text-stone-600" />
-            )}
-          </div>
-        </div>
-
-        {/* Right Content Area: Stacked Rows */}
-        <div className="flex-1 flex flex-col justify-center min-w-0 pr-3 pl-0 py-1.5 relative">
-          {/* Top Row: Title & Artist / Time Reveal */}
-          <div className="flex flex-col min-w-0 flex-1 justify-center">
-            <div className="text-white font-semibold truncate text-[14px] leading-tight">
-              {trackTitle}
-            </div>
-            <div
-              className={cn(
-                'text-white/50 text-[12px] truncate font-medium transition-all duration-300',
-                isHoveringSlider || isDraggingSlider
-                  ? 'opacity-0 translate-y-1'
-                  : 'opacity-100 translate-y-0',
-              )}
-            >
-              {trackArtist}
-            </div>
-
-            {/* Hover-reveal times */}
-            <div
-              className={cn(
-                'absolute left-0 right-3 top-[26px] flex items-center justify-between text-[11px] text-white/40 tabular-nums transition-all duration-300 pointer-events-none',
-                isHoveringSlider || isDraggingSlider
-                  ? 'opacity-100 translate-y-0'
-                  : 'opacity-0 -translate-y-1',
-              )}
-            >
-              <span>{formatTime(currentTime)}</span>
-              <span>{formatTimeLeft(currentTime, duration)}</span>
-            </div>
-          </div>
-
-          {/* Bottom Row: Progress Slider */}
-          <Slider
-            value={currentTime}
-            max={duration || 100}
-            showThumb={false}
-            onMouseEnter={() => setIsHoveringSlider(true)}
-            onMouseLeave={() => setIsHoveringSlider(false)}
-            onPointerDown={() => setIsDraggingSlider(true)}
-            onPointerUp={() => setIsDraggingSlider(false)}
-            onChange={(newTime) => {
-              if (audioRef.current) audioRef.current.currentTime = newTime;
-              setCurrentTime(newTime);
-            }}
-            className="mt-auto w-full"
+          {/* Island 2: Track Info & Progress (Center) */}
+          <PlayerTrackInfo
+            formatTime={formatTime}
+            formatTimeLeft={formatTimeLeft}
+            onSeek={handleSeek}
           />
+
+          {/* Island 3: Actions (Right) */}
+          <PlayerActions />
         </div>
-      </div>
-
-      {/* Island 3: Actions (Right) */}
-      <div
-        className="flex h-14 items-center gap-0.5 px-2 py-2.5 bg-stone-900 border border-white/8 shadow-lg min-w-auto"
-        style={{ borderRadius: '0.75rem 2rem 2rem 0.75rem' }}
-      >
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-white/40 hover:text-white active:scale-95 h-9 w-9"
-        >
-          <DotsThreeIcon size={20} weight="bold" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-white/40 hover:text-white active:scale-95 h-9 w-9"
-        >
-          <StarIcon size={20} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-white/40 hover:text-white active:scale-95 h-9 w-9"
-        >
-          <QuotesIcon size={20} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className={cn(
-            'text-white/40 hover:text-white active:scale-95 h-9 w-9',
-            isQueueOpen && 'text-white bg-white/10',
-          )}
-          onClick={toggleQueue}
-        >
-          <QueueIcon size={20} />
-        </Button>
-
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              size="icon"
-              variant="ghost"
-              className="text-white/40 hover:text-white active:scale-95 h-9 w-9 ml-1"
-            >
-              <SpeakerHighIcon size={20} />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            side="top"
-            align="end"
-            className="w-40 bg-stone-900/95 backdrop-blur-xl border-white/10 p-3 mb-2 shadow-[0_10px_40px_rgba(0,0,0,0.5)]"
-            sideOffset={16}
-          >
-            <Slider
-              value={volume * 100}
-              min={0}
-              max={100}
-              onChange={(val) => setVolume(val / 100)}
-              className="h-4"
-            />
-          </PopoverContent>
-        </Popover>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/app/Player.tsx
+++ b/apps/web/src/components/app/Player.tsx
@@ -11,10 +11,10 @@ export function AppPlayer() {
     audioRef,
     handleTimeUpdate,
     handleLoadedMetadata,
+    handleTrackEnd,
     getAudioUrl,
     formatTime,
     formatTimeLeft,
-    nextTrack,
   } = usePlayerAudio();
 
   const handleSeek = (time: number) => {
@@ -31,7 +31,7 @@ export function AppPlayer() {
         crossOrigin="anonymous"
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={handleLoadedMetadata}
-        onEnded={nextTrack}
+        onEnded={handleTrackEnd}
       />
 
       {isMobile ? (

--- a/apps/web/src/components/app/Queue.tsx
+++ b/apps/web/src/components/app/Queue.tsx
@@ -1,103 +1,12 @@
-import { Button } from '@/components/ui/button';
 import React from 'react';
-import { usePlayerStore, type QueueItem } from '@/stores/player.store';
+import { usePlayerStore, type QueueItem as PlayrQueueItem } from '@/stores/player.store';
 import { cn } from '@/lib/utils';
-import {
-  ClockCounterClockwiseIcon,
-  DotsSixVerticalIcon,
-  MusicNotesIcon,
-  PlayIcon,
-  TrashIcon,
-  XIcon,
-} from '@phosphor-icons/react';
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  DragEndEvent,
-} from '@dnd-kit/core';
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-  useSortable,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
 import { History as QueueHistory } from './History';
-
-interface SortableTrackItemProps {
-  track: QueueItem;
-  onPlay: (track: QueueItem) => void;
-  onRemove: (uniqueId: string, event: React.MouseEvent) => void;
-}
-
-function SortableTrackItem({ track, onPlay, onRemove }: SortableTrackItemProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: track.uniqueId,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    zIndex: isDragging ? 1 : 0,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className="group flex items-center gap-2 p-2 rounded-md hover:bg-white/5 transition-colors cursor-pointer"
-      onClick={() => onPlay(track)}
-    >
-      <div
-        {...attributes}
-        {...listeners}
-        className="text-white/20 hover:text-white/50 cursor-grab active:cursor-grabbing p-1 -ml-1"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <DotsSixVerticalIcon size={20} />
-      </div>
-
-      <div className="relative h-10 w-10 shrink-0 rounded overflow-hidden bg-stone-800">
-        {track.album?.cover?.url ? (
-          <img
-            src={track.album.cover.url}
-            alt={track.title}
-            className="h-full w-full object-cover group-hover:opacity-40 transition-opacity"
-          />
-        ) : (
-          <div className="h-full w-full flex items-center justify-center group-hover:opacity-40 transition-opacity">
-            <MusicNotesIcon className="text-white/20" size={16} />
-          </div>
-        )}
-        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-          <PlayIcon weight="fill" className="text-white" size={16} />
-        </div>
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-white/90 truncate group-hover:text-white">
-          {track.title}
-        </div>
-        <div className="text-xs text-white/50 truncate">
-          {track.artists?.map((a: { name: string }) => a.name).join(', ')}
-        </div>
-      </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-8 w-8 text-white/20 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all"
-        onClick={(e) => onRemove(track.uniqueId, e)}
-      >
-        <TrashIcon />
-      </Button>
-    </div>
-  );
-}
+import { DragEndEvent } from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+import { QueueHeader } from './queue/QueueHeader';
+import { QueueNowPlaying } from './queue/QueueNowPlaying';
+import { QueueNextUp } from './queue/QueueNextUp';
 
 export function Queue() {
   const {
@@ -108,6 +17,7 @@ export function Queue() {
     toggleQueue,
     reorderQueue,
     isQueueOpen,
+    isShuffled,
   } = usePlayerStore();
   const [view, setView] = React.useState<'main' | 'history'>('main');
 
@@ -117,19 +27,12 @@ export function Queue() {
     }
   }, [isQueueOpen]);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
-
   const handleRemoveTrack = (uniqueId: string, event: React.MouseEvent) => {
     event.stopPropagation();
     removeFromQueue(uniqueId);
   };
 
-  const handlePlayTrack = (track: QueueItem) => {
+  const handlePlayTrack = (track: PlayrQueueItem) => {
     playTrack(track);
   };
 
@@ -164,100 +67,17 @@ export function Queue() {
             : 'opacity-0 scale-98 blur-xs pointer-events-none',
         )}
       >
-        <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-white">Queue</h2>
-          </div>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-white/50 hover:text-white"
-              onClick={() => setView('history')}
-              title="Show History"
-            >
-              <ClockCounterClockwiseIcon size={20} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-white/50 hover:text-white md:hidden"
-              onClick={toggleQueue}
-            >
-              <XIcon size={20} />
-            </Button>
-          </div>
-        </div>
+        <QueueHeader onShowHistory={() => setView('history')} onToggleQueue={toggleQueue} />
 
         <div className="flex-1 overflow-y-auto p-4 space-y-6">
-          {/* Now Playing */}
-          {currentTrack && (
-            <div className="space-y-3">
-              <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">
-                Now Playing
-              </h3>
-              <div className="group flex items-center gap-3 p-2 rounded-md bg-white/5 border border-white/5 transition-colors hover:bg-white/10">
-                <div className="relative h-12 w-12 shrink-0 rounded overflow-hidden bg-stone-800">
-                  {currentTrack.album?.cover?.url ? (
-                    <img
-                      src={currentTrack.album.cover.url}
-                      alt={currentTrack.title}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <div className="h-full w-full flex items-center justify-center">
-                      <MusicNotesIcon className="text-white/20" size={20} />
-                    </div>
-                  )}
-                  <div className="absolute inset-0 flex items-center justify-center bg-black/40">
-                    <div className="flex items-end gap-0.5 h-3">
-                      <div className="w-1 h-3 bg-green-500 animate-music-bar-1" />
-                      <div className="w-1 h-2 bg-green-500 animate-music-bar-2" />
-                      <div className="w-1 h-3 bg-green-500 animate-music-bar-3" />
-                    </div>
-                  </div>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-green-500 truncate">
-                    {currentTrack.title}
-                  </div>
-                  <div className="text-xs text-white/50 truncate">
-                    {currentTrack.artists?.map((a: { name: string }) => a.name).join(', ')}
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Next Up */}
-          <div className="space-y-3">
-            <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">Next Up</h3>
-            {nextUp.length === 0 ? (
-              <div className="text-sm text-white/30 italic text-center py-8">Queue is empty</div>
-            ) : (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={nextUp.map((t) => t.uniqueId)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <div className="space-y-0.5">
-                    {nextUp.map((track) => (
-                      <SortableTrackItem
-                        key={track.uniqueId}
-                        track={track}
-                        onPlay={handlePlayTrack}
-                        onRemove={handleRemoveTrack}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-              </DndContext>
-            )}
-          </div>
+          <QueueNowPlaying currentTrack={currentTrack} />
+          <QueueNextUp
+            nextUp={nextUp}
+            isShuffled={isShuffled}
+            onDragEnd={handleDragEnd}
+            onPlayTrack={handlePlayTrack}
+            onRemoveTrack={handleRemoveTrack}
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/app/Queue.tsx
+++ b/apps/web/src/components/app/Queue.tsx
@@ -1,16 +1,117 @@
 import { Button } from '@/components/ui/button';
-import { usePlayerStore } from '@/stores/player.store';
-import { MusicNotesIcon, PlayIcon, TrashIcon, XIcon } from '@phosphor-icons/react';
+import { usePlayerStore, type QueueItem } from '@/stores/player.store';
+import {
+  DotsSixVerticalIcon,
+  MusicNotesIcon,
+  PlayIcon,
+  TrashIcon,
+  XIcon,
+} from '@phosphor-icons/react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+interface SortableTrackItemProps {
+  track: QueueItem;
+  onPlay: (track: QueueItem) => void;
+  onRemove: (uniqueId: string, event: React.MouseEvent) => void;
+}
+
+function SortableTrackItem({ track, onPlay, onRemove }: SortableTrackItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: track.uniqueId,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1 : 0,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="group flex items-center gap-2 p-2 rounded-md hover:bg-white/5 transition-colors cursor-pointer"
+      onClick={() => onPlay(track)}
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        className="text-white/20 hover:text-white/50 cursor-grab active:cursor-grabbing p-1 -ml-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DotsSixVerticalIcon size={20} />
+      </div>
+
+      <div className="relative h-10 w-10 shrink-0 rounded overflow-hidden bg-stone-800">
+        {track.album?.cover?.url ? (
+          <img
+            src={track.album.cover.url}
+            alt={track.title}
+            className="h-full w-full object-cover group-hover:opacity-40 transition-opacity"
+          />
+        ) : (
+          <div className="h-full w-full flex items-center justify-center group-hover:opacity-40 transition-opacity">
+            <MusicNotesIcon className="text-white/20" size={16} />
+          </div>
+        )}
+        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+          <PlayIcon weight="fill" className="text-white" size={16} />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-white/90 truncate group-hover:text-white">
+          {track.title}
+        </div>
+        <div className="text-xs text-white/50 truncate">
+          {track.artists?.map((a: { name: string }) => a.name).join(', ')}
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-white/20 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all"
+        onClick={(e) => onRemove(track.uniqueId, e)}
+      >
+        <TrashIcon />
+      </Button>
+    </div>
+  );
+}
 
 export function Queue() {
-  const { queue, currentTrack, playTrack, removeFromQueue, toggleQueue } = usePlayerStore();
+  const { queue, currentTrack, playTrack, removeFromQueue, toggleQueue, reorderQueue } =
+    usePlayerStore();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   const handleRemoveTrack = (uniqueId: string, event: React.MouseEvent) => {
     event.stopPropagation();
     removeFromQueue(uniqueId);
   };
 
-  const handlePlayTrack = (track: import('@repo/contracts').ZodTrack) => {
+  const handlePlayTrack = (track: QueueItem) => {
     playTrack(track);
   };
 
@@ -19,6 +120,20 @@ export function Queue() {
     : -1;
 
   const nextUp = queue.slice(currentIndex + 1);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = queue.findIndex((t) => t.uniqueId === active.id);
+      const newIndex = queue.findIndex((t) => t.uniqueId === over.id);
+
+      if (oldIndex !== -1 && newIndex !== -1) {
+        const newQueue = arrayMove(queue, oldIndex, newIndex);
+        reorderQueue(newQueue);
+      }
+    }
+  };
 
   return (
     <div className="flex flex-col h-full bg-stone-900 border-l border-white/5 w-full">
@@ -81,48 +196,27 @@ export function Queue() {
           {nextUp.length === 0 ? (
             <div className="text-sm text-white/30 italic text-center py-8">Queue is empty</div>
           ) : (
-            <div className="space-y-0.5">
-              {nextUp.map((track) => (
-                <div
-                  key={track.uniqueId}
-                  className="group flex items-center gap-3 p-2 rounded-md hover:bg-white/5 transition-colors cursor-pointer"
-                  onClick={() => handlePlayTrack(track)}
-                >
-                  <div className="relative h-10 w-10 shrink-0 rounded overflow-hidden bg-stone-800">
-                    {track.album?.cover?.url ? (
-                      <img
-                        src={track.album.cover.url}
-                        alt={track.title}
-                        className="h-full w-full object-cover group-hover:opacity-40 transition-opacity"
-                      />
-                    ) : (
-                      <div className="h-full w-full flex items-center justify-center group-hover:opacity-40 transition-opacity">
-                        <MusicNotesIcon className="text-white/20" size={16} />
-                      </div>
-                    )}
-                    <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                      <PlayIcon weight="fill" className="text-white" size={16} />
-                    </div>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-white/90 truncate group-hover:text-white">
-                      {track.title}
-                    </div>
-                    <div className="text-xs text-white/50 truncate">
-                      {track.artists?.map((a: { name: string }) => a.name).join(', ')}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-white/20 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all"
-                    onClick={(e) => handleRemoveTrack(track.uniqueId, e)}
-                  >
-                    <TrashIcon />
-                  </Button>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={nextUp.map((t) => t.uniqueId)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-0.5">
+                  {nextUp.map((track) => (
+                    <SortableTrackItem
+                      key={track.uniqueId}
+                      track={track}
+                      onPlay={handlePlayTrack}
+                      onRemove={handleRemoveTrack}
+                    />
+                  ))}
                 </div>
-              ))}
-            </div>
+              </SortableContext>
+            </DndContext>
           )}
         </div>
       </div>

--- a/apps/web/src/components/app/Queue.tsx
+++ b/apps/web/src/components/app/Queue.tsx
@@ -1,6 +1,9 @@
 import { Button } from '@/components/ui/button';
+import React from 'react';
 import { usePlayerStore, type QueueItem } from '@/stores/player.store';
+import { cn } from '@/lib/utils';
 import {
+  ClockCounterClockwiseIcon,
   DotsSixVerticalIcon,
   MusicNotesIcon,
   PlayIcon,
@@ -24,6 +27,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { History as QueueHistory } from './History';
 
 interface SortableTrackItemProps {
   track: QueueItem;
@@ -96,8 +100,22 @@ function SortableTrackItem({ track, onPlay, onRemove }: SortableTrackItemProps) 
 }
 
 export function Queue() {
-  const { queue, currentTrack, playTrack, removeFromQueue, toggleQueue, reorderQueue } =
-    usePlayerStore();
+  const {
+    queue,
+    currentTrack,
+    playTrack,
+    removeFromQueue,
+    toggleQueue,
+    reorderQueue,
+    isQueueOpen,
+  } = usePlayerStore();
+  const [view, setView] = React.useState<'main' | 'history'>('main');
+
+  React.useEffect(() => {
+    if (!isQueueOpen) {
+      setView('main');
+    }
+  }, [isQueueOpen]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -136,90 +154,114 @@ export function Queue() {
   };
 
   return (
-    <div className="flex flex-col h-full bg-stone-900 border-l border-white/5 w-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
-        <h2 className="text-lg font-semibold text-white">Queue</h2>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-white/50 hover:text-white md:hidden"
-          onClick={toggleQueue}
-        >
-          <XIcon size={20} />
-        </Button>
-      </div>
+    <div className="flex flex-col h-full bg-stone-900 border-l border-white/5 w-full relative overflow-hidden">
+      {/* Main Queue View */}
+      <div
+        className={cn(
+          'absolute inset-0 flex flex-col transition-all duration-300 ease-out',
+          view === 'main'
+            ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+            : 'opacity-0 scale-98 blur-xs pointer-events-none',
+        )}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-white">Queue</h2>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-white/50 hover:text-white"
+              onClick={() => setView('history')}
+              title="Show History"
+            >
+              <ClockCounterClockwiseIcon size={20} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-white/50 hover:text-white md:hidden"
+              onClick={toggleQueue}
+            >
+              <XIcon size={20} />
+            </Button>
+          </div>
+        </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-6">
-        {/* Now Playing */}
-        {currentTrack && (
-          <div className="space-y-3">
-            <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">
-              Now Playing
-            </h3>
-            <div className="group flex items-center gap-3 p-2 rounded-md bg-white/5 border border-white/5 transition-colors hover:bg-white/10">
-              <div className="relative h-12 w-12 shrink-0 rounded overflow-hidden bg-stone-800">
-                {currentTrack.album?.cover?.url ? (
-                  <img
-                    src={currentTrack.album.cover.url}
-                    alt={currentTrack.title}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="h-full w-full flex items-center justify-center">
-                    <MusicNotesIcon className="text-white/20" size={20} />
-                  </div>
-                )}
-                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
-                  <div className="flex items-end gap-0.5 h-3">
-                    <div className="w-1 h-3 bg-green-500 animate-music-bar-1" />
-                    <div className="w-1 h-2 bg-green-500 animate-music-bar-2" />
-                    <div className="w-1 h-3 bg-green-500 animate-music-bar-3" />
+        <div className="flex-1 overflow-y-auto p-4 space-y-6">
+          {/* Now Playing */}
+          {currentTrack && (
+            <div className="space-y-3">
+              <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">
+                Now Playing
+              </h3>
+              <div className="group flex items-center gap-3 p-2 rounded-md bg-white/5 border border-white/5 transition-colors hover:bg-white/10">
+                <div className="relative h-12 w-12 shrink-0 rounded overflow-hidden bg-stone-800">
+                  {currentTrack.album?.cover?.url ? (
+                    <img
+                      src={currentTrack.album.cover.url}
+                      alt={currentTrack.title}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="h-full w-full flex items-center justify-center">
+                      <MusicNotesIcon className="text-white/20" size={20} />
+                    </div>
+                  )}
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                    <div className="flex items-end gap-0.5 h-3">
+                      <div className="w-1 h-3 bg-green-500 animate-music-bar-1" />
+                      <div className="w-1 h-2 bg-green-500 animate-music-bar-2" />
+                      <div className="w-1 h-3 bg-green-500 animate-music-bar-3" />
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium text-green-500 truncate">
-                  {currentTrack.title}
-                </div>
-                <div className="text-xs text-white/50 truncate">
-                  {currentTrack.artists?.map((a: { name: string }) => a.name).join(', ')}
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-green-500 truncate">
+                    {currentTrack.title}
+                  </div>
+                  <div className="text-xs text-white/50 truncate">
+                    {currentTrack.artists?.map((a: { name: string }) => a.name).join(', ')}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
-
-        {/* Next Up */}
-        <div className="space-y-3">
-          <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">Next Up</h3>
-
-          {nextUp.length === 0 ? (
-            <div className="text-sm text-white/30 italic text-center py-8">Queue is empty</div>
-          ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={nextUp.map((t) => t.uniqueId)}
-                strategy={verticalListSortingStrategy}
-              >
-                <div className="space-y-0.5">
-                  {nextUp.map((track) => (
-                    <SortableTrackItem
-                      key={track.uniqueId}
-                      track={track}
-                      onPlay={handlePlayTrack}
-                      onRemove={handleRemoveTrack}
-                    />
-                  ))}
-                </div>
-              </SortableContext>
-            </DndContext>
           )}
+
+          {/* Next Up */}
+          <div className="space-y-3">
+            <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">Next Up</h3>
+            {nextUp.length === 0 ? (
+              <div className="text-sm text-white/30 italic text-center py-8">Queue is empty</div>
+            ) : (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={nextUp.map((t) => t.uniqueId)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-0.5">
+                    {nextUp.map((track) => (
+                      <SortableTrackItem
+                        key={track.uniqueId}
+                        track={track}
+                        onPlay={handlePlayTrack}
+                        onRemove={handleRemoveTrack}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
         </div>
       </div>
+
+      <QueueHistory isVisible={view === 'history'} onBack={() => setView('main')} />
     </div>
   );
 }

--- a/apps/web/src/components/app/player/PlayerActions.tsx
+++ b/apps/web/src/components/app/player/PlayerActions.tsx
@@ -1,0 +1,101 @@
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
+import { usePlayerStore } from '@/stores/player.store';
+import {
+  DotsThreeIcon,
+  QueueIcon,
+  QuotesIcon,
+  SpeakerHighIcon,
+  StarIcon,
+} from '@phosphor-icons/react';
+
+export function PlayerActions() {
+  const { volume, setVolume, isQueueOpen, setQueueOpen, sidebarView, setSidebarView } =
+    usePlayerStore();
+
+  return (
+    <div
+      className="flex h-14 items-center gap-0.5 px-2 py-2.5 bg-stone-900 border border-white/8 shadow-lg min-w-auto"
+      style={{ borderRadius: '0.5rem 2rem 2rem 0.5rem' }}
+    >
+      <Button
+        size="icon"
+        variant="ghost"
+        className="text-white/40 hover:text-white active:scale-95 h-9 w-9"
+      >
+        <DotsThreeIcon size={20} weight="bold" />
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="text-white/40 hover:text-white active:scale-95 h-9 w-9"
+      >
+        <StarIcon size={20} />
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className={cn(
+          'text-white/40 hover:text-white active:scale-95 h-9 w-9',
+          isQueueOpen && sidebarView === 'lyrics' && 'text-white bg-white/10',
+        )}
+        onClick={() => {
+          if (isQueueOpen && sidebarView === 'lyrics') {
+            setQueueOpen(false);
+          } else {
+            setSidebarView('lyrics');
+            setQueueOpen(true);
+          }
+        }}
+      >
+        <QuotesIcon size={20} />
+      </Button>
+      <Button
+        size="icon"
+        variant="ghost"
+        className={cn(
+          'text-white/40 hover:text-white active:scale-95 h-9 w-9',
+          isQueueOpen && sidebarView === 'queue' && 'text-white bg-white/10',
+        )}
+        onClick={() => {
+          if (isQueueOpen && sidebarView === 'queue') {
+            setQueueOpen(false);
+          } else {
+            setSidebarView('queue');
+            setQueueOpen(true);
+          }
+        }}
+      >
+        <QueueIcon size={20} />
+      </Button>
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-white/40 hover:text-white active:scale-95 h-9 w-9 ml-1"
+          >
+            <SpeakerHighIcon size={20} />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="end"
+          className="w-40 bg-stone-900/95 backdrop-blur-xl border-white/10 p-3 mb-2 shadow-[0_10px_40px_rgba(0,0,0,0.5)]"
+          sideOffset={16}
+        >
+          <Slider
+            value={volume * 100}
+            min={0}
+            max={100}
+            onChange={(val) => setVolume(val / 100)}
+            className="h-4"
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/player/PlayerControls.tsx
+++ b/apps/web/src/components/app/player/PlayerControls.tsx
@@ -1,0 +1,59 @@
+import { Button } from '@/components/ui/button';
+import { usePlayerStore } from '@/stores/player.store';
+import {
+  PauseIcon,
+  PlayIcon,
+  RepeatIcon,
+  ShuffleIcon,
+  SkipBackIcon,
+  SkipForwardIcon,
+} from '@phosphor-icons/react';
+
+export function PlayerControls() {
+  const { isPlaying, togglePlay, nextTrack, previousTrack } = usePlayerStore();
+
+  return (
+    <div
+      className="flex items-center gap-1.5 px-3 py-1.5 bg-stone-900 border border-white/8 shadow-lg h-14"
+      style={{ borderRadius: '2rem 0.5rem 0.5rem 2rem' }}
+    >
+      <Button
+        size="icon"
+        className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
+      >
+        <ShuffleIcon size={16} />
+      </Button>
+      <Button
+        size="icon"
+        className="text-white/60 hover:text-white bg-transparent hover:bg-white/5 active:bg-white/10 rounded-full h-9 w-9 active:scale-95 transition-all"
+        onClick={previousTrack}
+      >
+        <SkipBackIcon size={22} weight="fill" />
+      </Button>
+      <Button
+        size="icon"
+        className="bg-white/15 text-white hover:bg-white/20 active:bg-white/25 rounded-full h-11 w-11 flex items-center justify-center active:scale-95 transition-all"
+        onClick={togglePlay}
+      >
+        {isPlaying ? (
+          <PauseIcon size={24} weight="fill" />
+        ) : (
+          <PlayIcon size={24} weight="fill" className="ml-0.5" />
+        )}
+      </Button>
+      <Button
+        size="icon"
+        className="text-white/60 hover:text-white bg-transparent hover:bg-white/5 active:bg-white/10 rounded-full h-9 w-9 active:scale-95 transition-all"
+        onClick={nextTrack}
+      >
+        <SkipForwardIcon size={22} weight="fill" />
+      </Button>
+      <Button
+        size="icon"
+        className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
+      >
+        <RepeatIcon size={16} />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/player/PlayerControls.tsx
+++ b/apps/web/src/components/app/player/PlayerControls.tsx
@@ -4,13 +4,17 @@ import {
   PauseIcon,
   PlayIcon,
   RepeatIcon,
+  RepeatOnceIcon,
   ShuffleIcon,
   SkipBackIcon,
   SkipForwardIcon,
 } from '@phosphor-icons/react';
 
 export function PlayerControls() {
-  const { isPlaying, togglePlay, nextTrack, previousTrack } = usePlayerStore();
+  const { isPlaying, togglePlay, nextTrack, previousTrack, repeatMode, toggleRepeatMode } =
+    usePlayerStore();
+
+  const isRepeatEnabled = repeatMode !== 'off';
 
   return (
     <div
@@ -50,9 +54,12 @@ export function PlayerControls() {
       </Button>
       <Button
         size="icon"
-        className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
+        className={`bg-transparent hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all ${
+          isRepeatEnabled ? 'text-emerald-500' : 'text-white/40 hover:text-white'
+        }`}
+        onClick={toggleRepeatMode}
       >
-        <RepeatIcon size={16} />
+        {repeatMode === 'one' ? <RepeatOnceIcon size={16} /> : <RepeatIcon size={16} />}
       </Button>
     </div>
   );

--- a/apps/web/src/components/app/player/PlayerControls.tsx
+++ b/apps/web/src/components/app/player/PlayerControls.tsx
@@ -11,8 +11,16 @@ import {
 } from '@phosphor-icons/react';
 
 export function PlayerControls() {
-  const { isPlaying, togglePlay, nextTrack, previousTrack, repeatMode, toggleRepeatMode } =
-    usePlayerStore();
+  const {
+    isPlaying,
+    togglePlay,
+    nextTrack,
+    previousTrack,
+    repeatMode,
+    toggleRepeatMode,
+    isShuffled,
+    toggleShuffle,
+  } = usePlayerStore();
 
   const isRepeatEnabled = repeatMode !== 'off';
 
@@ -23,7 +31,10 @@ export function PlayerControls() {
     >
       <Button
         size="icon"
-        className="text-white/40 bg-transparent hover:text-white hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all"
+        className={`bg-transparent hover:bg-white/2 active:bg-white/5 rounded-full h-8 w-8 active:scale-95 transition-all ${
+          isShuffled ? 'text-emerald-500' : 'text-white/40 hover:text-white'
+        }`}
+        onClick={toggleShuffle}
       >
         <ShuffleIcon size={16} />
       </Button>

--- a/apps/web/src/components/app/player/PlayerMobile.tsx
+++ b/apps/web/src/components/app/player/PlayerMobile.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components/ui/button';
+import { usePlayerStore } from '@/stores/player.store';
+import { MusicNotesIcon, PauseIcon, PlayIcon } from '@phosphor-icons/react';
+
+export function PlayerMobile() {
+  const { currentTrack, isPlaying, togglePlay } = usePlayerStore();
+
+  const trackTitle = currentTrack?.title || 'No track selected';
+  const trackArtist = currentTrack?.artists?.map((a) => a.name).join(', ') || 'Unknown Artist';
+  const coverUrl = currentTrack?.album?.cover?.url;
+
+  return (
+    <div className="w-full h-full flex items-center justify-between px-2">
+      <div className="flex items-center gap-3 overflow-hidden">
+        <div className="h-10 w-10 shrink-0 bg-stone-900 rounded-md flex items-center justify-center overflow-hidden border border-white/10 shadow-lg">
+          {coverUrl ? (
+            <img src={coverUrl} alt="" className="size-full object-cover" />
+          ) : (
+            <MusicNotesIcon size={20} className="text-stone-500" />
+          )}
+        </div>
+        <div className="flex flex-col min-w-0">
+          <div className="text-white font-semibold truncate text-sm">{trackTitle}</div>
+          <div className="text-white/50 text-xs truncate font-medium">{trackArtist}</div>
+        </div>
+      </div>
+      <Button
+        size="icon-lg"
+        variant="ghost"
+        className="active:scale-95 shrink-0"
+        onClick={togglePlay}
+      >
+        {isPlaying ? <PauseIcon weight="fill" /> : <PlayIcon weight="fill" />}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/player/PlayerTrackInfo.tsx
+++ b/apps/web/src/components/app/player/PlayerTrackInfo.tsx
@@ -1,0 +1,90 @@
+import { Slider } from '@/components/ui/slider';
+import { cn } from '@/lib/utils';
+import { usePlayerStore } from '@/stores/player.store';
+import { MusicNotesIcon } from '@phosphor-icons/react';
+import { useState } from 'react';
+
+interface PlayerTrackInfoProps {
+  formatTime: (time: number) => string;
+  formatTimeLeft: (time: number, total: number) => string;
+  onSeek: (time: number) => void;
+}
+
+export function PlayerTrackInfo({ formatTime, formatTimeLeft, onSeek }: PlayerTrackInfoProps) {
+  const { currentTrack, currentTime, duration, setCurrentTime } = usePlayerStore();
+  const [isHoveringSlider, setIsHoveringSlider] = useState(false);
+  const [isDraggingSlider, setIsDraggingSlider] = useState(false);
+
+  const trackTitle = currentTrack?.title || 'No track selected';
+  const trackArtist = currentTrack?.artists?.map((a) => a.name).join(', ') || 'Unknown Artist';
+  const coverUrl = currentTrack?.album?.cover?.url;
+
+  return (
+    <div
+      className={cn(
+        'flex-1 max-w-[600px] border border-white/8 bg-stone-900 flex items-stretch relative overflow-hidden shadow-xl h-14',
+      )}
+      style={{ borderRadius: '0.5rem' }}
+    >
+      {/* Floating Rounded Square Artwork */}
+      <div className="p-1.5 shrink-0">
+        <div className="h-full aspect-square bg-stone-800 rounded flex items-center justify-center overflow-hidden shadow-inner">
+          {coverUrl ? (
+            <img src={coverUrl} alt="" className="size-full object-cover" />
+          ) : (
+            <MusicNotesIcon size={20} className="text-stone-600" />
+          )}
+        </div>
+      </div>
+
+      {/* Right Content Area: Stacked Rows */}
+      <div className="flex-1 flex flex-col justify-center min-w-0 pr-3 pl-0 py-1.5 relative">
+        {/* Top Row: Title & Artist / Time Reveal */}
+        <div className="flex flex-col min-w-0 flex-1 justify-center">
+          <div className="text-white font-semibold truncate text-[14px] leading-tight">
+            {trackTitle}
+          </div>
+          <div
+            className={cn(
+              'text-white/50 text-[12px] truncate font-medium transition-all duration-300',
+              isHoveringSlider || isDraggingSlider
+                ? 'opacity-0 translate-y-1'
+                : 'opacity-100 translate-y-0',
+            )}
+          >
+            {trackArtist}
+          </div>
+
+          {/* Hover-reveal times */}
+          <div
+            className={cn(
+              'absolute left-0 right-3 top-[26px] flex items-center justify-between text-[11px] text-white/40 tabular-nums transition-all duration-300 pointer-events-none',
+              isHoveringSlider || isDraggingSlider
+                ? 'opacity-100 translate-y-0'
+                : 'opacity-0 -translate-y-1',
+            )}
+          >
+            <span>{formatTime(currentTime)}</span>
+            <span>{formatTimeLeft(currentTime, duration)}</span>
+          </div>
+        </div>
+
+        {/* Bottom Row: Progress Slider */}
+        <Slider
+          value={currentTime}
+          max={duration || 100}
+          showThumb={false}
+          onMouseEnter={() => setIsHoveringSlider(true)}
+          onMouseLeave={() => setIsHoveringSlider(false)}
+          onPointerDown={() => setIsDraggingSlider(true)}
+          onPointerUp={() => setIsDraggingSlider(false)}
+          onChange={(newTime) => {
+            onSeek(newTime);
+            setCurrentTime(newTime);
+          }}
+          className="mt-auto w-full"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/player/use-player-audio.ts
+++ b/apps/web/src/components/app/player/use-player-audio.ts
@@ -16,6 +16,7 @@ export function usePlayerAudio() {
     setCurrentTime,
     setDuration,
     nextTrack,
+    repeatMode,
   } = usePlayerStore();
 
   const { accessToken } = useAuthStore();
@@ -76,6 +77,17 @@ export function usePlayerAudio() {
     }
   };
 
+  const handleTrackEnd = () => {
+    if (repeatMode === 'one') {
+      if (audioRef.current) {
+        audioRef.current.currentTime = 0;
+        audioRef.current.play();
+      }
+    } else {
+      nextTrack();
+    }
+  };
+
   const getAudioUrl = () => {
     if (!currentTrack) return '';
     return `${apiBaseUrl}/library/tracks/${currentTrack.id}/stream?quality=${quality}&token=${accessToken}`;
@@ -96,6 +108,7 @@ export function usePlayerAudio() {
     audioRef,
     handleTimeUpdate,
     handleLoadedMetadata,
+    handleTrackEnd,
     getAudioUrl,
     formatTime,
     formatTimeLeft,

--- a/apps/web/src/components/app/player/use-player-audio.ts
+++ b/apps/web/src/components/app/player/use-player-audio.ts
@@ -1,0 +1,104 @@
+import { useAuthStore } from '@/stores/auth.store';
+import { usePlayerStore } from '@/stores/player.store';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook to manage audio element synchronization with player store
+ */
+export function usePlayerAudio() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const {
+    currentTrack,
+    isPlaying,
+    volume,
+    currentTime,
+    quality,
+    setCurrentTime,
+    setDuration,
+    nextTrack,
+  } = usePlayerStore();
+
+  const { accessToken } = useAuthStore();
+  const apiBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+  // Sync isPlaying with audio element
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !audio.src) return;
+
+    const playPromise = async () => {
+      try {
+        if (isPlaying) {
+          if (audio.readyState === 0) {
+            audio.load();
+          }
+          await audio.play();
+        } else {
+          audio.pause();
+        }
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          console.error('[AppPlayer] Playback Error:', {
+            name: err.name,
+            message: err.message,
+            readyState: audio.readyState,
+          });
+        }
+      }
+    };
+
+    playPromise();
+  }, [isPlaying, currentTrack]);
+
+  // Sync volume
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = volume;
+    }
+  }, [volume]);
+
+  // Sync currentTime from store (for seeking)
+  useEffect(() => {
+    if (audioRef.current && Math.abs(audioRef.current.currentTime - currentTime) > 1) {
+      audioRef.current.currentTime = currentTime;
+    }
+  }, [currentTime]);
+
+  const handleTimeUpdate = () => {
+    if (audioRef.current) {
+      setCurrentTime(audioRef.current.currentTime);
+    }
+  };
+
+  const handleLoadedMetadata = () => {
+    if (audioRef.current) {
+      setDuration(audioRef.current.duration);
+    }
+  };
+
+  const getAudioUrl = () => {
+    if (!currentTrack) return '';
+    return `${apiBaseUrl}/library/tracks/${currentTrack.id}/stream?quality=${quality}&token=${accessToken}`;
+  };
+
+  const formatTime = (time: number) => {
+    const mins = Math.floor(time / 60);
+    const secs = Math.floor(time % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const formatTimeLeft = (time: number, total: number) => {
+    const timeLeft = total - time;
+    return `-${formatTime(timeLeft)}`;
+  };
+
+  return {
+    audioRef,
+    handleTimeUpdate,
+    handleLoadedMetadata,
+    getAudioUrl,
+    formatTime,
+    formatTimeLeft,
+    nextTrack,
+  };
+}

--- a/apps/web/src/components/app/queue/QueueHeader.tsx
+++ b/apps/web/src/components/app/queue/QueueHeader.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button';
+import { ClockCounterClockwiseIcon, XIcon } from '@phosphor-icons/react';
+
+interface QueueHeaderProps {
+  onShowHistory: () => void;
+  onToggleQueue: () => void;
+}
+
+export function QueueHeader({ onShowHistory, onToggleQueue }: QueueHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0 h-16">
+      <div className="flex items-center gap-2">
+        <h2 className="text-lg font-semibold text-white">Queue</h2>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white/50 hover:text-white"
+          onClick={onShowHistory}
+          title="Show History"
+        >
+          <ClockCounterClockwiseIcon size={20} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white/50 hover:text-white md:hidden"
+          onClick={onToggleQueue}
+        >
+          <XIcon size={20} />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/queue/QueueItem.tsx
+++ b/apps/web/src/components/app/queue/QueueItem.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { QueueItem as PlayrQueueItem } from '@/stores/player.store';
+import { Button } from '@/components/ui/button';
+import { DotsSixVerticalIcon, MusicNotesIcon, PlayIcon, TrashIcon } from '@phosphor-icons/react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { motion } from 'framer-motion';
+
+export interface QueueItemProps {
+  track: PlayrQueueItem;
+  onPlay: (track: PlayrQueueItem) => void;
+  onRemove: (uniqueId: string, event: React.MouseEvent) => void;
+}
+
+export function QueueItem({ track, onPlay, onRemove }: QueueItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: track.uniqueId,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 1 : 0,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <motion.div
+      layout="position"
+      initial={{ opacity: 0, scale: 0.8, filter: 'blur(4px)' }}
+      animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+      exit={{ opacity: 0, scale: 0.8, filter: 'blur(8px)', transition: { duration: 0.2 } }}
+      ref={setNodeRef}
+      style={style}
+      className="group flex items-center gap-2 p-2 rounded-md hover:bg-white/5 transition-colors cursor-pointer"
+      onClick={() => onPlay(track)}
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        className="text-white/20 hover:text-white/50 cursor-grab active:cursor-grabbing p-1 -ml-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DotsSixVerticalIcon size={20} />
+      </div>
+
+      <div className="relative h-10 w-10 shrink-0 rounded overflow-hidden bg-stone-800">
+        {track.album?.cover?.url ? (
+          <img
+            src={track.album.cover.url}
+            alt={track.title}
+            className="h-full w-full object-cover group-hover:opacity-40 transition-opacity"
+          />
+        ) : (
+          <div className="h-full w-full flex items-center justify-center group-hover:opacity-40 transition-opacity">
+            <MusicNotesIcon className="text-white/20" size={16} />
+          </div>
+        )}
+        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+          <PlayIcon weight="fill" className="text-white" size={16} />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-white/90 truncate group-hover:text-white">
+          {track.title}
+        </div>
+        <div className="text-xs text-white/50 truncate">
+          {track.artists?.map((a: { name: string }) => a.name).join(', ')}
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-white/20 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all"
+        onClick={(e) => onRemove(track.uniqueId, e)}
+      >
+        <TrashIcon />
+      </Button>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/app/queue/QueueNextUp.tsx
+++ b/apps/web/src/components/app/queue/QueueNextUp.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { QueueItem as PlayrQueueItem } from '@/stores/player.store';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { QueueItem } from './QueueItem';
+
+interface QueueNextUpProps {
+  nextUp: PlayrQueueItem[];
+  isShuffled: boolean;
+  onDragEnd: (event: DragEndEvent) => void;
+  onPlayTrack: (track: PlayrQueueItem) => void;
+  onRemoveTrack: (uniqueId: string, event: React.MouseEvent) => void;
+}
+
+export function QueueNextUp({
+  nextUp,
+  isShuffled,
+  onDragEnd,
+  onPlayTrack,
+  onRemoveTrack,
+}: QueueNextUpProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">Next Up</h3>
+      <AnimatePresence mode="wait">
+        {nextUp.length === 0 ? (
+          <motion.div
+            key="empty-queue"
+            initial={{ opacity: 0, scale: 0.98, filter: 'blur(4px)' }}
+            animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+            exit={{
+              opacity: 0,
+              scale: 0.98,
+              filter: 'blur(4px)',
+              transition: { duration: 0.2 },
+            }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            className="text-sm text-white/30 italic text-center py-8"
+          >
+            Queue is empty
+          </motion.div>
+        ) : (
+          <motion.div
+            key={isShuffled ? 'shuffled-list' : 'unshuffled-list'}
+            initial={{ opacity: 0, scale: 0.98, filter: 'blur(4px)' }}
+            animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+            exit={{
+              opacity: 0,
+              scale: 0.98,
+              filter: 'blur(4px)',
+              transition: { duration: 0.2 },
+            }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            className="w-full"
+          >
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+              <SortableContext
+                items={nextUp.map((t) => t.uniqueId)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-0.5">
+                  <AnimatePresence mode="popLayout">
+                    {nextUp.map((track) => (
+                      <QueueItem
+                        key={track.uniqueId}
+                        track={track}
+                        onPlay={onPlayTrack}
+                        onRemove={onRemoveTrack}
+                      />
+                    ))}
+                  </AnimatePresence>
+                </div>
+              </SortableContext>
+            </DndContext>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/queue/QueueNowPlaying.tsx
+++ b/apps/web/src/components/app/queue/QueueNowPlaying.tsx
@@ -1,0 +1,59 @@
+import { QueueItem as PlayrQueueItem } from '@/stores/player.store';
+import { motion, AnimatePresence } from 'framer-motion';
+import { MusicNotesIcon } from '@phosphor-icons/react';
+
+interface QueueNowPlayingProps {
+  currentTrack: PlayrQueueItem | null;
+}
+
+export function QueueNowPlaying({ currentTrack }: QueueNowPlayingProps) {
+  if (!currentTrack) return null;
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-xs font-bold text-white/40 uppercase tracking-wider">Now Playing</h3>
+      <AnimatePresence mode="popLayout">
+        <motion.div
+          key={currentTrack.uniqueId}
+          initial={{ opacity: 0, scale: 0.9, filter: 'blur(8px)' }}
+          animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+          exit={{
+            opacity: 0,
+            scale: 0.9,
+            filter: 'blur(8px)',
+            transition: { duration: 0.2 },
+          }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+          className="group flex items-center gap-3 p-2 rounded-md bg-white/5 border border-white/5 transition-colors hover:bg-white/10"
+        >
+          <div className="relative h-12 w-12 shrink-0 rounded overflow-hidden bg-stone-800">
+            {currentTrack.album?.cover?.url ? (
+              <img
+                src={currentTrack.album.cover.url}
+                alt={currentTrack.title}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="h-full w-full flex items-center justify-center">
+                <MusicNotesIcon className="text-white/20" size={20} />
+              </div>
+            )}
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <div className="flex items-end gap-0.5 h-3">
+                <div className="w-1 h-3 bg-green-500 animate-music-bar-1" />
+                <div className="w-1 h-2 bg-green-500 animate-music-bar-2" />
+                <div className="w-1 h-3 bg-green-500 animate-music-bar-3" />
+              </div>
+            </div>
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-green-500 truncate">{currentTrack.title}</div>
+            <div className="text-xs text-white/50 truncate">
+              {currentTrack.artists?.map((a: { name: string }) => a.name).join(', ')}
+            </div>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/sidebar-layout.tsx
+++ b/apps/web/src/components/layout/sidebar-layout.tsx
@@ -5,13 +5,28 @@ import { useIsMounted } from '@/hooks/use-is-mounted';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { cn } from '@/lib/utils';
 import { usePlayerStore } from '@/stores/player.store';
+import { useState, useEffect } from 'react';
 import { AppPlayer } from '../app/Player';
 import { Queue } from '../app/Queue';
+import { Lyrics } from '../app/Lyrics';
 
 export function SidebarLayout({ children }: { children: React.ReactNode }) {
-  const { isQueueOpen, setQueueOpen } = usePlayerStore();
+  const { isQueueOpen, setQueueOpen, sidebarView } = usePlayerStore();
   const isDesktop = useMediaQuery('(min-width: 1500px)');
   const mounted = useIsMounted();
+  const [isSettledInternal, setIsSettledInternal] = useState(false);
+
+  useEffect(() => {
+    if (isQueueOpen) {
+      const timer = setTimeout(() => setIsSettledInternal(true), 500);
+      return () => {
+        clearTimeout(timer);
+        setIsSettledInternal(false);
+      };
+    }
+  }, [isQueueOpen]);
+
+  const isSettled = isQueueOpen && isSettledInternal;
 
   return (
     <SidebarProvider>
@@ -20,8 +35,8 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
         {/* Main Content Area */}
         <div
           className={cn(
-            'flex-1 flex flex-col relative min-w-0 transition-all duration-300 mt-2',
-            !isQueueOpen && isDesktop ? 'mr-2' : '',
+            'flex-1 flex flex-col relative min-w-0 transition-all duration-500 ease-apple mt-2',
+            isDesktop ? 'mr-2' : '',
           )}
         >
           <div className="mx-auto flex h-full w-full max-w-480 flex-col relative">
@@ -41,12 +56,36 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
         {mounted && isDesktop && (
           <div
             className={cn(
-              'border-l border-white/10 bg-stone-900 transition-all duration-300 ease-in-out flex flex-col',
-              isQueueOpen ? 'w-100 border-l' : 'w-0 border-none overflow-hidden',
+              'bg-stone-900 transition-all duration-500 ease-apple flex flex-col shadow-2xl overflow-hidden my-2 rounded-xl origin-right',
+              isQueueOpen
+                ? 'w-[360px] mr-2 border border-white/10 opacity-100 blur-0'
+                : 'w-0 mr-0 border-none opacity-50 blur-xs',
             )}
+            style={{ height: 'calc(100vh - 1rem)' }}
           >
-            <div className="w-100 h-full">
-              <Queue />
+            <div className="w-[360px] h-full relative">
+              <div
+                className={cn(
+                  'absolute inset-0',
+                  isSettled ? 'transition-all duration-300 ease-out' : 'transition-none',
+                  sidebarView === 'queue'
+                    ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+                    : 'opacity-0 scale-98 blur-xs pointer-events-none',
+                )}
+              >
+                <Queue />
+              </div>
+              <div
+                className={cn(
+                  'absolute inset-0',
+                  isSettled ? 'transition-all duration-300 ease-out' : 'transition-none',
+                  sidebarView === 'lyrics'
+                    ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+                    : 'opacity-0 scale-98 blur-xs pointer-events-none',
+                )}
+              >
+                <Lyrics />
+              </div>
             </div>
           </div>
         )}
@@ -56,9 +95,32 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
           <Sheet open={isQueueOpen} onOpenChange={setQueueOpen}>
             <SheetContent
               side="right"
-              className="w-full sm:w-100 p-0 bg-stone-900 border-l border-white/10 text-white"
+              className="w-full sm:w-[360px] p-0 bg-stone-900 border-l border-white/10 text-white"
             >
-              <Queue />
+              <div className="w-full h-full relative">
+                <div
+                  className={cn(
+                    'absolute inset-0',
+                    isSettled ? 'transition-all duration-300 ease-out' : 'transition-none',
+                    sidebarView === 'queue'
+                      ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+                      : 'opacity-0 scale-98 blur-sm pointer-events-none',
+                  )}
+                >
+                  <Queue />
+                </div>
+                <div
+                  className={cn(
+                    'absolute inset-0',
+                    isSettled ? 'transition-all duration-300 ease-out' : 'transition-none',
+                    sidebarView === 'lyrics'
+                      ? 'opacity-100 scale-100 blur-0 pointer-events-auto'
+                      : 'opacity-0 scale-98 blur-sm pointer-events-none',
+                  )}
+                >
+                  <Lyrics />
+                </div>
+              </div>
             </SheetContent>
           </Sheet>
         )}

--- a/apps/web/src/stores/player.store.ts
+++ b/apps/web/src/stores/player.store.ts
@@ -13,6 +13,7 @@ export interface PlayerState {
   quality: StreamAudioQuality;
   queue: QueueItem[];
   history: QueueItem[];
+  repeatMode: 'off' | 'all' | 'one';
 
   // Actions
   playTrack: (track: ZodTrack, queue?: ZodTrack[]) => void;
@@ -26,6 +27,7 @@ export interface PlayerState {
   setQueue: (queue: ZodTrack[]) => void;
   nextTrack: () => void;
   previousTrack: () => void;
+  toggleRepeatMode: () => void;
   addToQueue: (track: ZodTrack) => void;
   playNext: (track: ZodTrack) => void;
   removeFromQueue: (uniqueId: string) => void;
@@ -57,6 +59,7 @@ export const usePlayerStore = create<PlayerState>()(
       quality: StreamAudioQuality.standard,
       queue: [],
       history: [],
+      repeatMode: 'off',
 
       addToHistory: (track) => {
         set((state) => {
@@ -118,6 +121,12 @@ export const usePlayerStore = create<PlayerState>()(
       setDuration: (duration) => set({ duration }),
       setQuality: (quality) => set({ quality }),
       setQueue: (queue) => set({ queue: queue.map(toQueueItem) }),
+      toggleRepeatMode: () =>
+        set((state) => {
+          const modes: Array<'off' | 'all' | 'one'> = ['off', 'all', 'one'];
+          const currentIndex = modes.indexOf(state.repeatMode);
+          return { repeatMode: modes[(currentIndex + 1) % modes.length] };
+        }),
 
       addToQueue: (track) => set((state) => ({ queue: [...state.queue, toQueueItem(track)] })),
 
@@ -150,7 +159,7 @@ export const usePlayerStore = create<PlayerState>()(
       },
 
       nextTrack: () => {
-        const { queue, currentTrack, addToHistory } = get();
+        const { queue, currentTrack, addToHistory, repeatMode } = get();
         if (!currentTrack || queue.length === 0) return;
 
         const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
@@ -158,11 +167,16 @@ export const usePlayerStore = create<PlayerState>()(
           addToHistory(currentTrack);
           const next = queue[currentIndex + 1];
           set({ currentTrack: next, currentTime: 0, isPlaying: true });
+        } else if (repeatMode === 'all') {
+          // Loop back to the start
+          addToHistory(currentTrack);
+          const next = queue[0];
+          set({ currentTrack: next, currentTime: 0, isPlaying: true });
         }
       },
 
       previousTrack: () => {
-        const { queue, currentTrack, currentTime, addToHistory } = get();
+        const { queue, currentTrack, currentTime, addToHistory, repeatMode } = get();
         if (!currentTrack || queue.length === 0) return;
 
         // If more than 3 seconds in, restart the track instead
@@ -176,6 +190,11 @@ export const usePlayerStore = create<PlayerState>()(
           addToHistory(currentTrack);
           const prev = queue[currentIndex - 1];
           set({ currentTrack: prev, currentTime: 0, isPlaying: true });
+        } else if (repeatMode === 'all') {
+          // Loop back to the end
+          addToHistory(currentTrack);
+          const prev = queue[queue.length - 1];
+          set({ currentTrack: prev, currentTime: 0, isPlaying: true });
         }
       },
     }),
@@ -187,6 +206,7 @@ export const usePlayerStore = create<PlayerState>()(
         queue: state.queue,
         history: state.history,
         currentTrack: state.currentTrack,
+        repeatMode: state.repeatMode,
       }),
     },
   ),

--- a/apps/web/src/stores/player.store.ts
+++ b/apps/web/src/stores/player.store.ts
@@ -1,5 +1,6 @@
 import { StreamAudioQuality, ZodTrack } from '@repo/contracts';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export type QueueItem = ZodTrack & { uniqueId: string };
 
@@ -11,6 +12,7 @@ export interface PlayerState {
   duration: number;
   quality: StreamAudioQuality;
   queue: QueueItem[];
+  history: QueueItem[];
 
   // Actions
   playTrack: (track: ZodTrack, queue?: ZodTrack[]) => void;
@@ -28,10 +30,13 @@ export interface PlayerState {
   playNext: (track: ZodTrack) => void;
   removeFromQueue: (uniqueId: string) => void;
   reorderQueue: (newQueue: QueueItem[]) => void;
+  addToHistory: (track: QueueItem) => void;
 
   isQueueOpen: boolean;
+  sidebarView: 'queue' | 'lyrics';
   toggleQueue: () => void;
   setQueueOpen: (isOpen: boolean) => void;
+  setSidebarView: (view: 'queue' | 'lyrics') => void;
 }
 
 const generateUniqueId = () => Math.random().toString(36).substring(2, 9);
@@ -41,117 +46,148 @@ const toQueueItem = (track: ZodTrack): QueueItem => ({
   uniqueId: generateUniqueId(),
 });
 
-export const usePlayerStore = create<PlayerState>((set, get) => ({
-  currentTrack: null,
-  isPlaying: false,
-  volume: 1,
-  currentTime: 0,
-  duration: 0,
-  quality: StreamAudioQuality.standard,
-  queue: [],
-
-  playTrack: (track, queue) => {
-    const currentQueueItem = toQueueItem(track);
-    const newQueue = queue ? queue.map(toQueueItem) : get().queue;
-
-    let finalQueue = newQueue;
-    let finalCurrentTrack = currentQueueItem;
-
-    if (queue) {
-      // Reconstruct queue with unique IDs
-      finalQueue = queue.map(toQueueItem);
-      // Ensure currentTrack matches an item in the queue by ID
-      const found = finalQueue.find((t) => t.id === track.id);
-      if (found) {
-        finalCurrentTrack = found;
-      } else {
-        // Track not in provided queue? Prepend it.
-        finalQueue = [finalCurrentTrack, ...finalQueue];
-      }
-    } else {
-      // If no queue provided and existing queue is empty, set as only item.
-      if (!get().queue.length) {
-        finalQueue = [finalCurrentTrack];
-      }
-    }
-
-    set({
-      currentTrack: finalCurrentTrack,
-      isPlaying: true,
-      queue: finalQueue,
+export const usePlayerStore = create<PlayerState>()(
+  persist(
+    (set, get) => ({
+      currentTrack: null,
+      isPlaying: false,
+      volume: 1,
       currentTime: 0,
-    });
-  },
+      duration: 0,
+      quality: StreamAudioQuality.standard,
+      queue: [],
+      history: [],
 
-  pause: () => set({ isPlaying: false }),
-  resume: () => set({ isPlaying: get().currentTrack !== null }),
-  togglePlay: () => set((state) => ({ isPlaying: !state.isPlaying && !!state.currentTrack })),
+      addToHistory: (track) => {
+        set((state) => {
+          const newHistory = [track, ...state.history].slice(0, 1024);
+          return { history: newHistory };
+        });
+      },
 
-  isQueueOpen: false,
-  toggleQueue: () => set((state) => ({ isQueueOpen: !state.isQueueOpen })),
-  setQueueOpen: (isOpen) => set({ isQueueOpen: isOpen }),
+      playTrack: (track, queue) => {
+        const { currentTrack, addToHistory } = get();
+        if (currentTrack) {
+          addToHistory(currentTrack);
+        }
 
-  setVolume: (volume) => set({ volume }),
-  setCurrentTime: (currentTime) => set({ currentTime }),
-  setDuration: (duration) => set({ duration }),
-  setQuality: (quality) => set({ quality }),
-  setQueue: (queue) => set({ queue: queue.map(toQueueItem) }),
+        const currentQueueItem = toQueueItem(track);
+        const newQueue = queue ? queue.map(toQueueItem) : get().queue;
 
-  addToQueue: (track) => set((state) => ({ queue: [...state.queue, toQueueItem(track)] })),
+        let finalQueue = newQueue;
+        let finalCurrentTrack = currentQueueItem;
 
-  removeFromQueue: (uniqueId) =>
-    set((state) => ({
-      queue: state.queue.filter((t) => t.uniqueId !== uniqueId),
-    })),
+        if (queue) {
+          // Reconstruct queue with unique IDs
+          finalQueue = queue.map(toQueueItem);
+          // Ensure currentTrack matches an item in the queue by ID
+          const found = finalQueue.find((t) => t.id === track.id);
+          if (found) {
+            finalCurrentTrack = found;
+          } else {
+            // Track not in provided queue? Prepend it.
+            finalQueue = [finalCurrentTrack, ...finalQueue];
+          }
+        } else {
+          // If no queue provided and existing queue is empty, set as only item.
+          if (!get().queue.length) {
+            finalQueue = [finalCurrentTrack];
+          }
+        }
 
-  reorderQueue: (newQueue) => set({ queue: newQueue }),
+        set({
+          currentTrack: finalCurrentTrack,
+          isPlaying: true,
+          queue: finalQueue,
+          currentTime: 0,
+        });
+      },
 
-  playNext: (track) => {
-    const { currentTrack, queue } = get();
-    const newItem = toQueueItem(track);
+      pause: () => set({ isPlaying: false }),
+      resume: () => set({ isPlaying: get().currentTrack !== null }),
+      togglePlay: () => set((state) => ({ isPlaying: !state.isPlaying && !!state.currentTrack })),
 
-    if (!currentTrack) {
-      set({ currentTrack: newItem, queue: [newItem], isPlaying: true });
-      return;
-    }
+      isQueueOpen: false,
+      sidebarView: 'queue',
+      toggleQueue: () => set((state) => ({ isQueueOpen: !state.isQueueOpen })),
+      setQueueOpen: (isOpen) => set({ isQueueOpen: isOpen }),
+      setSidebarView: (view) => set({ sidebarView: view }),
 
-    const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
+      setVolume: (volume) => set({ volume }),
+      setCurrentTime: (currentTime) => set({ currentTime }),
+      setDuration: (duration) => set({ duration }),
+      setQuality: (quality) => set({ quality }),
+      setQueue: (queue) => set({ queue: queue.map(toQueueItem) }),
 
-    if (currentIndex === -1) {
-      // Current track playing but not in queue (weird state), append to end
-      set((state) => ({ queue: [...state.queue, newItem] }));
-    } else {
-      const newQueue = [...queue];
-      newQueue.splice(currentIndex + 1, 0, newItem);
-      set({ queue: newQueue });
-    }
-  },
+      addToQueue: (track) => set((state) => ({ queue: [...state.queue, toQueueItem(track)] })),
 
-  nextTrack: () => {
-    const { queue, currentTrack } = get();
-    if (!currentTrack || queue.length === 0) return;
+      removeFromQueue: (uniqueId) =>
+        set((state) => ({
+          queue: state.queue.filter((t) => t.uniqueId !== uniqueId),
+        })),
 
-    const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
-    if (currentIndex > -1 && currentIndex < queue.length - 1) {
-      const next = queue[currentIndex + 1];
-      set({ currentTrack: next, currentTime: 0, isPlaying: true });
-    }
-  },
+      reorderQueue: (newQueue) => set({ queue: newQueue }),
 
-  previousTrack: () => {
-    const { queue, currentTrack, currentTime } = get();
-    if (!currentTrack || queue.length === 0) return;
+      playNext: (track) => {
+        const { currentTrack, queue } = get();
+        const newItem = toQueueItem(track);
 
-    // If more than 3 seconds in, restart the track instead
-    if (currentTime > 3) {
-      set({ currentTime: 0 });
-      return;
-    }
+        if (!currentTrack) {
+          set({ currentTrack: newItem, queue: [newItem], isPlaying: true });
+          return;
+        }
 
-    const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
-    if (currentIndex > 0) {
-      const prev = queue[currentIndex - 1];
-      set({ currentTrack: prev, currentTime: 0, isPlaying: true });
-    }
-  },
-}));
+        const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
+
+        if (currentIndex === -1) {
+          // Current track playing but not in queue (weird state), append to end
+          set((state) => ({ queue: [...state.queue, newItem] }));
+        } else {
+          const newQueue = [...queue];
+          newQueue.splice(currentIndex + 1, 0, newItem);
+          set({ queue: newQueue });
+        }
+      },
+
+      nextTrack: () => {
+        const { queue, currentTrack, addToHistory } = get();
+        if (!currentTrack || queue.length === 0) return;
+
+        const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
+        if (currentIndex > -1 && currentIndex < queue.length - 1) {
+          addToHistory(currentTrack);
+          const next = queue[currentIndex + 1];
+          set({ currentTrack: next, currentTime: 0, isPlaying: true });
+        }
+      },
+
+      previousTrack: () => {
+        const { queue, currentTrack, currentTime, addToHistory } = get();
+        if (!currentTrack || queue.length === 0) return;
+
+        // If more than 3 seconds in, restart the track instead
+        if (currentTime > 3) {
+          set({ currentTime: 0 });
+          return;
+        }
+
+        const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
+        if (currentIndex > 0) {
+          addToHistory(currentTrack);
+          const prev = queue[currentIndex - 1];
+          set({ currentTrack: prev, currentTime: 0, isPlaying: true });
+        }
+      },
+    }),
+    {
+      name: 'player-storage',
+      partialize: (state) => ({
+        volume: state.volume,
+        quality: state.quality,
+        queue: state.queue,
+        history: state.history,
+        currentTrack: state.currentTrack,
+      }),
+    },
+  ),
+);

--- a/apps/web/src/stores/player.store.ts
+++ b/apps/web/src/stores/player.store.ts
@@ -27,6 +27,7 @@ export interface PlayerState {
   addToQueue: (track: ZodTrack) => void;
   playNext: (track: ZodTrack) => void;
   removeFromQueue: (uniqueId: string) => void;
+  reorderQueue: (newQueue: QueueItem[]) => void;
 
   isQueueOpen: boolean;
   toggleQueue: () => void;
@@ -102,6 +103,8 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
     set((state) => ({
       queue: state.queue.filter((t) => t.uniqueId !== uniqueId),
     })),
+
+  reorderQueue: (newQueue) => set({ queue: newQueue }),
 
   playNext: (track) => {
     const { currentTrack, queue } = get();

--- a/apps/web/src/stores/player.store.ts
+++ b/apps/web/src/stores/player.store.ts
@@ -12,8 +12,10 @@ export interface PlayerState {
   duration: number;
   quality: StreamAudioQuality;
   queue: QueueItem[];
+  originalQueue: QueueItem[];
   history: QueueItem[];
   repeatMode: 'off' | 'all' | 'one';
+  isShuffled: boolean;
 
   // Actions
   playTrack: (track: ZodTrack, queue?: ZodTrack[]) => void;
@@ -28,6 +30,7 @@ export interface PlayerState {
   nextTrack: () => void;
   previousTrack: () => void;
   toggleRepeatMode: () => void;
+  toggleShuffle: () => void;
   addToQueue: (track: ZodTrack) => void;
   playNext: (track: ZodTrack) => void;
   removeFromQueue: (uniqueId: string) => void;
@@ -48,6 +51,15 @@ const toQueueItem = (track: ZodTrack): QueueItem => ({
   uniqueId: generateUniqueId(),
 });
 
+function shuffleArray<T>(array: T[]): T[] {
+  const newArray = [...array];
+  for (let i = newArray.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+  }
+  return newArray;
+}
+
 export const usePlayerStore = create<PlayerState>()(
   persist(
     (set, get) => ({
@@ -58,8 +70,10 @@ export const usePlayerStore = create<PlayerState>()(
       duration: 0,
       quality: StreamAudioQuality.standard,
       queue: [],
+      originalQueue: [],
       history: [],
       repeatMode: 'off',
+      isShuffled: false,
 
       addToHistory: (track) => {
         set((state) => {
@@ -102,6 +116,8 @@ export const usePlayerStore = create<PlayerState>()(
           currentTrack: finalCurrentTrack,
           isPlaying: true,
           queue: finalQueue,
+          originalQueue: [],
+          isShuffled: false,
           currentTime: 0,
         });
       },
@@ -120,7 +136,12 @@ export const usePlayerStore = create<PlayerState>()(
       setCurrentTime: (currentTime) => set({ currentTime }),
       setDuration: (duration) => set({ duration }),
       setQuality: (quality) => set({ quality }),
-      setQueue: (queue) => set({ queue: queue.map(toQueueItem) }),
+      setQueue: (queue) =>
+        set({
+          queue: queue.map(toQueueItem),
+          originalQueue: [],
+          isShuffled: false,
+        }),
       toggleRepeatMode: () =>
         set((state) => {
           const modes: Array<'off' | 'all' | 'one'> = ['off', 'all', 'one'];
@@ -128,33 +149,99 @@ export const usePlayerStore = create<PlayerState>()(
           return { repeatMode: modes[(currentIndex + 1) % modes.length] };
         }),
 
-      addToQueue: (track) => set((state) => ({ queue: [...state.queue, toQueueItem(track)] })),
+      toggleShuffle: () =>
+        set((state) => {
+          if (state.isShuffled) {
+            // Turn off shuffle: restore original queue
+            return {
+              isShuffled: false,
+              queue: state.originalQueue,
+              originalQueue: [],
+            };
+          } else {
+            // Turn on shuffle
+            const newQueue = shuffleArray(state.queue);
+            // If there's a current track, ensure it's first
+            if (state.currentTrack) {
+              const currentId = state.currentTrack.uniqueId;
+              const trackIndex = newQueue.findIndex((t) => t.uniqueId === currentId);
+              if (trackIndex > -1) {
+                const [track] = newQueue.splice(trackIndex, 1);
+                newQueue.unshift(track);
+              }
+            }
+            return {
+              isShuffled: true,
+              originalQueue: state.queue,
+              queue: newQueue,
+            };
+          }
+        }),
+
+      addToQueue: (track) =>
+        set((state) => {
+          const newItem = toQueueItem(track);
+          return {
+            queue: [...state.queue, newItem],
+            originalQueue: state.isShuffled
+              ? [...state.originalQueue, newItem]
+              : state.originalQueue,
+          };
+        }),
 
       removeFromQueue: (uniqueId) =>
         set((state) => ({
           queue: state.queue.filter((t) => t.uniqueId !== uniqueId),
+          originalQueue: state.isShuffled
+            ? state.originalQueue.filter((t) => t.uniqueId !== uniqueId)
+            : state.originalQueue,
         })),
 
-      reorderQueue: (newQueue) => set({ queue: newQueue }),
+      reorderQueue: (newQueue) =>
+        set((state) => ({
+          queue: newQueue,
+          originalQueue: state.isShuffled ? state.originalQueue : [], // Reordering manually clears shuffle original queue conceptually, or we accept the new order
+        })),
 
       playNext: (track) => {
-        const { currentTrack, queue } = get();
+        const { currentTrack, queue, isShuffled, originalQueue } = get();
         const newItem = toQueueItem(track);
 
         if (!currentTrack) {
-          set({ currentTrack: newItem, queue: [newItem], isPlaying: true });
+          set({
+            currentTrack: newItem,
+            queue: [newItem],
+            originalQueue: isShuffled ? [newItem] : [],
+            isPlaying: true,
+          });
           return;
         }
 
         const currentIndex = queue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
 
         if (currentIndex === -1) {
-          // Current track playing but not in queue (weird state), append to end
-          set((state) => ({ queue: [...state.queue, newItem] }));
+          set((state) => ({
+            queue: [...state.queue, newItem],
+            originalQueue: state.isShuffled
+              ? [...state.originalQueue, newItem]
+              : state.originalQueue,
+          }));
         } else {
           const newQueue = [...queue];
           newQueue.splice(currentIndex + 1, 0, newItem);
-          set({ queue: newQueue });
+
+          let newOriginalQueue = originalQueue;
+          if (isShuffled) {
+            const origIndex = originalQueue.findIndex((t) => t.uniqueId === currentTrack.uniqueId);
+            if (origIndex > -1) {
+              newOriginalQueue = [...originalQueue];
+              newOriginalQueue.splice(origIndex + 1, 0, newItem);
+            } else {
+              newOriginalQueue = [...originalQueue, newItem];
+            }
+          }
+
+          set({ queue: newQueue, originalQueue: newOriginalQueue });
         }
       },
 
@@ -207,6 +294,8 @@ export const usePlayerStore = create<PlayerState>()(
         history: state.history,
         currentTrack: state.currentTrack,
         repeatMode: state.repeatMode,
+        isShuffled: state.isShuffled,
+        originalQueue: state.originalQueue,
       }),
     },
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1073,6 +1082,28 @@ packages:
   '@dependents/detective-less@5.0.1':
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.0.20':
     resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
@@ -7921,6 +7952,31 @@ snapshots:
     dependencies:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      framer-motion:
+        specifier: ^12.34.2
+        version: 12.34.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4736,6 +4739,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.34.2:
+    resolution: {integrity: sha512-CcnYTzbRybm1/OE8QLXfXI8gR1cx5T4dF3D2kn5IyqsGNeLAKl2iFHb2BzFyXBGqESntDt6rPYl4Jhrb7tdB8g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -5610,6 +5627,12 @@ packages:
     resolution: {integrity: sha512-Rs5FVpVcBYRHPLuhHOjgbRhosaQYLtEo3JIeDIbmNo7mSssi1CTzwMh8v36gAzpbzLGXI9wB/yHh+5+3fY1QVw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  motion-dom@12.34.2:
+    resolution: {integrity: sha512-n7gknp7gHcW7DUcmet0JVPLVHmE3j9uWwDp5VbE3IkCNnW5qdu0mOhjNYzXMkrQjrgr+h6Db3EDM2QBhW2qNxQ==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -11937,6 +11960,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.34.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.34.2
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fresh@2.0.0: {}
 
   fs-extra@10.1.0:
@@ -12769,6 +12801,12 @@ snapshots:
       glob: 7.2.3
       requirejs: 2.3.8
       requirejs-config-file: 4.0.0
+
+  motion-dom@12.34.2:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
# Enhanced Music Player with Drag-and-Drop Queue and History

## Features

### Player Store Enhancements
- Add reorderQueue action to player store for drag-and-drop functionality
- Add history tracking to record played tracks (max 1024 items)
- Add sidebarView state to toggle between queue and lyrics views
- Persist player state to localStorage using zustand middleware

### Queue Management
- Implement drag-and-drop reordering with dnd-kit
- Create SortableTrackItem component for queue items
- Add sensors for pointer and keyboard interactions
- Handle drag events to persist reordered queue state

### New Components
- Add History component to display listening history with pagination
- Add Lyrics component as placeholder for future lyrics functionality
- Create usePlayerAudio hook for audio element synchronization

### UI Improvements
- Extract Player component into focused, reusable modules:
  - PlayerControls: playback buttons (play, pause, skip)
  - PlayerTrackInfo: track display with progress slider
  - PlayerActions: queue, lyrics, and volume controls
  - PlayerMobile: mobile-optimized player layout
- Implement smooth transitions between sidebar views
- Add view switching with opacity, scale, and blur animations
- Update sidebar styling with improved transitions
- Apply consistent design to both desktop and mobile layouts

## Technical Details
- Add dnd-kit dependencies for drag-and-drop functionality
- Implement DndContext with sortable items
- Create audio synchronization hook for better separation of concerns
- Use zustand persist middleware to save player state
- Add transition animations for smooth view switching

This PR enhances the music player with a more robust queue management system, listening history tracking, and improved UI components.