### PR TITLE
refactor: extract shared tsup configurations to centralized configs package

### DIFF
--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -1,34 +1,4 @@
+import { nestjsConfig } from '@repo/configs/tsup/nestjs';
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ['src/main.ts'],
-  format: ['esm'],
-  target: 'esnext',
-  platform: 'node',
-  outDir: 'dist',
-  clean: true,
-  sourcemap: true,
-  treeshake: true,
-  splitting: false,
-  publicDir: 'src/assets',
-  // Path aliases from tsconfig
-  tsconfig: './tsconfig.build.json',
-  // Keep class names for Nest DI
-  esbuildOptions(options) {
-    options.keepNames = true;
-  },
-  // Externalize workspace packages (they're built separately)
-  external: [
-    '@repo/db',
-    '@repo/contracts',
-    'crypto',
-    'fs',
-    'http',
-    'https',
-    'net',
-    'os',
-    'path',
-    'stream',
-    'util',
-  ],
-});
+export default defineConfig(nestjsConfig);

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -12,7 +12,10 @@
     "./eslint/react": "./src/eslint/react.js",
     "./eslint/nestjs": "./src/eslint/nestjs.js",
     "./eslint/packages": "./src/eslint/packages.js",
-    "./prettier": "./src/prettier/base.json"
+    "./prettier": "./src/prettier/base.json",
+    "./tsup/base": "./src/tsup/base.js",
+    "./tsup/packages": "./src/tsup/packages.js",
+    "./tsup/nestjs": "./src/tsup/nestjs.js"
   },
   "dependencies": {
     "@eslint/js": "^9.39.2",
@@ -28,6 +31,7 @@
   "peerDependencies": {
     "eslint": "catalog:",
     "prettier": "catalog:",
+    "tsup": "^8.5.1",
     "typescript": "catalog:"
   }
 }

--- a/packages/configs/src/tsup/base.js
+++ b/packages/configs/src/tsup/base.js
@@ -1,0 +1,6 @@
+/** @type {import('tsup').Options} */
+export const baseConfig = {
+  format: ['esm'],
+  clean: true,
+  sourcemap: true,
+};

--- a/packages/configs/src/tsup/nestjs.js
+++ b/packages/configs/src/tsup/nestjs.js
@@ -1,0 +1,30 @@
+import { baseConfig } from './base.js';
+
+/** @type {import('tsup').Options} */
+export const nestjsConfig = {
+  ...baseConfig,
+  entry: ['src/main.ts'],
+  target: 'esnext',
+  platform: 'node',
+  outDir: 'dist',
+  treeshake: true,
+  splitting: false,
+  publicDir: 'src/assets',
+  tsconfig: './tsconfig.build.json',
+  esbuildOptions(options) {
+    options.keepNames = true;
+  },
+  external: [
+    '@repo/db',
+    '@repo/contracts',
+    'crypto',
+    'fs',
+    'http',
+    'https',
+    'net',
+    'os',
+    'path',
+    'stream',
+    'util',
+  ],
+};

--- a/packages/configs/src/tsup/packages.js
+++ b/packages/configs/src/tsup/packages.js
@@ -1,0 +1,8 @@
+import { baseConfig } from './base.js';
+
+/** @type {import('tsup').Options} */
+export const packagesConfig = {
+  ...baseConfig,
+  entry: ['src/index.ts'],
+  dts: true,
+};

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,4 +1,4 @@
-import { packagesConfig } from '@repo/configs/tsup/packages';
-import { defineConfig } from 'tsup';
+import { packagesConfig } from "@repo/configs/tsup/packages";
+import { defineConfig } from "tsup";
 
 export default defineConfig(packagesConfig);

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,9 +1,4 @@
-import { defineConfig } from "tsup";
+import { packagesConfig } from '@repo/configs/tsup/packages';
+import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-});
+export default defineConfig(packagesConfig);

--- a/packages/db/tsup.config.ts
+++ b/packages/db/tsup.config.ts
@@ -1,4 +1,4 @@
-import { packagesConfig } from '@repo/configs/tsup/packages';
-import { defineConfig } from 'tsup';
+import { packagesConfig } from "@repo/configs/tsup/packages";
+import { defineConfig } from "tsup";
 
 export default defineConfig(packagesConfig);

--- a/packages/db/tsup.config.ts
+++ b/packages/db/tsup.config.ts
@@ -1,9 +1,4 @@
-import { defineConfig } from "tsup";
+import { packagesConfig } from '@repo/configs/tsup/packages';
+import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-});
+export default defineConfig(packagesConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,6 +647,9 @@ importers:
       prettier-plugin-packagejson:
         specifier: ^3.0.0
         version: 3.0.0(prettier@3.8.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.18)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
build(packages/configs): add shared tsup configurations

- Add tsup to peer dependencies
- Export base, nestjs, and packages tsup configurations to support standardized ESM builds across the monorepo

build(deps): update pnpm-lock.yaml

build(config): migrate to shared tsup configurations

Replace local tsup configurations in apps/api, packages/contracts, and packages/db with the shared configurations from @repo/configs/tsup.

style: formatted files via prettier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build infrastructure by centralizing build configuration management across packages. Previously duplicated configuration settings are now unified in a centralized system, enhancing maintainability and consistency. This internal improvement has no impact on product functionality or end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->