### PR TITLE
Fix(Docker): fixed zero setup dev env. 1 command needed to run env after git clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 *.pem
 *.tsbuildinfo
 .pnpm-store
+
+# IDEs and editors
+.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}
     entrypoint: >
       /bin/sh -c "
-        /usr/bin/mc alias set myminio http://minio:9000 \${S3_ACCESS_KEY} \${S3_SECRET_KEY} || true;
+         /usr/bin/mc alias set myminio http://minio:9000 ${S3_ACCESS_KEY:-minioadmin} ${S3_SECRET_KEY:-minioadmin} || true;
         /usr/bin/mc mb myminio/public --ignore-existing;
         /usr/bin/mc anonymous set download myminio/public;
         /usr/bin/mc mb myminio/private --ignore-existing;
@@ -96,7 +96,14 @@ services:
       THROTTLE_ENABLED: ${THROTTLE_ENABLED:-true}
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
-    command: /bin/sh -c "apk add --no-cache ffmpeg && corepack enable && pnpm install && pnpm turbo run dev --filter=@repo/api"
+    command: >
+      /bin/sh -c "
+      apk add --no-cache ffmpeg && 
+      corepack enable && 
+      pnpm install && 
+      pnpm turbo run prisma:generate --filter=@repo/db && 
+      pnpm turbo run prisma:push --filter=@repo/db && 
+      pnpm turbo run dev --filter=@repo/api"
     depends_on:
       - db
       - minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-playr}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-playr}
       POSTGRES_DB: ${POSTGRES_DB:-playr}
+    healthcheck:  
+     test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-playr} -h localhost"]  
+     interval: 5s  
+     timeout: 5s  
+     retries: 5
     ports:
       - "5435:5432"
     volumes:
@@ -44,7 +49,8 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}
     entrypoint: >
       /bin/sh -c "
-         /usr/bin/mc alias set myminio http://minio:9000 ${S3_ACCESS_KEY:-minioadmin} ${S3_SECRET_KEY:-minioadmin} || true;
+        set -eu; 
+        /usr/bin/mc alias set myminio http://minio:9000 \"${S3_ACCESS_KEY:-minioadmin}\" \"${S3_SECRET_KEY:-minioadmin}\";  
         /usr/bin/mc mb myminio/public --ignore-existing;
         /usr/bin/mc anonymous set download myminio/public;
         /usr/bin/mc mb myminio/private --ignore-existing;
@@ -105,9 +111,12 @@ services:
       pnpm turbo run prisma:push --filter=@repo/db && 
       pnpm turbo run dev --filter=@repo/api"
     depends_on:
-      - db
-      - minio
-      - redis
+      db:  
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       - playr-network
 


### PR DESCRIPTION
## Added Prisma commands to Docker for zero-setup development environment

Added `prisma:generate` and `prisma:push` commands to the Docker Compose API service startup sequence, enabling a complete zero-setup development environment that only requires running `docker compose up`. Previously before running docker compose up after a fresh install you needed to run few other commands.

## Added .idea/ to .gitignore

Added `.idea/` directory to .gitignore to prevent IDE configuration files and DataGrip database settings from being committed to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to improve IDE file handling.
  * Enhanced Docker Compose setup with improved default credential handling for storage services and automated database initialization during API service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->