### PR TITLE
refactor(apps/api): extract integration test utilities to shared testing package

### DIFF
--- a/apps/api/integration/auth.int-spec.ts
+++ b/apps/api/integration/auth.int-spec.ts
@@ -2,9 +2,10 @@ import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { EmailAddress, EmailStatus, EmailType, Gender, User } from '@repo/db';
+// @ts-expect-error - ignore type errors from testing package imports
+import { PrismaServiceMock } from '@repo/testing';
 import request from 'supertest';
 import { vi } from 'vitest';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
 import { createIntegrationApp } from './test-utils';
 
 describe('AuthController (Integration)', () => {

--- a/apps/api/integration/library-albums.int-spec.ts
+++ b/apps/api/integration/library-albums.int-spec.ts
@@ -1,46 +1,58 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import {
+  AccessRole,
+  AudioFormat,
+  AudioQuality,
+  FileBucket,
+  LibraryAlbum,
+  PrismaClient,
+  ProcessingStatus,
+} from '@repo/db';
+import {
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildAlbumWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildImageForIntegration,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibrary,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibraryAlbumWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildTrack,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildTrackAccess,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildTrackWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildUser,
+  // @ts-expect-error - ignore type errors from testing package imports
+  createAuthHeaderFactory,
+  // @ts-expect-error - ignore type errors from testing package imports
+  DEFAULT_TEST_USER_ID,
+  // @ts-expect-error - ignore type errors from testing package imports
+  PrismaServiceMock,
+  // @ts-expect-error - ignore type errors from testing package imports
+  type AlbumWithRelations
+} from '@repo/testing';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { ImageService } from '../src/shared/services/image.service';
 import { StorageService } from '../src/shared/services/storage.service';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
 import './setup-env';
 import { createIntegrationApp } from './test-utils';
-import {
-  AlbumGetPayload,
-  AudioFormat,
-  AudioQuality,
-  FileBucket,
-  Image,
-  Library,
-  LibraryAlbum,
-  PrismaClient,
-  ProcessingStatus,
-  Track,
-  TrackGetPayload,
-  User,
-  Visibility,
-} from '@repo/db';
-
-// Helper type for Album with relations matching repository include
-type AlbumWithRelations = AlbumGetPayload<{
-  include: { artists: true; genres: true; tracks: true; access: true; cover: true };
-}>;
-
-// Helper type for LibraryAlbum with relations matching repository include
-type LibraryAlbumWithRelations = LibraryAlbum & {
-  album: AlbumWithRelations;
-};
 
 describe('LibraryAlbumsController (Integration)', () => {
   let app: INestApplication;
   let prismaMock: PrismaServiceMock;
-  let jwtService: JwtService;
-  let config: ConfigService;
+  let getAuthHeader: ReturnType<typeof createAuthHeaderFactory>;
   let storageServiceMock: { uploadFile: any; deleteFile: any };
   let imageServiceMock: { validateImage: any; resizeToMaxDimension: any };
+
+  const mockLibrary = buildLibrary();
+  const mockAlbum = buildAlbumWithRelations();
+  const mockLibraryAlbum = buildLibraryAlbumWithRelations({ album: mockAlbum });
 
   beforeAll(async () => {
     storageServiceMock = {
@@ -62,8 +74,9 @@ describe('LibraryAlbumsController (Integration)', () => {
 
     app = setup.app;
     prismaMock = setup.prismaMock;
-    jwtService = app.get(JwtService);
-    config = app.get(ConfigService);
+    const jwtService = app.get(JwtService);
+    const config = app.get(ConfigService);
+    getAuthHeader = createAuthHeaderFactory(jwtService, config);
   });
 
   beforeEach(() => {
@@ -73,79 +86,6 @@ describe('LibraryAlbumsController (Integration)', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  const getAuthHeader = async (userId: string = 'user-123') => {
-    const token = await jwtService.signAsync(
-      { sub: userId, username: 'testuser', sessionId: 'session-123' },
-      {
-        secret: config.get('JWT_ACCESS_SECRET'),
-        expiresIn: '15m',
-      },
-    );
-    return `Bearer ${token}`;
-  };
-
-  const mockLibrary: Library = {
-    id: 'library-123',
-    userId: 'user-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockAlbum: AlbumWithRelations = {
-    id: 'album-123',
-    name: 'Test Album',
-    description: 'Test Description',
-    type: 'album',
-    totalTracks: 10,
-    totalDuration: 3000,
-    releaseDate: new Date(),
-    coverId: null,
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    artists: [],
-    genres: [],
-    tracks: [],
-    cover: null,
-    access: [
-      {
-        id: 'access-123',
-        userId: 'user-123',
-        role: 'owner',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        albumId: 'album-123',
-      },
-    ],
-  };
-
-  const mockLibraryAlbum: LibraryAlbumWithRelations = {
-    id: 'lib-album-123',
-    libraryId: 'library-123',
-    albumId: 'album-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    album: mockAlbum,
-  };
-
-  const mockImage: Image = {
-    id: 'img-123',
-    alt: null,
-    bucket: 'public',
-    key: 'test-key.webp',
-    url: 'https://cdn.example.com/test.webp',
-    mimeType: 'image/webp',
-    blurhash: null,
-    reportId: null,
-    uploadStatus: 'uploaded',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
 
   describe('POST /library/albums', () => {
     it('should create an album successfully (201)', async () => {
@@ -395,12 +335,11 @@ describe('LibraryAlbumsController (Integration)', () => {
         async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
       );
 
-      const mockCoverImage: Image = {
-        ...mockImage,
+      const mockCoverImage = buildImageForIntegration({
         id: 'img-cover',
         key: 'cover.webp',
         url: 'https://cdn.example.com/cover.webp',
-      };
+      });
 
       prismaMock.client.image.create.mockResolvedValue(mockCoverImage);
 
@@ -434,20 +373,7 @@ describe('LibraryAlbumsController (Integration)', () => {
   });
 
   describe('POST /library/albums/:id/tracks/bulk', () => {
-    const mockUser: User = {
-      id: 'user-123',
-      username: 'testu',
-      firstName: 'Test',
-      lastName: 'User',
-      birthDate: null,
-      gender: null,
-      description: null,
-      password: 'hashed-password',
-      avatarId: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-    };
+    const mockUser = buildUser({ username: 'testu' });
 
     it('should create multiple tracks successfully (201)', async () => {
       const authHeader = await getAuthHeader();
@@ -456,36 +382,22 @@ describe('LibraryAlbumsController (Integration)', () => {
       prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
       prismaMock.client.album.findFirst.mockResolvedValue(mockAlbum);
 
-      const mockTrack1: Track = {
+      const mockTrack1 = buildTrack({
         id: 'track-1',
         title: 'Track 1',
         trackNumber: 1,
         diskNumber: 1,
         duration: 0,
-        listenedCount: 0,
-        explicit: false,
-        lyrics: null,
-        visibility: 'private',
         albumId: mockAlbum.id,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      };
-      const mockTrack2: Track = {
+      });
+      const mockTrack2 = buildTrack({
         id: 'track-2',
         title: 'Track 2',
         trackNumber: 2,
         diskNumber: 1,
         duration: 0,
-        listenedCount: 0,
-        explicit: false,
-        lyrics: null,
-        visibility: 'private',
         albumId: mockAlbum.id,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      };
+      });
 
       prismaMock.client.track.create
         .mockResolvedValueOnce(mockTrack1)
@@ -545,50 +457,25 @@ describe('LibraryAlbumsController (Integration)', () => {
   });
 
   describe('POST /library/albums/:id/tracks/bulk/audio', () => {
-    const mockUser: User = {
-      id: 'user-123',
-      username: 'testu',
-      firstName: 'Test',
-      lastName: 'User',
-      birthDate: null,
-      gender: null,
-      description: null,
-      password: 'hashed-password',
-      avatarId: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-    };
-
-    const mockTrackWithAccess: TrackGetPayload<{
-      include: { artists: true; album: true; access: true };
-    }> = {
+    const mockUser = buildUser({ id: DEFAULT_TEST_USER_ID, username: 'testu' });
+    const mockTrackWithAccess = buildTrackWithRelations({
       id: 'track-1',
       title: 'Track 1',
       trackNumber: 1,
       diskNumber: 1,
       duration: 0,
-      listenedCount: 0,
-      explicit: false,
-      lyrics: null,
-      visibility: 'private' as Visibility,
       albumId: mockAlbum.id,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-      artists: [],
       album: mockAlbum,
+      artists: [],
       access: [
-        {
+        buildTrackAccess({
           id: 'access-1',
-          userId: 'user-123',
-          role: 'owner',
+          userId: DEFAULT_TEST_USER_ID,
+          role: AccessRole.owner,
           trackId: 'track-1',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
+        }),
       ],
-    };
+    });
 
     it('should upload multiple audio files successfully (201)', async () => {
       const authHeader = await getAuthHeader();

--- a/apps/api/integration/library-albums.int-spec.ts
+++ b/apps/api/integration/library-albums.int-spec.ts
@@ -2,39 +2,38 @@ import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import {
-  AccessRole,
-  AudioFormat,
-  AudioQuality,
-  FileBucket,
-  LibraryAlbum,
-  PrismaClient,
-  ProcessingStatus,
+    AccessRole,
+    AudioFormat,
+    AudioQuality,
+    FileBucket,
+    PrismaClient,
+    ProcessingStatus,
 } from '@repo/db';
 import {
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildAlbumWithRelations,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildImageForIntegration,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildLibrary,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildLibraryAlbumWithRelations,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildTrack,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildTrackAccess,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildTrackWithRelations,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildUser,
-  // @ts-expect-error - ignore type errors from testing package imports
-  createAuthHeaderFactory,
-  // @ts-expect-error - ignore type errors from testing package imports
-  DEFAULT_TEST_USER_ID,
-  // @ts-expect-error - ignore type errors from testing package imports
-  PrismaServiceMock,
-  // @ts-expect-error - ignore type errors from testing package imports
-  type AlbumWithRelations
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildAlbumWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildImageForIntegration,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildLibrary,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildLibraryAlbumWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildTrack,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildTrackAccess,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildTrackWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildUser,
+    // @ts-expect-error - ignore type errors from testing package imports
+    createAuthHeaderFactory,
+    // @ts-expect-error - ignore type errors from testing package imports
+    DEFAULT_TEST_USER_ID,
+    // @ts-expect-error - ignore type errors from testing package imports
+    PrismaServiceMock,
+    // @ts-expect-error - ignore type errors from testing package imports
+    type AlbumWithRelations
 } from '@repo/testing';
 import request from 'supertest';
 import { vi } from 'vitest';
@@ -161,10 +160,9 @@ describe('LibraryAlbumsController (Integration)', () => {
       const authHeader = await getAuthHeader();
 
       prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
-      // findMany returns LibraryAlbum[] but in reality it returns LibraryAlbumWithRelations[] due to include in repository
       prismaMock.client.libraryAlbum.findMany.mockResolvedValue([
         mockLibraryAlbum,
-      ] as unknown as LibraryAlbum[]);
+      ]);
       prismaMock.client.libraryAlbum.count.mockResolvedValue(1);
 
       const response = await request(app.getHttpServer())

--- a/apps/api/integration/library-artists.int-spec.ts
+++ b/apps/api/integration/library-artists.int-spec.ts
@@ -1,20 +1,24 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { LibraryAlbum, LibraryArtist, PrismaClient } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import {
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildArtistWithRelations,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildImageForIntegration,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildLibrary,
-  // @ts-expect-error - ignore type errors from testing package imports
-  buildLibraryArtistWithRelations,
-  // @ts-expect-error - ignore type errors from testing package imports
-  createAuthHeaderFactory,
-  // @ts-expect-error - ignore type errors from testing package imports
-  PrismaServiceMock,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildAlbumWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildArtistWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildImageForIntegration,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildLibrary,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildLibraryAlbumWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    buildLibraryArtistWithRelations,
+    // @ts-expect-error - ignore type errors from testing package imports
+    createAuthHeaderFactory,
+    // @ts-expect-error - ignore type errors from testing package imports
+    PrismaServiceMock,
 } from '@repo/testing';
 import request from 'supertest';
 import { vi } from 'vitest';
@@ -125,7 +129,7 @@ describe('LibraryArtistsController (Integration)', () => {
       prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
       prismaMock.client.libraryArtist.findMany.mockResolvedValue([
         mockLibraryArtist,
-      ] as unknown as LibraryArtist[]);
+      ]);
       prismaMock.client.libraryArtist.count.mockResolvedValue(1);
 
       const response = await request(app.getHttpServer())
@@ -163,10 +167,8 @@ describe('LibraryArtistsController (Integration)', () => {
     it('should return an artist by id (200)', async () => {
       const authHeader = await getAuthHeader();
 
-      // GetLibraryArtistHandler uses libraryArtistRepository.findOne
-      // mock as unknown as LibraryArtist because findFirst returns LibraryArtist but we return LibraryArtistWithRelations
       prismaMock.client.libraryArtist.findFirst.mockResolvedValue(
-        mockLibraryArtist as unknown as LibraryArtist,
+        mockLibraryArtist,
       );
 
       const response = await request(app.getHttpServer())
@@ -269,39 +271,26 @@ describe('LibraryArtistsController (Integration)', () => {
 
       prismaMock.client.library.findUnique.mockResolvedValue(mockLibrary);
 
-      const mockLibraryAlbum = {
+      const mockLibraryAlbum = buildLibraryAlbumWithRelations({
         id: 'lib-album-1',
         libraryId: 'library-123',
         albumId: 'album-1',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-        album: {
+        album: buildAlbumWithRelations({
           id: 'album-1',
           name: 'Album 1',
-          type: 'album',
           artists: [mockArtist],
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-          coverId: null,
-          releaseDate: new Date(),
-          description: null,
-          totalTracks: 0,
-          totalDuration: 0,
-          visibility: 'public',
-        },
-      };
+        }),
+      });
 
       prismaMock.client.libraryArtist.findFirst.mockResolvedValue(
-        mockLibraryArtist as unknown as LibraryArtist,
+        mockLibraryArtist,
       );
       prismaMock.client.libraryArtist.findUnique.mockResolvedValue(
-        mockLibraryArtist as unknown as LibraryArtist,
+        mockLibraryArtist,
       );
       prismaMock.client.libraryAlbum.findMany.mockResolvedValue([
         mockLibraryAlbum,
-      ] as unknown as LibraryAlbum[]);
+      ]);
       prismaMock.client.libraryAlbum.count.mockResolvedValue(1);
 
       const response = await request(app.getHttpServer())

--- a/apps/api/integration/library-artists.int-spec.ts
+++ b/apps/api/integration/library-artists.int-spec.ts
@@ -1,39 +1,38 @@
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import { LibraryAlbum, LibraryArtist, PrismaClient } from '@repo/db';
+import {
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildArtistWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildImageForIntegration,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibrary,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibraryArtistWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  createAuthHeaderFactory,
+  // @ts-expect-error - ignore type errors from testing package imports
+  PrismaServiceMock,
+} from '@repo/testing';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { ImageService } from '../src/shared/services/image.service';
 import { StorageService } from '../src/shared/services/storage.service';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
 import './setup-env';
 import { createIntegrationApp } from './test-utils';
-import {
-  ArtistGetPayload,
-  Image,
-  Library,
-  LibraryAlbum,
-  LibraryArtist,
-  PrismaClient,
-} from '@repo/db';
-
-// Helper type for Artist with relations matching repository include
-type ArtistWithRelations = ArtistGetPayload<{
-  include: { avatar: true; banner: true };
-}>;
-
-// Helper type for LibraryArtist with relations matching repository include
-type LibraryArtistWithRelations = LibraryArtist & {
-  artist: ArtistWithRelations;
-};
 
 describe('LibraryArtistsController (Integration)', () => {
   let app: INestApplication;
   let prismaMock: PrismaServiceMock;
-  let jwtService: JwtService;
-  let config: ConfigService;
+  let getAuthHeader: ReturnType<typeof createAuthHeaderFactory>;
   let storageServiceMock: { uploadFile: any; deleteFile: any };
   let imageServiceMock: { validateImage: any; resizeToMaxDimension: any };
+
+  const mockLibrary = buildLibrary();
+  const mockArtist = buildArtistWithRelations();
+  const mockLibraryArtist = buildLibraryArtistWithRelations({ artist: mockArtist });
 
   beforeAll(async () => {
     storageServiceMock = {
@@ -55,8 +54,9 @@ describe('LibraryArtistsController (Integration)', () => {
 
     app = setup.app;
     prismaMock = setup.prismaMock;
-    jwtService = app.get(JwtService);
-    config = app.get(ConfigService);
+    const jwtService = app.get(JwtService);
+    const config = app.get(ConfigService);
+    getAuthHeader = createAuthHeaderFactory(jwtService, config);
   });
 
   beforeEach(() => {
@@ -66,66 +66,6 @@ describe('LibraryArtistsController (Integration)', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  const getAuthHeader = async (userId: string = 'user-123') => {
-    const token = await jwtService.signAsync(
-      { sub: userId, username: 'testuser', sessionId: 'session-123' },
-      {
-        secret: config.get('JWT_ACCESS_SECRET'),
-        expiresIn: '15m',
-      },
-    );
-    return `Bearer ${token}`;
-  };
-
-  const mockLibrary: Library = {
-    id: 'library-123',
-    userId: 'user-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockArtist: ArtistWithRelations = {
-    id: 'artist-123',
-    name: 'Test Artist',
-    description: 'Test Description',
-    isCommunity: false,
-    verified: false,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    avatarId: null,
-    bannerId: null,
-    visibility: 'private',
-    avatar: null,
-    banner: null,
-  };
-
-  const mockLibraryArtist: LibraryArtistWithRelations = {
-    id: 'lib-artist-123',
-    libraryId: 'library-123',
-    artistId: 'artist-123',
-    artist: mockArtist,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockImage: Image = {
-    id: 'img-123',
-    alt: null,
-    bucket: 'public',
-    key: 'test-key.webp',
-    url: 'https://cdn.example.com/test.webp',
-    mimeType: 'image/webp',
-    blurhash: null,
-    reportId: null,
-    uploadStatus: 'uploaded',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
 
   describe('POST /library/artists', () => {
     it('should create an artist successfully (201)', async () => {
@@ -252,7 +192,7 @@ describe('LibraryArtistsController (Integration)', () => {
   describe('PATCH /library/artists/:id', () => {
     it('should update an artist successfully (200)', async () => {
       const authHeader = await getAuthHeader();
-      const updatedArtist: ArtistWithRelations = { ...mockArtist, name: 'Updated Name' };
+      const updatedArtist = { ...mockArtist, name: 'Updated Name' };
 
       // Reset mocks specific to this test to ensure clean state
       prismaMock.client.artist.findFirst.mockReset();
@@ -393,12 +333,11 @@ describe('LibraryArtistsController (Integration)', () => {
         async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
       );
 
-      const mockAvatarImage: Image = {
-        ...mockImage,
+      const mockAvatarImage = buildImageForIntegration({
         id: 'img-avatar',
         key: 'avatar.webp',
         url: 'https://cdn.example.com/avatar.webp',
-      };
+      });
 
       prismaMock.client.image.create.mockResolvedValue(mockAvatarImage);
 
@@ -436,12 +375,11 @@ describe('LibraryArtistsController (Integration)', () => {
         async (cb: (client: PrismaClient) => Promise<any>) => cb(prismaMock.client),
       );
 
-      const mockBannerImage: Image = {
-        ...mockImage,
+      const mockBannerImage = buildImageForIntegration({
         id: 'img-banner',
         key: 'banner.webp',
         url: 'https://cdn.example.com/banner.webp',
-      };
+      });
 
       prismaMock.client.image.create.mockResolvedValue(mockBannerImage);
 

--- a/apps/api/integration/library-tracks.int-spec.ts
+++ b/apps/api/integration/library-tracks.int-spec.ts
@@ -1,44 +1,38 @@
-import { Readable } from 'stream';
 import { INestApplication } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+import { AudioFile, AudioFormat, AudioQuality, FileBucket, PrismaClient, ProcessingStatus } from '@repo/db';
 import {
-  Album,
-  Artist,
-  AudioFile,
-  AudioFormat,
-  AudioQuality,
-  FileBucket,
-  Library,
-  LibraryTrack,
-  PrismaClient,
-  ProcessingStatus,
-  TrackAccess,
-  TrackGetPayload,
-  User,
-  Visibility,
-} from '@repo/db';
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibrary,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildLibraryTrackWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildTrackWithRelations,
+  // @ts-expect-error - ignore type errors from testing package imports
+  buildUser,
+  // @ts-expect-error - ignore type errors from testing package imports
+  createAuthHeaderFactory,
+  // @ts-expect-error - ignore type errors from testing package imports
+  PrismaServiceMock,
+} from '@repo/testing';
+import { Readable } from 'stream';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { StorageService } from '../src/shared/services/storage.service';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
 import './setup-env';
 import { createIntegrationApp } from './test-utils';
-
-type TrackWithRelations = TrackGetPayload<{
-  include: { artists: true; album: true; access: true };
-}>;
-
-type LibraryTrackWithRelations = LibraryTrack & {
-  track: TrackWithRelations;
-};
 
 describe('LibraryTracksController (Integration)', () => {
   let app: INestApplication;
   let prismaMock: PrismaServiceMock;
-  let jwtService: JwtService;
-  let config: ConfigService;
+  let getAuthHeader: ReturnType<typeof createAuthHeaderFactory>;
   let storageServiceMock: { getFileStream: any };
+
+  const mockUser = buildUser({ username: 'testu' });
+  const mockLibrary = buildLibrary();
+  const mockTrack = buildTrackWithRelations();
+  const mockLibraryTrack = buildLibraryTrackWithRelations({ track: mockTrack });
 
   beforeAll(async () => {
     storageServiceMock = {
@@ -51,8 +45,9 @@ describe('LibraryTracksController (Integration)', () => {
 
     app = setup.app;
     prismaMock = setup.prismaMock;
-    jwtService = app.get(JwtService);
-    config = app.get(ConfigService);
+    const jwtService = app.get(JwtService);
+    const config = app.get(ConfigService);
+    getAuthHeader = createAuthHeaderFactory(jwtService, config);
   });
 
   beforeEach(() => {
@@ -62,107 +57,6 @@ describe('LibraryTracksController (Integration)', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  const getAuthHeader = async (userId: string = 'user-123') => {
-    const token = await jwtService.signAsync(
-      { sub: userId, username: 'testuser', sessionId: 'session-123' },
-      {
-        secret: config.get('JWT_ACCESS_SECRET'),
-        expiresIn: '15m',
-      },
-    );
-    return `Bearer ${token}`;
-  };
-
-  const mockUser: User = {
-    id: 'user-123',
-    username: 'testu',
-    firstName: 'Test',
-    lastName: 'User',
-    birthDate: null,
-    gender: null,
-    description: null,
-    password: 'hashed-password',
-    avatarId: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockLibrary: Library = {
-    id: 'library-123',
-    userId: 'user-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockTrack: TrackWithRelations = {
-    id: 'track-123',
-    title: 'Test Track',
-    trackNumber: 1,
-    diskNumber: 1,
-    duration: 180,
-    listenedCount: 0,
-    explicit: false,
-    lyrics: null,
-    visibility: 'private' as Visibility,
-    albumId: 'album-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    album: {
-      id: 'album-123',
-      name: 'Test Album',
-      description: 'Test Description',
-      type: 'album',
-      totalTracks: 10,
-      totalDuration: 3000,
-      releaseDate: new Date(),
-      coverId: null,
-      visibility: 'public' as Visibility,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-    } as Album,
-    artists: [
-      {
-        id: 'artist-123',
-        name: 'Test Artist',
-        description: 'Test Description',
-        isCommunity: false,
-        verified: true,
-        bannerId: null,
-        avatarId: null,
-        visibility: 'public' as Visibility,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      } as Artist,
-    ],
-    access: [
-      {
-        id: 'access-123',
-        userId: 'user-123',
-        role: 'owner',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        trackId: 'track-123',
-      } as TrackAccess,
-    ],
-  };
-
-  const mockLibraryTrack: LibraryTrackWithRelations = {
-    id: 'lib-track-123',
-    libraryId: 'library-123',
-    trackId: 'track-123',
-    listenedCount: 0,
-    listenCountResetAt: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    track: mockTrack,
-  };
 
   describe('POST /library/tracks', () => {
     it('should create a track successfully (201)', async () => {

--- a/apps/api/integration/library.int-spec.ts
+++ b/apps/api/integration/library.int-spec.ts
@@ -3,21 +3,22 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import request from 'supertest';
 import { vi } from 'vitest';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
+// @ts-expect-error - ignore type errors from testing package imports
+import { createAuthHeaderFactory, PrismaServiceMock } from '@repo/testing';
 import { createIntegrationApp } from './test-utils';
 
 describe('LibraryController (Integration)', () => {
   let app: INestApplication;
   let prismaMock: PrismaServiceMock;
-  let jwtService: JwtService;
-  let config: ConfigService;
+  let getAuthHeader: ReturnType<typeof createAuthHeaderFactory>;
 
   beforeAll(async () => {
     const setup = await createIntegrationApp();
     app = setup.app;
     prismaMock = setup.prismaMock;
-    jwtService = app.get(JwtService);
-    config = app.get(ConfigService);
+    const jwtService = app.get(JwtService);
+    const config = app.get(ConfigService);
+    getAuthHeader = createAuthHeaderFactory(jwtService, config);
   });
 
   beforeEach(() => {
@@ -27,17 +28,6 @@ describe('LibraryController (Integration)', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  const getAuthHeader = async (userId: string = 'user-123') => {
-    const token = await jwtService.signAsync(
-      { sub: userId, username: 'testuser', sessionId: 'session-123' },
-      {
-        secret: config.get('JWT_ACCESS_SECRET'),
-        expiresIn: '15m',
-      },
-    );
-    return `Bearer ${token}`;
-  };
 
   describe('POST /library', () => {
     it('should create a library successfully (201)', async () => {

--- a/apps/api/integration/mocks/prisma.service.mock.ts
+++ b/apps/api/integration/mocks/prisma.service.mock.ts
@@ -1,4 +1,0 @@
-// @ts-expect-error - ignore type errors from testing package imports
-import { PrismaServiceMock } from '@repo/testing';
-
-export { PrismaServiceMock };

--- a/apps/api/integration/test-utils.ts
+++ b/apps/api/integration/test-utils.ts
@@ -10,8 +10,9 @@ import { vi } from 'vitest';
 import { AppModule } from '../src/app.module';
 import { GlobalExceptionFilter } from '../src/common/filters/global-exception.filter';
 import { ResponseInterceptor } from '../src/common/interceptors/response.interceptor';
+// @ts-expect-error - ignore type errors from testing package imports
+import { PrismaServiceMock } from '@repo/testing';
 import { PrismaService } from '../src/shared/services/prisma.service';
-import { PrismaServiceMock } from './mocks/prisma.service.mock';
 
 // Mock BullMQ to avoid Redis connections in integration tests
 vi.mock('@nestjs/bullmq', async () => {

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -1,6 +1,8 @@
 export * from "./builders";
 export * from "./execution-context";
 export * from "./express-mocks";
+export * from "./integration";
 export * from "./prisma";
 export * from "./prisma-service-mock";
 export * from "./unit-of-work";
+

--- a/packages/testing/src/api/integration/auth.ts
+++ b/packages/testing/src/api/integration/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Default user ID used across integration test fixtures.
+ * Use this when building users and access records to ensure JWT sub, request.user, and mocks align.
+ */
+export const DEFAULT_TEST_USER_ID = 'user-123' as const;
+
+/**
+ * Factory that accepts JwtService + ConfigService from the bootstrapped app.
+ * Use in integration tests to create auth headers without duplicating JWT logic.
+ */
+export function createAuthHeaderFactory(
+  jwtService: {
+    signAsync: (
+      payload: object,
+      opts: { secret: string; expiresIn: string },
+    ) => Promise<string>;
+  },
+  config: { get: (key: string) => string },
+) {
+  return async (userId = DEFAULT_TEST_USER_ID) => {
+    const token = await jwtService.signAsync(
+      { sub: userId, username: 'testuser', sessionId: 'session-123' },
+      { secret: config.get('JWT_ACCESS_SECRET'), expiresIn: '15m' },
+    );
+    return `Bearer ${token}`;
+  };
+}

--- a/packages/testing/src/api/integration/fixtures.ts
+++ b/packages/testing/src/api/integration/fixtures.ts
@@ -1,0 +1,205 @@
+import type {
+    AlbumGetPayload,
+    ArtistGetPayload,
+    LibraryAlbum,
+    LibraryArtist,
+    LibraryTrack,
+    TrackGetPayload,
+} from "@repo/db";
+import { AccessRole, AlbumType, FileBucket, Visibility } from "@repo/db";
+import { buildWithOverrides } from "../../shared";
+import { buildAlbumAccess, buildTrackAccess } from "../models/acl";
+import { buildAlbum, buildArtist, buildTrack } from "../models/catalog";
+import { buildLibraryAlbum, buildLibraryArtist, buildLibraryTrack } from "../models/library";
+import { buildImage } from "../models/media";
+
+// Types matching repository include shapes for integration test mocks
+
+export type AlbumWithRelations = AlbumGetPayload<{
+  include: { artists: true; genres: true; tracks: true; access: true; cover: true };
+}>;
+
+export type LibraryAlbumWithRelations = LibraryAlbum & {
+  album: AlbumWithRelations;
+};
+
+export type TrackWithRelations = TrackGetPayload<{
+  include: { artists: true; album: true; access: true };
+}>;
+
+export type LibraryTrackWithRelations = LibraryTrack & {
+  track: TrackWithRelations;
+};
+
+export type ArtistWithRelations = ArtistGetPayload<{
+  include: { avatar: true; banner: true };
+}>;
+
+export type LibraryArtistWithRelations = LibraryArtist & {
+  artist: ArtistWithRelations;
+};
+
+// Relation builders for integration tests
+
+export function buildAlbumWithRelations(
+  overrides: Partial<AlbumWithRelations> = {},
+): AlbumWithRelations {
+  const album = buildAlbum({
+    id: "album-123",
+    name: "Test Album",
+    description: "Test Description",
+    type: AlbumType.album,
+    totalTracks: 10,
+    totalDuration: 3000,
+    visibility: Visibility.private,
+    ...overrides,
+  });
+  const access = [
+    buildAlbumAccess({
+      id: "access-123",
+      userId: "user-123",
+      role: AccessRole.owner,
+      albumId: album.id,
+    }),
+  ];
+  const base: AlbumWithRelations = {
+    ...album,
+    artists: overrides.artists ?? [],
+    genres: overrides.genres ?? [],
+    tracks: overrides.tracks ?? [],
+    cover: overrides.cover ?? null,
+    access,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+export function buildLibraryAlbumWithRelations(
+  overrides: Partial<LibraryAlbumWithRelations> = {},
+): LibraryAlbumWithRelations {
+  const { album: albumOverrides, ...restOverrides } = overrides;
+  const album = buildAlbumWithRelations(
+    (albumOverrides as Partial<AlbumWithRelations>) ?? {},
+  );
+  const libraryAlbum = buildLibraryAlbum({
+    libraryId: "library-123",
+    albumId: album.id,
+    ...restOverrides,
+  });
+  const base: LibraryAlbumWithRelations = {
+    ...libraryAlbum,
+    album,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+export function buildTrackWithRelations(
+  overrides: Partial<TrackWithRelations> = {},
+): TrackWithRelations {
+  const album = buildAlbum({
+    id: "album-123",
+    name: "Test Album",
+    description: "Test Description",
+    type: AlbumType.album,
+    totalTracks: 10,
+    totalDuration: 3000,
+    visibility: Visibility.public,
+  });
+  const track = buildTrack({
+    id: "track-123",
+    title: "Test Track",
+    albumId: album.id,
+    visibility: Visibility.private,
+    ...overrides,
+  });
+  const artist = buildArtist({
+    id: "artist-123",
+    name: "Test Artist",
+    description: "Test Description",
+    verified: true,
+  });
+  const access = [
+    buildTrackAccess({
+      id: "access-123",
+      userId: "user-123",
+      role: AccessRole.owner,
+      trackId: track.id,
+    }),
+  ];
+  const base: TrackWithRelations = {
+    ...track,
+    album,
+    artists: overrides.artists ?? [artist],
+    access,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+export function buildLibraryTrackWithRelations(
+  overrides: Partial<LibraryTrackWithRelations> = {},
+): LibraryTrackWithRelations {
+  const { track: trackOverrides, ...restOverrides } = overrides;
+  const track = buildTrackWithRelations(
+    (trackOverrides as Partial<TrackWithRelations>) ?? {},
+  );
+  const libraryTrack = buildLibraryTrack({
+    libraryId: "library-123",
+    trackId: track.id,
+    ...restOverrides,
+  });
+  const base: LibraryTrackWithRelations = {
+    ...libraryTrack,
+    track,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+export function buildArtistWithRelations(
+  overrides: Partial<ArtistWithRelations> = {},
+): ArtistWithRelations {
+  const artist = buildArtist({
+    id: "artist-123",
+    name: "Test Artist",
+    description: "Test Description",
+    visibility: Visibility.private,
+    ...overrides,
+  });
+  const base: ArtistWithRelations = {
+    ...artist,
+    avatar: overrides.avatar ?? null,
+    banner: overrides.banner ?? null,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+export function buildLibraryArtistWithRelations(
+  overrides: Partial<LibraryArtistWithRelations> = {},
+): LibraryArtistWithRelations {
+  const { artist: artistOverrides, ...restOverrides } = overrides;
+  const artist = buildArtistWithRelations(
+    (artistOverrides as Partial<ArtistWithRelations>) ?? {},
+  );
+  const libraryArtist = buildLibraryArtist({
+    libraryId: "library-123",
+    artistId: artist.id,
+    ...restOverrides,
+  });
+  const base: LibraryArtistWithRelations = {
+    ...libraryArtist,
+    artist,
+  };
+  return buildWithOverrides(base, overrides);
+}
+
+// Re-export buildImage with common integration overrides (public bucket, webp)
+export function buildImageForIntegration(
+  overrides: Partial<Parameters<typeof buildImage>[0]> = {},
+) {
+  return buildImage({
+    id: "img-123",
+    bucket: FileBucket.public,
+    key: "test-key.webp",
+    url: "https://cdn.example.com/test.webp",
+    mimeType: "image/webp",
+    ...overrides,
+  });
+}

--- a/packages/testing/src/api/integration/index.ts
+++ b/packages/testing/src/api/integration/index.ts
@@ -1,0 +1,3 @@
+export * from "./auth";
+export * from "./fixtures";
+


### PR DESCRIPTION
test(packages/testing): add integration test auth utilities and fixture builders

refactor(apps/api): remove redundant PrismaServiceMock from api tests

refactor(apps/api): use @repo/testing utilities in integration tests

Replace inline mock definitions with builder functions from @repo/testing package in library-albums, library-artists, library-tracks, and library integration tests. Also use createAuthHeaderFactory for consistent auth header creation across tests.