### PR TITLE
build(apps/api): configure swc for typescript decorators

### DIFF
--- a/.cursor/rules/api-testing.mdc
+++ b/.cursor/rules/api-testing.mdc
@@ -1,6 +1,6 @@
 ---
 alwaysApply: false
-globs: ["**/*.spec.ts", "**/*.int-spec.ts", "packages/testing/**/*.ts"]
+globs: ["**/*.spec.ts", "**/*.int-spec.ts"]
 ---
 
 # API Testing Standards

--- a/.cursor/rules/api-testing.mdc
+++ b/.cursor/rules/api-testing.mdc
@@ -1,0 +1,47 @@
+---
+alwaysApply: false
+globs: ["**/*.spec.ts", "**/*.int-spec.ts", "packages/testing/**/*.ts"]
+---
+
+# API Testing Standards
+
+## Test Location and Package Roles
+
+- **Unit and integration tests** live inside the project itself (e.g. `apps/api/src/**/*.spec.ts`, `apps/api/integration/**/*.int-spec.ts`).
+- **E2e tests** have their own app using Playwright.
+- **`@repo/testing`** is for utilities only: mock builders, `createMockFile`, `createMock`, etc. No tests belong in the testing package.
+
+## When to Use Unit vs Integration Tests
+
+- **Unit tests** (`*.spec.ts`): Test handlers, services, repositories in isolation with mocked dependencies. Fast, focused on business logic.
+- **Integration tests** (`*.int-spec.ts`): Test HTTP endpoints end-to-end with mocked Prisma. Verify controller + handler + repository flow.
+
+## File Naming and Config
+
+- Unit: `**/*.spec.ts` → `vitest.config.mts`
+- Integration: `integration/**/*.int-spec.ts` → `vitest.config.integration.mts`
+
+## Unit Test Structure
+
+1. Use `createMock<T>()` and `DeepMocked<T>` from `@repo/testing/nestjs`
+2. Use builders from `@repo/testing` for entities: `trackBuilder`, `albumBuilder`, `libraryBuilder`, etc.
+3. Define stable IDs in describe scope for cross-entity relations
+4. `afterEach`: always `vi.clearAllMocks()`; add `vi.restoreAllMocks()` only when using `vi.spyOn`
+5. For `UnitOfWorkService`: `unitOfWork.runInTransaction.mockImplementation(async (cb) => cb())`
+6. For BullMQ: `getQueueToken('queue-name')` with `useValue: createMock<Queue>()`
+
+## Mock Management
+
+- **Shared mocks**: Use `createMockFile` from `@repo/testing` for `Express.Multer.File`
+- **Track with access**: Use `trackWithAccessBuilder` from `@repo/testing` for permission tests
+- **Relations**: Build parent entities first with stable IDs, then children referencing them
+- **Factory functions**: Use parametrized helpers (e.g. `mockTrackWithAccess(trackId, albumId)`) when structure varies by ID
+
+## Integration Test Structure
+
+1. Use `createIntegrationApp()` from `integration/test-utils`
+2. Mock Prisma via `prismaMock.client.*.mockResolvedValue(...)`
+3. Use builders for all Prisma return values
+4. For transactions: `prismaMock.mainClient.$transaction.mockImplementation(async (cb) => cb(prismaMock.client))`
+5. Auth: sign JWT with `jwtService.signAsync({ sub: userId, ... })` for `Authorization: Bearer <token>`
+6. Override external services: `createIntegrationApp((b) => b.overrideProvider(StorageService).useValue(mock))`

--- a/apps/api/src/common/config/env.schema.spec.ts
+++ b/apps/api/src/common/config/env.schema.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateEnv } from './env.schema';
 
 describe('envSchema', () => {
@@ -15,8 +15,12 @@ describe('envSchema', () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should validate a correct config and return parsed data', () => {

--- a/apps/api/src/common/decorators/current-user.decorator.spec.ts
+++ b/apps/api/src/common/decorators/current-user.decorator.spec.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext } from '@nestjs/common';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { User } from '@repo/db';
+import { userBuilder } from '@repo/testing';
 import { describe, expect, it } from 'vitest';
 import { AuthenticatedUser } from '../types/auth.types';
 import { CurrentUser } from './current-user.decorator';
@@ -18,11 +19,10 @@ function getParamDecoratorFactory(decorator: (...args: any[]) => ParameterDecora
 describe('CurrentUser Decorator', () => {
   const factory = getParamDecoratorFactory(CurrentUser);
 
-  const mockUser = {
+  const mockUser = userBuilder({
     id: 'user-123',
     username: 'testuser',
-    email: 'test@example.com',
-  } as unknown as User;
+  });
 
   const createMockContext = (user: User | null): ExecutionContext =>
     ({

--- a/apps/api/src/common/filters/global-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/global-exception.filter.spec.ts
@@ -1,4 +1,4 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { ArgumentsHost, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
@@ -17,6 +17,7 @@ describe('GlobalExceptionFilter', () => {
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 

--- a/apps/api/src/common/interceptors/response.interceptor.spec.ts
+++ b/apps/api/src/common/interceptors/response.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { DeepMocked, createMock } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { CallHandler, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';

--- a/apps/api/src/common/middleware/request-id.middleware.spec.ts
+++ b/apps/api/src/common/middleware/request-id.middleware.spec.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RequestIdMiddleware } from './request-id.middleware';
 
 describe('RequestIdMiddleware', () => {
@@ -17,6 +17,11 @@ describe('RequestIdMiddleware', () => {
       setHeader: vi.fn(),
     };
     nextFunction = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should generate a new request ID if header is missing', () => {
@@ -46,7 +51,6 @@ describe('RequestIdMiddleware', () => {
     middleware.use(mockRequest as Request, mockResponse as Response, nextFunction);
 
     expect(mockRequest.startTime).toBe(now);
-    vi.restoreAllMocks();
   });
 
   it('should handle x-request-id being an array', () => {

--- a/apps/api/src/features/audio-processing/audio-processing.utils.spec.ts
+++ b/apps/api/src/features/audio-processing/audio-processing.utils.spec.ts
@@ -1,3 +1,5 @@
+import { trackWithAccessBuilder } from '@repo/testing';
+import { AccessRole } from '@repo/db';
 import { describe, expect, it } from 'vitest';
 import { canUserUpdateTrackDuration } from './audio-processing.utils';
 
@@ -10,25 +12,37 @@ describe('audio-processing.utils', () => {
 
     it('should return true when user is owner', () => {
       expect(
-        canUserUpdateTrackDuration({ access: [{ userId: 'user-1', role: 'owner' }] }, 'user-1'),
+        canUserUpdateTrackDuration(
+          trackWithAccessBuilder({ userId: 'user-1', role: AccessRole.owner }),
+          'user-1',
+        ),
       ).toBe(true);
     });
 
     it('should return true when user is editor', () => {
       expect(
-        canUserUpdateTrackDuration({ access: [{ userId: 'user-1', role: 'editor' }] }, 'user-1'),
+        canUserUpdateTrackDuration(
+          trackWithAccessBuilder({ userId: 'user-1', role: AccessRole.editor }),
+          'user-1',
+        ),
       ).toBe(true);
     });
 
     it('should return false when user is viewer', () => {
       expect(
-        canUserUpdateTrackDuration({ access: [{ userId: 'user-1', role: 'viewer' }] }, 'user-1'),
+        canUserUpdateTrackDuration(
+          trackWithAccessBuilder({ userId: 'user-1', role: AccessRole.viewer }),
+          'user-1',
+        ),
       ).toBe(false);
     });
 
     it('should return false when userId does not match', () => {
       expect(
-        canUserUpdateTrackDuration({ access: [{ userId: 'other-user', role: 'owner' }] }, 'user-1'),
+        canUserUpdateTrackDuration(
+          trackWithAccessBuilder({ userId: 'other-user', role: AccessRole.owner }),
+          'user-1',
+        ),
       ).toBe(false);
     });
   });

--- a/apps/api/src/features/audio-processing/audio-processing.worker.spec.ts
+++ b/apps/api/src/features/audio-processing/audio-processing.worker.spec.ts
@@ -1,17 +1,11 @@
 import { AudioFileRepository } from '@/shared/repositories/audio-file.repository';
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { StorageService } from '@/shared/services/storage.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { audioFileBuilder, trackWithAccessBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { Logger, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  AudioFile,
-  AudioFormat,
-  AudioQuality,
-  FileBucket,
-  ProcessingStatus,
-  Track,
-} from '@repo/db';
+import { AccessRole, AudioFormat, AudioQuality, ProcessingStatus } from '@repo/db';
 import { Job } from 'bullmq';
 import * as fs from 'fs/promises';
 import * as mm from 'music-metadata';
@@ -22,45 +16,6 @@ import { WaveformService } from './waveform.service';
 
 vi.mock('fs/promises');
 vi.mock('music-metadata');
-
-const createAudioFileFixture = (overrides: Partial<AudioFile> = {}): AudioFile => ({
-  id: 'af-123',
-  bucket: FileBucket.private,
-  key: 'path/to/original.mp3',
-  url: null,
-  mimeType: 'audio/mpeg',
-  size: 1234,
-  format: AudioFormat.mp3,
-  duration: null,
-  bitrate: null,
-  sampleRate: null,
-  channels: null,
-  isOriginal: true,
-  waveformJson: null,
-  trackId: 'tr-123',
-  quality: AudioQuality.original,
-  status: ProcessingStatus.pending,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  ...overrides,
-});
-
-const createTrackFixture = (overrides: Partial<Track> = {}): Track => ({
-  id: 'tr-123',
-  title: 'Test Track',
-  trackNumber: 1,
-  diskNumber: 1,
-  duration: 0,
-  listenedCount: 0,
-  explicit: false,
-  lyrics: null,
-  visibility: 'private',
-  albumId: 'album-123',
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  deletedAt: null,
-  ...overrides,
-});
 
 const createMockJob = (
   data: AudioProcessingJobData,
@@ -124,6 +79,7 @@ describe('AudioProcessingWorker', () => {
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
@@ -179,18 +135,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should process audio file successfully for non-lossless', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       await worker.process(mockJob);
@@ -209,18 +168,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should process audio file successfully for lossless', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.flac,
           key: 'path/to/original.flac',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 120 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 120,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       await worker.process(mockJob);
@@ -231,18 +193,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should process WAV file and create original FLAC with undefined bitrate', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.wav,
           key: 'path/to/original.wav',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       await worker.process(mockJob);
@@ -257,7 +222,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should handle track not found exception', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
@@ -274,7 +239,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should catch global errors and mark as failed', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
@@ -290,7 +255,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should process audio file and not update duration if missing from metadata', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
@@ -313,7 +278,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should process audio file and not update track if access role is invalid', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
@@ -323,11 +288,14 @@ describe('AudioProcessingWorker', () => {
       vi.mocked(mm.parseFile).mockResolvedValue({
         format: { duration: 120 },
       } as mm.IAudioMetadata);
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'viewer' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.viewer,
+        }),
+      );
 
       await worker.process(mockJob);
       expect(trackRepository.update).not.toHaveBeenCalled();
@@ -335,7 +303,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should skip transcoding if quality and format match', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           quality: AudioQuality.low,
@@ -346,11 +314,14 @@ describe('AudioProcessingWorker', () => {
       vi.mocked(mm.parseFile).mockResolvedValue({
         format: { duration: 120 },
       } as mm.IAudioMetadata);
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       await worker.process(mockJob);
@@ -359,18 +330,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should log error if transcode fails for one quality and continue', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.wav,
           key: 'path/to/original.wav',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       transcodeService.transcode
@@ -386,18 +360,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should use temp dir prefix with job id', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       const jobWithId = createMockJob(
@@ -416,18 +393,21 @@ describe('AudioProcessingWorker', () => {
 
     it('should fallback to unknown job id when job id is missing', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
         }),
       );
       storageService.getFile.mockResolvedValue(Buffer.from('input'));
-      const trackWithAccess: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 0 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithAccess);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 0,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       const jobWithoutId = createMock<Job<AudioProcessingJobData>>({
@@ -442,7 +422,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should skip track update if rounded duration matches existing duration', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',
@@ -457,11 +437,14 @@ describe('AudioProcessingWorker', () => {
           numberOfChannels: 2,
         },
       } as mm.IAudioMetadata);
-      const trackWithSameDuration: Track & { access: { userId: string; role: string }[] } = {
-        ...createTrackFixture({ id: 'tr-123', duration: 120 }),
-        access: [{ userId: 'user-123', role: 'owner' }],
-      };
-      trackRepository.findOne.mockResolvedValue(trackWithSameDuration);
+      trackRepository.findOne.mockResolvedValue(
+        trackWithAccessBuilder({
+          id: 'tr-123',
+          duration: 120,
+          userId: 'user-123',
+          role: AccessRole.owner,
+        }),
+      );
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
 
       await worker.process(mockJob);
@@ -471,7 +454,7 @@ describe('AudioProcessingWorker', () => {
 
     it('should log warning if temp dir cleanup fails', async () => {
       audioFileRepository.findOne.mockResolvedValue(
-        createAudioFileFixture({
+        audioFileBuilder({
           id: 'af-123',
           format: AudioFormat.mp3,
           key: 'path/to/original.mp3',

--- a/apps/api/src/features/audio-processing/audio-transcode.service.spec.ts
+++ b/apps/api/src/features/audio-processing/audio-transcode.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AudioFormat } from '@repo/db';
 import ffmpeg from 'fluent-ffmpeg';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AudioTranscodeService } from './audio-transcode.service';
 
 vi.mock('fluent-ffmpeg');
@@ -15,6 +15,10 @@ describe('AudioTranscodeService', () => {
     }).compile();
 
     service = module.get<AudioTranscodeService>(AudioTranscodeService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('should be defined', () => {

--- a/apps/api/src/features/audio-processing/waveform.service.spec.ts
+++ b/apps/api/src/features/audio-processing/waveform.service.spec.ts
@@ -18,6 +18,7 @@ describe('WaveformService', () => {
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 

--- a/apps/api/src/features/auth/commands/handlers/login.handler.spec.ts
+++ b/apps/api/src/features/auth/commands/handlers/login.handler.spec.ts
@@ -2,8 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LoginHandler } from './login.handler';
 import { LoginCommand } from '../impl/login.command';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
-import { User, Gender } from '@repo/db';
+import { userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { Gender } from '@repo/db';
 import { UserSchema } from '@repo/contracts';
 import { TokenService } from '../../services/token.service';
 
@@ -11,7 +12,7 @@ describe('LoginHandler', () => {
   let handler: LoginHandler;
   let tokenService: DeepMocked<TokenService>;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -19,12 +20,7 @@ describe('LoginHandler', () => {
     lastName: 'Doe',
     birthDate: '2000-01-01',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    avatarId: null,
-    description: null,
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     tokenService = createMock<TokenService>();
@@ -80,14 +76,14 @@ describe('LoginHandler', () => {
 
     it('should handle user with minimal fields', async () => {
       // Arrange
-      const minimalUser: User = {
+      const minimalUser = userBuilder({
         ...mockUser,
         lastName: null,
         birthDate: null,
         gender: null,
         description: null,
         avatarId: null,
-      };
+      });
 
       tokenService.generateAuthTokens.mockResolvedValue({
         accessToken: 'access-token',

--- a/apps/api/src/features/auth/commands/handlers/logout.handler.spec.ts
+++ b/apps/api/src/features/auth/commands/handlers/logout.handler.spec.ts
@@ -4,7 +4,7 @@ import { LogoutCommand } from '../impl/logout.command';
 import { SessionRepository } from '../../../../shared/repositories/session.repository';
 import { RefreshTokenRepository } from '../../../../shared/repositories/refresh-token.repository';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 
 describe('LogoutHandler', () => {
   let handler: LogoutHandler;

--- a/apps/api/src/features/auth/commands/handlers/refresh-tokens.handler.spec.ts
+++ b/apps/api/src/features/auth/commands/handlers/refresh-tokens.handler.spec.ts
@@ -1,7 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { User } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionRepository } from '../../../../shared/repositories/session.repository';
 import { UserRepository } from '../../../../shared/repositories/user.repository';
@@ -53,10 +53,9 @@ describe('RefreshTokensHandler', () => {
         isRevoked: false,
       });
 
-      userRepository.getById.mockResolvedValue({
-        id: mockUserId,
-        username: 'test-user',
-      } as User);
+      userRepository.getById.mockResolvedValue(
+        userBuilder({ id: mockUserId, username: 'test-user' }),
+      );
 
       tokenService.generateAuthTokens.mockResolvedValue({
         accessToken: 'new-access-token',

--- a/apps/api/src/features/auth/commands/handlers/refresh-tokens.handler.spec.ts
+++ b/apps/api/src/features/auth/commands/handlers/refresh-tokens.handler.spec.ts
@@ -34,6 +34,7 @@ describe('RefreshTokensHandler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should be defined', () => {

--- a/apps/api/src/features/auth/commands/handlers/register.handler.spec.ts
+++ b/apps/api/src/features/auth/commands/handlers/register.handler.spec.ts
@@ -5,10 +5,11 @@ import { UserRepository } from '@/shared/repositories/user.repository';
 import { HashingService } from '@/shared/services/hashing.service';
 import { PrismaService } from '@/shared/services/prisma.service';
 import { ConflictException } from '@nestjs/common';
-import { EmailStatus, User, Gender } from '@repo/db';
+import { EmailStatus, Gender } from '@repo/db';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { RegisterRequestDto } from '../../dto/register.request.dto';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { emailAddressBuilder, userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PrismaClient } from '@repo/db';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
 import { UserSchema } from '@repo/contracts';
@@ -21,7 +22,7 @@ describe('RegisterHandler', () => {
   let unitOfWork: DeepMocked<UnitOfWorkService>;
   let mockPrismaClient: DeepMocked<PrismaClient>;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -29,12 +30,7 @@ describe('RegisterHandler', () => {
     lastName: 'Doe',
     birthDate: '2000-01-01',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    avatarId: null,
-    description: null,
-    deletedAt: null,
-  };
+  });
 
   const mockPayload: RegisterRequestDto = {
     username: 'testuser',
@@ -77,6 +73,7 @@ describe('RegisterHandler', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should be defined', () => {
@@ -90,17 +87,14 @@ describe('RegisterHandler', () => {
       userRepository.getByUsername.mockResolvedValue(null);
       hashingService.hash.mockResolvedValue('hashed-password');
       mockPrismaClient.user.create.mockResolvedValue(mockUser);
-      mockPrismaClient.emailAddress.create.mockResolvedValue({
-        id: 'email-id',
-        email: 'test@example.com',
-        userId: mockUser.id,
-        type: 'primary',
-        status: EmailStatus.verified,
-        updatedAt: new Date(),
-        createdAt: new Date(),
-        verifiedAt: null,
-        deletedAt: null,
-      });
+      mockPrismaClient.emailAddress.create.mockResolvedValue(
+        emailAddressBuilder({
+          id: 'email-id',
+          email: 'test@example.com',
+          userId: mockUser.id,
+          status: EmailStatus.verified,
+        }),
+      );
 
       const command = new RegisterCommand(mockPayload);
 
@@ -148,7 +142,7 @@ describe('RegisterHandler', () => {
 
     it('should throw ConflictException if email already exists', async () => {
       // Arrange
-      userRepository.getByEmail.mockResolvedValue({ id: 'existing-email-id' } as User);
+      userRepository.getByEmail.mockResolvedValue(userBuilder({ id: 'existing-email-id' }));
       userRepository.getByUsername.mockResolvedValue(null);
 
       const command = new RegisterCommand(mockPayload);
@@ -165,10 +159,7 @@ describe('RegisterHandler', () => {
     it('should throw ConflictException if username already exists', async () => {
       // Arrange
       userRepository.getByEmail.mockResolvedValue(null);
-      // Same assumption for getByUsername
-      userRepository.getByUsername.mockResolvedValue({
-        id: 'existing-user-id',
-      } as User);
+      userRepository.getByUsername.mockResolvedValue(userBuilder({ id: 'existing-user-id' }));
 
       const command = new RegisterCommand(mockPayload);
 
@@ -182,10 +173,8 @@ describe('RegisterHandler', () => {
 
     it('should prioritize email conflict over username when both exist', async () => {
       // Arrange
-      userRepository.getByEmail.mockResolvedValue({ id: 'existing-email-id' } as User);
-      userRepository.getByUsername.mockResolvedValue({
-        id: 'existing-user-id',
-      } as User);
+      userRepository.getByEmail.mockResolvedValue(userBuilder({ id: 'existing-email-id' }));
+      userRepository.getByUsername.mockResolvedValue(userBuilder({ id: 'existing-user-id' }));
 
       const command = new RegisterCommand(mockPayload);
 
@@ -231,16 +220,13 @@ describe('RegisterHandler', () => {
         ...mockPayload,
         lastName: null,
       };
-      const minimalUser = {
-        ...mockUser,
-        lastName: null,
-      };
+      const minimalUser = userBuilder({ lastName: null });
 
       userRepository.getByEmail.mockResolvedValue(null);
       userRepository.getByUsername.mockResolvedValue(null);
       hashingService.hash.mockResolvedValue('hashed-password');
       mockPrismaClient.user.create.mockResolvedValue(minimalUser);
-      mockPrismaClient.emailAddress.create.mockResolvedValue({} as any);
+      mockPrismaClient.emailAddress.create.mockResolvedValue(emailAddressBuilder());
 
       const command = new RegisterCommand(minimalPayload as any);
 

--- a/apps/api/src/features/auth/interceptors/refresh-token.interceptor.spec.ts
+++ b/apps/api/src/features/auth/interceptors/refresh-token.interceptor.spec.ts
@@ -1,4 +1,4 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { CallHandler, ExecutionContext } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';

--- a/apps/api/src/features/auth/queries/handlers/validate-user.handler.spec.ts
+++ b/apps/api/src/features/auth/queries/handlers/validate-user.handler.spec.ts
@@ -3,9 +3,10 @@ import { ValidateUserHandler } from './validate-user.handler';
 import { ValidateUserQuery } from '../impl/validate-user.query';
 import { UserRepository } from '@/shared/repositories/user.repository';
 import { HashingService } from '@/shared/services/hashing.service';
-import { EmailStatus, User, Gender } from '@repo/db';
+import { EmailStatus, Gender } from '@repo/db';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { UnauthorizedException } from '@nestjs/common';
 
 describe('ValidateUserHandler', () => {
@@ -13,7 +14,7 @@ describe('ValidateUserHandler', () => {
   let userRepository: DeepMocked<UserRepository>;
   let hashingService: DeepMocked<HashingService>;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -21,12 +22,7 @@ describe('ValidateUserHandler', () => {
     lastName: 'Doe',
     birthDate: '2000-01-01',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    avatarId: null,
-    description: null,
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     userRepository = createMock<UserRepository>();
@@ -49,10 +45,9 @@ describe('ValidateUserHandler', () => {
 
   describe('execute', () => {
     it('should return user if credentials are valid and email is verified', async () => {
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockResolvedValue(true);
 
       const result = await handler.execute(new ValidateUserQuery('test@example.com', 'password'));
@@ -67,10 +62,9 @@ describe('ValidateUserHandler', () => {
     });
 
     it('should return null if password invalid', async () => {
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockResolvedValue(false);
 
       const result = await handler.execute(new ValidateUserQuery('test@example.com', 'wrong'));
@@ -78,10 +72,9 @@ describe('ValidateUserHandler', () => {
     });
 
     it('should throw UnauthorizedException if email not verified', async () => {
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.pending,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.pending }),
+      );
       hashingService.compare.mockResolvedValue(true);
 
       await expect(
@@ -93,11 +86,12 @@ describe('ValidateUserHandler', () => {
     });
 
     it('should throw UnauthorizedException if account is deleted', async () => {
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-        deletedAt: new Date(),
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, {
+          emailStatus: EmailStatus.verified,
+          deletedAt: new Date(),
+        }),
+      );
       hashingService.compare.mockResolvedValue(true);
 
       await expect(
@@ -117,10 +111,9 @@ describe('ValidateUserHandler', () => {
     });
 
     it('should throw error if hashing service fails', async () => {
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockRejectedValue(new Error('Hashing Error'));
 
       await expect(
@@ -130,10 +123,9 @@ describe('ValidateUserHandler', () => {
 
     it('should strip emailStatus from the returned user object', async () => {
       // Arrange
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockResolvedValue(true);
 
       // Act
@@ -146,10 +138,9 @@ describe('ValidateUserHandler', () => {
 
     it('should handle mixed-case email by relying on repository normalization', async () => {
       // Arrange
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockResolvedValue(true);
 
       // Act
@@ -162,10 +153,9 @@ describe('ValidateUserHandler', () => {
 
     it('should return null if password is an empty string', async () => {
       // Arrange
-      userRepository.getByEmailWithStatus.mockResolvedValue({
-        ...mockUser,
-        emailStatus: EmailStatus.verified,
-      });
+      userRepository.getByEmailWithStatus.mockResolvedValue(
+        Object.assign({}, mockUser, { emailStatus: EmailStatus.verified }),
+      );
       hashingService.compare.mockResolvedValue(false);
 
       // Act

--- a/apps/api/src/features/auth/services/token.service.spec.ts
+++ b/apps/api/src/features/auth/services/token.service.spec.ts
@@ -7,7 +7,8 @@ import { RefreshTokenRepository } from '../../../shared/repositories/refresh-tok
 import { UnitOfWorkService } from '../../../shared/services/unit-of-work.service';
 import { PrismaService } from '../../../shared/services/prisma.service';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { refreshTokenBuilder, sessionBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 
 describe('TokenService', () => {
   let service: TokenService;
@@ -61,7 +62,7 @@ describe('TokenService', () => {
     it('should generate tokens and create a new session if sessionId is not provided', async () => {
       // Arrange
       jwtService.signAsync.mockResolvedValue('mock-token');
-      sessionRepository.create.mockResolvedValue({ id: 'new-session-id' } as any);
+      sessionRepository.create.mockResolvedValue(sessionBuilder({ id: 'new-session-id' }));
 
       // Act
       const result = await service.generateAuthTokens('user-123', 'username');
@@ -105,14 +106,12 @@ describe('TokenService', () => {
     it('should return decoded info if token and session are valid', async () => {
       // Arrange
       jwtService.verifyAsync.mockResolvedValue(mockPayload);
-      refreshTokenRepository.getByToken.mockResolvedValue({
-        revokedAt: null,
-        deletedAt: null,
-      } as any);
-      sessionRepository.getById.mockResolvedValue({
-        revokedAt: null,
-        deletedAt: null,
-      } as any);
+      refreshTokenRepository.getByToken.mockResolvedValue(
+        refreshTokenBuilder({ revokedAt: null, deletedAt: null }),
+      );
+      sessionRepository.getById.mockResolvedValue(
+        sessionBuilder({ revokedAt: null, deletedAt: null }),
+      );
 
       // Act
       const result = await service.verifyRefreshToken(mockToken);
@@ -151,9 +150,9 @@ describe('TokenService', () => {
     it('should return isRevoked: true if token is revoked in database', async () => {
       // Arrange
       jwtService.verifyAsync.mockResolvedValue(mockPayload);
-      refreshTokenRepository.getByToken.mockResolvedValue({
-        revokedAt: new Date(),
-      } as any);
+      refreshTokenRepository.getByToken.mockResolvedValue(
+        refreshTokenBuilder({ revokedAt: new Date() }),
+      );
 
       // Act
       const result = await service.verifyRefreshToken(mockToken);
@@ -169,12 +168,8 @@ describe('TokenService', () => {
     it('should return isRevoked: true if session is revoked in database', async () => {
       // Arrange
       jwtService.verifyAsync.mockResolvedValue(mockPayload);
-      refreshTokenRepository.getByToken.mockResolvedValue({
-        revokedAt: null,
-      } as any);
-      sessionRepository.getById.mockResolvedValue({
-        revokedAt: new Date(),
-      } as any);
+      refreshTokenRepository.getByToken.mockResolvedValue(refreshTokenBuilder({ revokedAt: null }));
+      sessionRepository.getById.mockResolvedValue(sessionBuilder({ revokedAt: new Date() }));
 
       // Act
       const result = await service.verifyRefreshToken(mockToken);
@@ -186,8 +181,8 @@ describe('TokenService', () => {
     it('should return null if session is deleted', async () => {
       // Arrange
       jwtService.verifyAsync.mockResolvedValue(mockPayload);
-      refreshTokenRepository.getByToken.mockResolvedValue({ revokedAt: null } as any);
-      sessionRepository.getById.mockResolvedValue(null); // or session with deletedAt
+      refreshTokenRepository.getByToken.mockResolvedValue(refreshTokenBuilder({ revokedAt: null }));
+      sessionRepository.getById.mockResolvedValue(null);
 
       // Act
       const result = await service.verifyRefreshToken(mockToken);

--- a/apps/api/src/features/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/features/auth/strategies/jwt.strategy.spec.ts
@@ -1,8 +1,9 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Gender, User } from '@repo/db';
+import { Gender } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { extractTokenFromQuery, JwtStrategy } from './jwt.strategy';
 import { Request } from 'express';
@@ -13,7 +14,7 @@ describe('JwtStrategy', () => {
   let userRepository: DeepMocked<UserRepository>;
   let configService: DeepMocked<ConfigService>;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -21,12 +22,7 @@ describe('JwtStrategy', () => {
     lastName: 'Doe',
     birthDate: '2000-01-01',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    avatarId: null,
-    description: null,
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     userRepository = createMock<UserRepository>();

--- a/apps/api/src/features/auth/strategies/local.strategy.spec.ts
+++ b/apps/api/src/features/auth/strategies/local.strategy.spec.ts
@@ -1,8 +1,9 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { userBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { UnauthorizedException } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Gender, User } from '@repo/db';
+import { Gender } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ValidateUserQuery } from '../queries/impl/validate-user.query';
 import { LocalStrategy } from './local.strategy';
@@ -11,7 +12,7 @@ describe('LocalStrategy', () => {
   let strategy: LocalStrategy;
   let queryBus: DeepMocked<QueryBus>;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -19,12 +20,7 @@ describe('LocalStrategy', () => {
     lastName: 'Doe',
     birthDate: '2000-01-01',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    avatarId: null,
-    description: null,
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     queryBus = createMock<QueryBus>();

--- a/apps/api/src/features/library-albums/commands/handlers/create-library-album.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/create-library-album.handler.spec.ts
@@ -2,7 +2,8 @@ import { AlbumRepository } from '@/shared/repositories/album.repository';
 import { LibraryAlbumRepository } from '@/shared/repositories/library-album.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { albumBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import {
   ConflictException,
   InternalServerErrorException,
@@ -10,7 +11,8 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AlbumSchema } from '@repo/contracts';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AlbumType, Visibility } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateLibraryAlbumCommand } from '../impl/create-library-album.command';
 import { CreateLibraryAlbumHandler } from './create-library-album.handler';
 
@@ -34,21 +36,18 @@ describe('CreateLibraryAlbumHandler', () => {
     artistId: mockArtistId,
   };
 
-  const mockAlbum = {
+  const mockLibrary = libraryBuilder({ id: mockLibraryId, userId: mockUserId });
+  const mockAlbum = albumBuilder({
     id: mockAlbumId,
-    ...mockRequest,
-    visibility: 'PRIVATE',
+    name: mockRequest.name,
+    description: mockRequest.description,
+    type: AlbumType.album,
+    releaseDate: mockRequest.releaseDate,
     coverId: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
     totalTracks: 0,
     totalDuration: 0,
-    cover: null,
-    artists: [],
-    tracks: [],
-    genres: [],
-  };
+    visibility: Visibility.private,
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -71,12 +70,17 @@ describe('CreateLibraryAlbumHandler', () => {
     unitOfWork.runInTransaction.mockImplementation(async (cb) => cb());
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
   it('should create library album successfully', async () => {
     const command = new CreateLibraryAlbumCommand(mockRequest, mockUserId);
 
-    libraryRepository.getByUserId.mockResolvedValue({ id: mockLibraryId } as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     albumRepository.findOne.mockResolvedValue(null);
-    albumRepository.create.mockResolvedValue(mockAlbum as any);
+    albumRepository.create.mockResolvedValue(mockAlbum);
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
 
     const result = await handler.execute(command);
@@ -99,8 +103,8 @@ describe('CreateLibraryAlbumHandler', () => {
   it('should throw ConflictException if album name already exists', async () => {
     const command = new CreateLibraryAlbumCommand(mockRequest, mockUserId);
 
-    libraryRepository.getByUserId.mockResolvedValue({ id: mockLibraryId } as any);
-    albumRepository.findOne.mockResolvedValue({ id: 'existing-id' } as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    albumRepository.findOne.mockResolvedValue(albumBuilder({ id: 'existing-id' }));
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
   });
@@ -108,7 +112,7 @@ describe('CreateLibraryAlbumHandler', () => {
   it('should throw InternalServerErrorException if result parsing fails', async () => {
     const command = new CreateLibraryAlbumCommand(mockRequest, mockUserId);
 
-    libraryRepository.getByUserId.mockResolvedValue({ id: mockLibraryId } as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     albumRepository.findOne.mockResolvedValue(null);
     albumRepository.create.mockResolvedValue({ invalid: 'data' } as any);
 

--- a/apps/api/src/features/library-albums/commands/handlers/delete-library-album-cover.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/delete-library-album-cover.handler.spec.ts
@@ -2,11 +2,12 @@ import { AlbumRepository } from '@/shared/repositories/album.repository';
 import { ImageRepository } from '@/shared/repositories/image.repository';
 import { StorageService } from '@/shared/services/storage.service';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { albumBuilder, imageBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AlbumSchema, ZodAlbum } from '@repo/contracts';
-import { FileBucket } from '@repo/db';
+import { AlbumSchema } from '@repo/contracts';
+import { AlbumType, FileBucket, ImageUploadStatus, Visibility } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeleteLibraryAlbumCoverCommand } from '../impl/delete-library-album-cover.command';
 import { DeleteLibraryAlbumCoverHandler } from './delete-library-album-cover.handler';
@@ -22,45 +23,31 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
   const mockAlbumId = 'album-123';
   const mockCoverId = 'cover-456';
 
-  const mockAlbum: ZodAlbum = {
+  const mockAlbum = albumBuilder({
     id: mockAlbumId,
     name: 'Test Album',
     description: 'Test Description',
-    type: 'album' as any,
+    type: AlbumType.album,
     totalTracks: 10,
     totalDuration: 3000,
     releaseDate: new Date(),
     coverId: mockCoverId,
-    visibility: 'public',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    cover: null,
-    artists: [],
-    tracks: [],
-    genres: [],
-  };
+    visibility: Visibility.public,
+  });
 
-  const mockAlbumWithoutCover: ZodAlbum = {
+  const mockAlbumWithoutCover = albumBuilder({
     ...mockAlbum,
     coverId: null,
-    cover: null,
-  };
+  });
 
-  const mockImage = {
+  const mockImage = imageBuilder({
     id: mockCoverId,
     bucket: FileBucket.private,
     key: 'covers/album-123/cover.webp',
     url: 'https://storage.url/cover.webp',
     mimeType: 'image/webp',
-    alt: null,
-    blurhash: null,
-    reportId: null,
-    uploadStatus: 'uploaded' as const,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+    uploadStatus: ImageUploadStatus.uploaded,
+  });
 
   beforeEach(async () => {
     albumRepository = createMock<AlbumRepository>();
@@ -109,7 +96,7 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should return album as-is when album has no cover', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbumWithoutCover as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbumWithoutCover);
 
       const result = await handler.execute(command);
 
@@ -121,8 +108,8 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should delete cover successfully and return updated album', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-      imageRepository.findOne.mockResolvedValue(mockImage as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbum);
+      imageRepository.findOne.mockResolvedValue(mockImage);
 
       const expectedAlbum = { ...mockAlbum, coverId: null, cover: null };
       vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
@@ -144,7 +131,7 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should not call storageService.deleteFile when image record not found', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbum);
       imageRepository.findOne.mockResolvedValue(null);
 
       const expectedAlbum = { ...mockAlbum, coverId: null, cover: null };
@@ -166,8 +153,8 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should throw Error when AlbumSchema.safeParse fails', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-      imageRepository.findOne.mockResolvedValue(mockImage as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbum);
+      imageRepository.findOne.mockResolvedValue(mockImage);
 
       vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
         success: false,
@@ -179,8 +166,8 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should run album update and image delete within transaction', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-      imageRepository.findOne.mockResolvedValue(mockImage as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbum);
+      imageRepository.findOne.mockResolvedValue(mockImage);
 
       const expectedAlbum = { ...mockAlbum, coverId: null, cover: null };
       vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
@@ -206,8 +193,8 @@ describe('DeleteLibraryAlbumCoverHandler', () => {
 
     it('should log error when storage delete fails but still return album', async () => {
       const command = new DeleteLibraryAlbumCoverCommand(mockAlbumId, mockUserId);
-      albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-      imageRepository.findOne.mockResolvedValue(mockImage as any);
+      albumRepository.findOne.mockResolvedValue(mockAlbum);
+      imageRepository.findOne.mockResolvedValue(mockImage);
       storageService.deleteFile.mockRejectedValue(new Error('S3 delete failed'));
 
       const expectedAlbum = { ...mockAlbum, coverId: null, cover: null };

--- a/apps/api/src/features/library-albums/commands/handlers/delete-library-album.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/delete-library-album.handler.spec.ts
@@ -1,9 +1,10 @@
 import { AlbumRepository } from '@/shared/repositories/album.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { albumBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ZodAlbum } from '@repo/contracts';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { AlbumType, Visibility } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeleteLibraryAlbumCommand } from '../impl/delete-library-album.command';
 import { DeleteLibraryAlbumHandler } from './delete-library-album.handler';
 
@@ -13,24 +14,17 @@ describe('DeleteLibraryAlbumHandler', () => {
 
   const mockUserId = 'user-123';
   const mockAlbumId = 'album-123';
-  const mockAlbum: ZodAlbum = {
+  const mockAlbum = albumBuilder({
     id: mockAlbumId,
     name: 'Test Album',
     description: 'Test Description',
-    type: 'album' as any,
+    type: AlbumType.album,
     totalTracks: 10,
     totalDuration: 3000,
     releaseDate: new Date(),
     coverId: null,
-    visibility: 'public',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    cover: null,
-    artists: [],
-    tracks: [],
-    genres: [],
-  };
+    visibility: Visibility.public,
+  });
 
   beforeEach(async () => {
     albumRepository = createMock<AlbumRepository>();
@@ -45,12 +39,16 @@ describe('DeleteLibraryAlbumHandler', () => {
     handler = module.get<DeleteLibraryAlbumHandler>(DeleteLibraryAlbumHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should delete an album successfully', async () => {
     const command = new DeleteLibraryAlbumCommand(mockAlbumId, mockUserId);
     const mockDeletedAlbum = { ...mockAlbum, deletedAt: new Date() };
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-    albumRepository.update.mockResolvedValue(mockDeletedAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
+    albumRepository.update.mockResolvedValue(mockDeletedAlbum);
 
     const result = await handler.execute(command);
 
@@ -69,7 +67,7 @@ describe('DeleteLibraryAlbumHandler', () => {
 
   it('should throw InternalServerErrorException if parsing fails', async () => {
     const command = new DeleteLibraryAlbumCommand(mockAlbumId, mockUserId);
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     albumRepository.update.mockResolvedValue({ invalid: 'data' } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);

--- a/apps/api/src/features/library-albums/commands/handlers/update-library-album.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/update-library-album.handler.spec.ts
@@ -1,9 +1,11 @@
 import { AlbumRepository } from '@/shared/repositories/album.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { albumBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { ConflictException, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AlbumSchema } from '@repo/contracts';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AlbumType } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateLibraryAlbumCommand } from '../impl/update-library-album.command';
 import { UpdateLibraryAlbumHandler } from './update-library-album.handler';
 
@@ -13,13 +15,13 @@ describe('UpdateLibraryAlbumHandler', () => {
 
   const mockUserId = 'user-123';
   const mockAlbumId = 'album-123';
-  const mockAlbum = {
+  const mockAlbum = albumBuilder({
     id: mockAlbumId,
     name: 'Old Name',
     description: 'Old Desc',
-    type: 'album',
+    type: AlbumType.album,
     coverId: 'old-cover',
-  };
+  });
 
   beforeEach(async () => {
     albumRepository = createMock<AlbumRepository>();
@@ -34,13 +36,18 @@ describe('UpdateLibraryAlbumHandler', () => {
     handler = module.get<UpdateLibraryAlbumHandler>(UpdateLibraryAlbumHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
   it('should update library album successfully', async () => {
     const request = { name: 'New Name' };
     const command = new UpdateLibraryAlbumCommand(mockAlbumId, request, mockUserId);
 
-    albumRepository.findOne.mockResolvedValueOnce(mockAlbum as any); // Finding existing album
+    albumRepository.findOne.mockResolvedValueOnce(mockAlbum); // Finding existing album
     albumRepository.findOne.mockResolvedValueOnce(null); // Checking for name collision
-    albumRepository.update.mockResolvedValue({ ...mockAlbum, ...request } as any);
+    albumRepository.update.mockResolvedValue({ ...mockAlbum, ...request });
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
       success: true,
       data: { ...mockAlbum, ...request },
@@ -66,8 +73,8 @@ describe('UpdateLibraryAlbumHandler', () => {
     const request = { name: 'Taken Name' };
     const command = new UpdateLibraryAlbumCommand(mockAlbumId, request, mockUserId);
 
-    albumRepository.findOne.mockResolvedValueOnce(mockAlbum as any); // Existing
-    albumRepository.findOne.mockResolvedValueOnce({ id: 'other' } as any); // Collision
+    albumRepository.findOne.mockResolvedValueOnce(mockAlbum); // Existing
+    albumRepository.findOne.mockResolvedValueOnce(albumBuilder({ id: 'other' })); // Collision
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
   });
@@ -76,8 +83,8 @@ describe('UpdateLibraryAlbumHandler', () => {
     const request = { coverId: null };
     const command = new UpdateLibraryAlbumCommand(mockAlbumId, request, mockUserId);
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-    albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: null } as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
+    albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: null });
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
 
     await handler.execute(command);
@@ -94,8 +101,8 @@ describe('UpdateLibraryAlbumHandler', () => {
     const request = { coverId: 'new-cover' };
     const command = new UpdateLibraryAlbumCommand(mockAlbumId, request, mockUserId);
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
-    albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: 'new-cover' } as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
+    albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: 'new-cover' });
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
 
     await handler.execute(command);
@@ -111,7 +118,7 @@ describe('UpdateLibraryAlbumHandler', () => {
   it('should throw InternalServerErrorException if result parsing fails', async () => {
     const command = new UpdateLibraryAlbumCommand(mockAlbumId, {}, mockUserId);
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     albumRepository.update.mockResolvedValue({ invalid: 'data' } as any);
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
       success: false,

--- a/apps/api/src/features/library-albums/commands/handlers/update-library-album.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/update-library-album.handler.spec.ts
@@ -85,7 +85,10 @@ describe('UpdateLibraryAlbumHandler', () => {
 
     albumRepository.findOne.mockResolvedValue(mockAlbum);
     albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: null });
-    vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
+    vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
+      success: true,
+      data: { ...mockAlbum, coverId: null },
+    } as any);
 
     await handler.execute(command);
 
@@ -103,7 +106,10 @@ describe('UpdateLibraryAlbumHandler', () => {
 
     albumRepository.findOne.mockResolvedValue(mockAlbum);
     albumRepository.update.mockResolvedValue({ ...mockAlbum, coverId: 'new-cover' });
-    vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
+    vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({
+      success: true,
+      data: { ...mockAlbum, coverId: 'new-cover' },
+    } as any);
 
     await handler.execute(command);
 

--- a/apps/api/src/features/library-albums/commands/handlers/upload-library-album-cover.handler.spec.ts
+++ b/apps/api/src/features/library-albums/commands/handlers/upload-library-album-cover.handler.spec.ts
@@ -2,7 +2,6 @@ import { AlbumRepository } from '@/shared/repositories/album.repository';
 import { ImageService } from '@/shared/services/image.service';
 import { PrismaService } from '@/shared/services/prisma.service';
 import { StorageService } from '@/shared/services/storage.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
 import {
   BadRequestException,
   InternalServerErrorException,
@@ -10,12 +9,13 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { FileBucket } from '@repo/db';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { vi } from 'vitest';
+import { ImageSchema } from '@repo/contracts';
+import { FileBucket, ImageUploadStatus } from '@repo/db';
+import { albumBuilder, imageBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UploadLibraryAlbumCoverCommand } from '../impl/upload-library-album-cover.command';
 import { UploadLibraryAlbumCoverHandler } from './upload-library-album-cover.handler';
-import { ImageSchema } from '@repo/contracts';
 
 describe('UploadLibraryAlbumCoverHandler', () => {
   let handler: UploadLibraryAlbumCoverHandler;
@@ -29,25 +29,16 @@ describe('UploadLibraryAlbumCoverHandler', () => {
   const mockBuffer = Buffer.from('test-image');
   const mockMimeType = 'image/png';
 
-  const mockAlbum = {
-    id: mockAlbumId,
-    coverId: null,
-  };
+  const mockAlbum = albumBuilder({ id: mockAlbumId, coverId: null });
 
-  const mockImageRecord = {
+  const mockImageRecord = imageBuilder({
     id: 'img-123',
-    alt: null,
     bucket: FileBucket.public,
     key: 'key.webp',
     url: 'http://bucket/key.webp',
     mimeType: 'image/webp',
-    blurhash: null,
-    reportId: null,
-    uploadStatus: 'uploaded',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+    uploadStatus: ImageUploadStatus.uploaded,
+  });
 
   beforeEach(async () => {
     albumRepository = createMock<AlbumRepository>();
@@ -71,6 +62,11 @@ describe('UploadLibraryAlbumCoverHandler', () => {
     prisma.mainClient.$transaction.mockImplementation(async (cb) => cb(prisma.client));
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
   it('should upload album cover successfully', async () => {
     const command = new UploadLibraryAlbumCoverCommand(
       mockAlbumId,
@@ -79,7 +75,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockUserId,
     );
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({
@@ -117,9 +113,9 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockMimeType,
       mockUserId,
     );
-    const mockAlbumWithCover = { ...mockAlbum, coverId: 'old-cover-id' };
+    const mockAlbumWithCover = albumBuilder({ id: mockAlbumId, coverId: 'old-cover-id' });
 
-    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({
@@ -129,7 +125,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
 
     prisma.client.image.findUnique.mockResolvedValue({
       id: 'old-cover-id',
-      bucket: 'public',
+      bucket: FileBucket.public,
       key: 'old-key',
     } as any);
 
@@ -153,7 +149,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
     });
 
     // S3 deletion
-    expect(storageService.deleteFile).toHaveBeenCalledWith('public', 'old-key');
+    expect(storageService.deleteFile).toHaveBeenCalledWith(FileBucket.public, 'old-key');
   });
 
   it('should not attempt to cleanup S3 if old cover image record not found in DB', async () => {
@@ -163,9 +159,9 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockMimeType,
       mockUserId,
     );
-    const mockAlbumWithCover = { ...mockAlbum, coverId: 'old-cover-id' };
+    const mockAlbumWithCover = albumBuilder({ id: mockAlbumId, coverId: 'old-cover-id' });
 
-    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
@@ -181,7 +177,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
 
     await handler.execute(command);
 
-    expect(storageService.deleteFile).not.toHaveBeenCalledWith('public', expect.any(String));
+    expect(storageService.deleteFile).not.toHaveBeenCalled();
   });
 
   it('should throw NotFoundException if album not found', async () => {
@@ -203,7 +199,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockMimeType,
       mockUserId,
     );
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     imageService.validateImage.mockResolvedValue(false);
 
     await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
@@ -217,7 +213,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockUserId,
     );
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({
@@ -241,16 +237,16 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockMimeType,
       mockUserId,
     );
-    const mockAlbumWithCover = { ...mockAlbum, coverId: 'old-cover-id' };
+    const mockAlbumWithCover = albumBuilder({ id: mockAlbumId, coverId: 'old-cover-id' });
 
-    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbumWithCover);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     prisma.client.image.findUnique.mockResolvedValue({
       id: 'old-cover-id',
-      bucket: 'public',
+      bucket: FileBucket.public,
       key: 'old-key',
     } as any);
 
@@ -280,7 +276,7 @@ describe('UploadLibraryAlbumCoverHandler', () => {
       mockUserId,
     );
 
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     imageService.validateImage.mockResolvedValue(true);
     imageService.resizeToMaxDimension.mockResolvedValue(mockBuffer);
     storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });

--- a/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-albums/queries/handlers/get-library-album-tracks.handler.spec.ts
@@ -1,9 +1,10 @@
 import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { libraryBuilder, libraryTrackBuilder, trackBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Library } from '@repo/db';
+import { Visibility } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryAlbumTracksQuery } from '../impl/get-library-album-tracks.query';
 import { GetLibraryAlbumTracksHandler } from './get-library-album-tracks.handler';
@@ -17,38 +18,23 @@ describe('GetLibraryAlbumTracksHandler', () => {
   const albumId = 'album-123';
   const query = new GetLibraryAlbumTracksQuery(userId, albumId);
 
-  const mockLibrary: Library = {
-    id: 'library-123',
-    userId,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockTrack = {
+  const mockLibrary = libraryBuilder({ id: 'library-123', userId });
+  const mockTrack = trackBuilder({
     id: 'track-123',
     title: 'Test Track',
     albumId,
     trackNumber: 1,
     diskNumber: 1,
     duration: 180,
-    listenedCount: 0,
-    explicit: false,
-    lyrics: null,
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
-
-  const mockLibraryTrack: any = {
-    id: 'lib-track-123',
-    libraryId: mockLibrary.id,
-    trackId: mockTrack.id,
+    visibility: Visibility.private,
+  });
+  const mockLibraryTrack = {
+    ...libraryTrackBuilder({
+      id: 'lib-track-123',
+      libraryId: mockLibrary.id,
+      trackId: mockTrack.id,
+    }),
     track: mockTrack,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
   };
 
   beforeEach(async () => {

--- a/apps/api/src/features/library-albums/queries/handlers/get-library-album.handler.spec.ts
+++ b/apps/api/src/features/library-albums/queries/handlers/get-library-album.handler.spec.ts
@@ -1,9 +1,10 @@
 import { AlbumRepository } from '@/shared/repositories/album.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { albumBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AlbumSchema } from '@repo/contracts';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryAlbumQuery } from '../impl/get-library-album.query';
 import { GetLibraryAlbumHandler } from './get-library-album.handler';
 
@@ -13,12 +14,10 @@ describe('GetLibraryAlbumHandler', () => {
 
   const mockAlbumId = 'album-123';
   const mockUserId = 'user-123';
-  const mockAlbum = {
+  const mockAlbum = albumBuilder({
     id: mockAlbumId,
     name: 'Test Album',
-    artists: [],
-    tracks: [],
-  };
+  });
 
   beforeEach(async () => {
     albumRepository = createMock<AlbumRepository>();
@@ -30,9 +29,14 @@ describe('GetLibraryAlbumHandler', () => {
     handler = module.get<GetLibraryAlbumHandler>(GetLibraryAlbumHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
   it('should return album successfully', async () => {
     const query = new GetLibraryAlbumQuery(mockAlbumId, mockUserId);
-    albumRepository.findOne.mockResolvedValue(mockAlbum as any);
+    albumRepository.findOne.mockResolvedValue(mockAlbum);
     vi.spyOn(AlbumSchema, 'safeParse').mockReturnValue({ success: true, data: mockAlbum } as any);
 
     const result = await handler.execute(query);

--- a/apps/api/src/features/library-albums/queries/handlers/get-library-albums.handler.spec.ts
+++ b/apps/api/src/features/library-albums/queries/handlers/get-library-albums.handler.spec.ts
@@ -1,9 +1,10 @@
 import { LibraryAlbumRepository } from '@/shared/repositories/library-album.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { libraryAlbumBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryAlbumsQuery } from '../impl/get-library-albums.query';
 import { GetLibraryAlbumsHandler } from './get-library-albums.handler';
 
@@ -14,6 +15,12 @@ describe('GetLibraryAlbumsHandler', () => {
 
   const mockUserId = 'user-123';
   const mockLibraryId = 'library-123';
+  const mockLibrary = libraryBuilder({ id: mockLibraryId, userId: mockUserId });
+  const mockItems = [
+    libraryAlbumBuilder({ id: 'album-1', libraryId: mockLibraryId }),
+    libraryAlbumBuilder({ id: 'album-2', libraryId: mockLibraryId }),
+  ];
+  const mockTotal = 2;
 
   beforeEach(async () => {
     libraryRepository = createMock<LibraryRepository>();
@@ -30,12 +37,14 @@ describe('GetLibraryAlbumsHandler', () => {
     handler = module.get<GetLibraryAlbumsHandler>(GetLibraryAlbumsHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should return library albums successfully', async () => {
     const query = new GetLibraryAlbumsQuery(mockUserId, 1, 10);
-    const mockItems = [{ id: 'album-1' }, { id: 'album-2' }];
-    const mockTotal = 2;
 
-    libraryRepository.getByUserId.mockResolvedValue({ id: mockLibraryId } as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     libraryAlbumRepository.findMany.mockResolvedValue(mockItems as any);
     libraryAlbumRepository.count.mockResolvedValue(mockTotal);
 

--- a/apps/api/src/features/library-artists/commands/handlers/create-library-artist.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/create-library-artist.handler.spec.ts
@@ -2,15 +2,15 @@ import { ArtistRepository } from '@/shared/repositories/artist.repository';
 import { LibraryArtistRepository } from '@/shared/repositories/library-artist.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { artistBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import {
   ConflictException,
   InternalServerErrorException,
   PreconditionFailedException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ZodArtist } from '@repo/contracts';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateLibraryArtistCommand } from '../impl/create-library-artist.command';
 import { CreateLibraryArtistHandler } from './create-library-artist.handler';
 
@@ -22,8 +22,8 @@ describe('CreateLibraryArtistHandler', () => {
   let libraryArtistRepository: DeepMocked<LibraryArtistRepository>;
 
   const mockUserId = 'user-123';
-  const mockLibrary = { id: 'library-123', userId: mockUserId };
-  const mockArtist: ZodArtist = {
+  const mockLibrary = libraryBuilder({ id: 'library-123', userId: mockUserId });
+  const mockArtist = artistBuilder({
     id: 'artist-123',
     name: 'Test Artist',
     description: 'Test Description',
@@ -31,13 +31,8 @@ describe('CreateLibraryArtistHandler', () => {
     verified: false,
     avatarId: null,
     bannerId: null,
-    avatar: null,
-    banner: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
     visibility: 'public',
-  };
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -61,15 +56,19 @@ describe('CreateLibraryArtistHandler', () => {
     handler = module.get<CreateLibraryArtistHandler>(CreateLibraryArtistHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should create an artist successfully', async () => {
     const command = new CreateLibraryArtistCommand(
       { name: 'Test Artist', description: 'Test Description' },
       mockUserId,
     );
 
-    libraryRepository.getByUserId.mockResolvedValue(mockLibrary as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     artistRepository.findOne.mockResolvedValue(null);
-    artistRepository.create.mockResolvedValue(mockArtist as any);
+    artistRepository.create.mockResolvedValue(mockArtist);
 
     const result = await handler.execute(command);
 
@@ -96,7 +95,7 @@ describe('CreateLibraryArtistHandler', () => {
 
   it('should throw ConflictException if artist name is already taken', async () => {
     const command = new CreateLibraryArtistCommand({ name: 'Taken' }, mockUserId);
-    libraryRepository.getByUserId.mockResolvedValue(mockLibrary as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     artistRepository.findOne.mockResolvedValue({ id: 'existing' } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
@@ -104,7 +103,7 @@ describe('CreateLibraryArtistHandler', () => {
 
   it('should throw InternalServerErrorException if parsing fails', async () => {
     const command = new CreateLibraryArtistCommand({ name: 'Test' }, mockUserId);
-    libraryRepository.getByUserId.mockResolvedValue(mockLibrary as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     artistRepository.findOne.mockResolvedValue(null);
     artistRepository.create.mockResolvedValue({ invalid: 'data' } as any);
 

--- a/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/delete-library-artist.handler.spec.ts
@@ -1,9 +1,10 @@
 import { ArtistRepository } from '@/shared/repositories/artist.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { artistBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ZodArtist } from '@repo/contracts';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { Visibility } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeleteLibraryArtistCommand } from '../impl/delete-library-artist.command';
 import { DeleteLibraryArtistHandler } from './delete-library-artist.handler';
 
@@ -13,7 +14,7 @@ describe('DeleteLibraryArtistHandler', () => {
 
   const mockUserId = 'user-123';
   const mockArtistId = 'artist-123';
-  const mockArtist: ZodArtist = {
+  const mockArtist = artistBuilder({
     id: mockArtistId,
     name: 'Test Artist',
     description: 'Test Description',
@@ -21,13 +22,8 @@ describe('DeleteLibraryArtistHandler', () => {
     verified: false,
     avatarId: null,
     bannerId: null,
-    avatar: null,
-    banner: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    visibility: 'public',
-  };
+    visibility: Visibility.public,
+  });
 
   beforeEach(async () => {
     artistRepository = createMock<ArtistRepository>();
@@ -42,12 +38,17 @@ describe('DeleteLibraryArtistHandler', () => {
     handler = module.get<DeleteLibraryArtistHandler>(DeleteLibraryArtistHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
   it('should delete an artist successfully', async () => {
     const command = new DeleteLibraryArtistCommand(mockArtistId, mockUserId);
     const mockDeletedArtist = { ...mockArtist, deletedAt: new Date() };
 
-    artistRepository.findOne.mockResolvedValue(mockArtist as any);
-    artistRepository.softDeleteCascade.mockResolvedValue(mockDeletedArtist as any);
+    artistRepository.findOne.mockResolvedValue(mockArtist);
+    artistRepository.softDeleteCascade.mockResolvedValue(mockDeletedArtist);
 
     const result = await handler.execute(command);
 
@@ -64,7 +65,7 @@ describe('DeleteLibraryArtistHandler', () => {
 
   it('should throw InternalServerErrorException if parsing fails', async () => {
     const command = new DeleteLibraryArtistCommand(mockArtistId, mockUserId);
-    artistRepository.findOne.mockResolvedValue(mockArtist as any);
+    artistRepository.findOne.mockResolvedValue(mockArtist);
     artistRepository.softDeleteCascade.mockResolvedValue({ invalid: 'data' } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);

--- a/apps/api/src/features/library-artists/commands/handlers/update-library-artist.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/update-library-artist.handler.spec.ts
@@ -1,9 +1,10 @@
 import { ArtistRepository } from '@/shared/repositories/artist.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { artistBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { ConflictException, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ZodArtist } from '@repo/contracts';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { Visibility } from '@repo/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateLibraryArtistCommand } from '../impl/update-library-artist.command';
 import { UpdateLibraryArtistHandler } from './update-library-artist.handler';
 
@@ -13,7 +14,7 @@ describe('UpdateLibraryArtistHandler', () => {
 
   const mockUserId = 'user-123';
   const mockArtistId = 'artist-123';
-  const mockArtist: ZodArtist = {
+  const mockArtist = artistBuilder({
     id: mockArtistId,
     name: 'Old Name',
     description: 'Old Description',
@@ -21,13 +22,8 @@ describe('UpdateLibraryArtistHandler', () => {
     verified: false,
     avatarId: null,
     bannerId: null,
-    avatar: null,
-    banner: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    visibility: 'public',
-  };
+    visibility: Visibility.public,
+  });
 
   beforeEach(async () => {
     artistRepository = createMock<ArtistRepository>();
@@ -42,14 +38,18 @@ describe('UpdateLibraryArtistHandler', () => {
     handler = module.get<UpdateLibraryArtistHandler>(UpdateLibraryArtistHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should update an artist successfully', async () => {
     const dto = { name: 'New Name', description: 'New Description' };
     const command = new UpdateLibraryArtistCommand(mockArtistId, dto, mockUserId);
     const mockUpdatedArtist = { ...mockArtist, ...dto };
 
-    artistRepository.findOne.mockResolvedValueOnce(mockArtist as any); // Check existence
+    artistRepository.findOne.mockResolvedValueOnce(mockArtist); // Check existence
     artistRepository.findOne.mockResolvedValueOnce(null); // Check name conflict
-    artistRepository.update.mockResolvedValue(mockUpdatedArtist as any);
+    artistRepository.update.mockResolvedValue(mockUpdatedArtist);
 
     const result = await handler.execute(command);
 
@@ -62,8 +62,8 @@ describe('UpdateLibraryArtistHandler', () => {
     const command = new UpdateLibraryArtistCommand(mockArtistId, dto, mockUserId);
     const mockUpdatedArtist = { ...mockArtist, ...dto };
 
-    artistRepository.findOne.mockResolvedValue(mockArtist as any);
-    artistRepository.update.mockResolvedValue(mockUpdatedArtist as any);
+    artistRepository.findOne.mockResolvedValue(mockArtist);
+    artistRepository.update.mockResolvedValue(mockUpdatedArtist);
 
     const result = await handler.execute(command);
 
@@ -87,15 +87,15 @@ describe('UpdateLibraryArtistHandler', () => {
     const dto = { name: 'Taken Name' };
     const command = new UpdateLibraryArtistCommand(mockArtistId, dto, mockUserId);
 
-    artistRepository.findOne.mockResolvedValueOnce(mockArtist as any); // Existence
-    artistRepository.findOne.mockResolvedValueOnce({ id: 'other-artist' } as any); // Conflict
+    artistRepository.findOne.mockResolvedValueOnce(mockArtist); // Existence
+    artistRepository.findOne.mockResolvedValueOnce(artistBuilder({ id: 'other-artist' })); // Conflict
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
   });
 
   it('should throw InternalServerErrorException if parsing fails', async () => {
     const command = new UpdateLibraryArtistCommand(mockArtistId, {}, mockUserId);
-    artistRepository.findOne.mockResolvedValue(mockArtist as any);
+    artistRepository.findOne.mockResolvedValue(mockArtist);
     artistRepository.update.mockResolvedValue({ invalid: 'data' } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);

--- a/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-avatar.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-avatar.handler.spec.ts
@@ -9,16 +9,18 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileBucket } from '@repo/db';
-import { vi } from 'vitest';
+import { artistBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UploadLibraryArtistAvatarCommand } from '../impl/upload-library-artist-avatar.command';
 import { UploadLibraryArtistAvatarHandler } from './upload-library-artist-avatar.handler';
 
-describe('UploadArtistAvatarHandler', () => {
+describe('UploadLibraryArtistAvatarHandler', () => {
   let handler: UploadLibraryArtistAvatarHandler;
-  let artistRepository: ArtistRepository;
-  let storageService: StorageService;
-  let imageService: ImageService;
-  let prismaService: PrismaService;
+  let artistRepository: DeepMocked<ArtistRepository>;
+  let storageService: DeepMocked<StorageService>;
+  let imageService: DeepMocked<ImageService>;
+  let prismaService: DeepMocked<PrismaService>;
 
   const mockTx = {
     image: {
@@ -44,50 +46,30 @@ describe('UploadArtistAvatarHandler', () => {
   };
 
   beforeEach(async () => {
+    artistRepository = createMock<ArtistRepository>();
+    storageService = createMock<StorageService>();
+    imageService = createMock<ImageService>();
+    prismaService = createMock<PrismaService>();
+
+    storageService.deleteFile.mockResolvedValue(undefined);
+    (prismaService as any).client = {
+      image: { findUnique: vi.fn() },
+    };
+    (prismaService as any).mainClient = {
+      $transaction: vi.fn((cb: (tx: typeof mockTx) => unknown) => cb(mockTx)),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UploadLibraryArtistAvatarHandler,
-        {
-          provide: ArtistRepository,
-          useValue: {
-            findOne: vi.fn(),
-          },
-        },
-        {
-          provide: StorageService,
-          useValue: {
-            uploadFile: vi.fn(),
-            deleteFile: vi.fn().mockResolvedValue(undefined),
-          },
-        },
-        {
-          provide: ImageService,
-          useValue: {
-            validateImage: vi.fn(),
-            resizeToMaxDimension: vi.fn(),
-          },
-        },
-        {
-          provide: PrismaService,
-          useValue: {
-            client: {
-              image: {
-                findUnique: vi.fn(),
-              },
-            },
-            mainClient: {
-              $transaction: vi.fn((cb) => cb(mockTx)),
-            },
-          },
-        },
+        { provide: ArtistRepository, useValue: artistRepository },
+        { provide: StorageService, useValue: storageService },
+        { provide: ImageService, useValue: imageService },
+        { provide: PrismaService, useValue: prismaService },
       ],
     }).compile();
 
     handler = module.get<UploadLibraryArtistAvatarHandler>(UploadLibraryArtistAvatarHandler);
-    artistRepository = module.get<ArtistRepository>(ArtistRepository);
-    storageService = module.get<StorageService>(StorageService);
-    imageService = module.get<ImageService>(ImageService);
-    prismaService = module.get<PrismaService>(PrismaService);
 
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01'));
@@ -96,6 +78,8 @@ describe('UploadArtistAvatarHandler', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should upload artist avatar and cleanup old one successfully', async () => {
@@ -106,18 +90,16 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      avatarId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue({
+    const mockArtist = artistBuilder({ id: 'artist-123', avatarId: 'img-old' });
+    artistRepository.findOne.mockResolvedValue(mockArtist);
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue({
       id: 'img-old',
       bucket: FileBucket.public,
       key: 'old-key',
     } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const result = await handler.execute(command);
     const expectedNewKey = `artists/artist-123/avatar-${new Date('2024-01-01').getTime()}.webp`;
@@ -142,15 +124,17 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockImplementation(async (_buf, _bucket, key) => ({
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockImplementation(async (_buf, _bucket, key) => ({
       url: 'new-url',
       key,
     }));
 
-    vi.mocked(prismaService.mainClient.$transaction).mockRejectedValue(new Error('DB Error'));
+    vi.mocked((prismaService as any).mainClient.$transaction).mockRejectedValue(
+      new Error('DB Error'),
+    );
 
     await expect(handler.execute(command)).rejects.toThrow('DB Error');
 
@@ -166,7 +150,7 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue(null);
+    artistRepository.findOne.mockResolvedValue(null);
 
     await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
   });
@@ -179,8 +163,8 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(false);
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(false);
 
     await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
   });
@@ -193,12 +177,11 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
-    // Mock create to return invalid image (missing required fields for ZodImage)
     vi.mocked(mockTx.image.create).mockResolvedValueOnce({
       id: 'img-new',
       // missing other required fields
@@ -206,7 +189,6 @@ describe('UploadArtistAvatarHandler', () => {
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
 
-    // Cleanup should be called
     const expectedNewKey = `artists/artist-123/avatar-${new Date('2024-01-01').getTime()}.webp`;
     expect(storageService.deleteFile).toHaveBeenCalledWith(FileBucket.public, expectedNewKey);
   });
@@ -219,21 +201,20 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      avatarId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue({
+    artistRepository.findOne.mockResolvedValue(
+      artistBuilder({ id: 'artist-123', avatarId: 'img-old' }),
+    );
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue({
       id: 'img-old',
       bucket: FileBucket.public,
       key: 'old-key',
     } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const loggerSpy = vi.spyOn((handler as any).logger, 'error').mockImplementation(() => {});
-    vi.mocked(storageService.deleteFile).mockRejectedValue(new Error('Delete error'));
+    storageService.deleteFile.mockRejectedValue(new Error('Delete error'));
 
     await handler.execute(command);
 
@@ -251,17 +232,18 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
-    vi.mocked(prismaService.mainClient.$transaction).mockRejectedValue(new Error('DB Error'));
+    vi.mocked((prismaService as any).mainClient.$transaction).mockRejectedValue(
+      new Error('DB Error'),
+    );
 
     const loggerSpy = vi.spyOn((handler as any).logger, 'error').mockImplementation(() => {});
-    vi.mocked(storageService.deleteFile).mockRejectedValue(new Error('Delete error'));
+    storageService.deleteFile.mockRejectedValue(new Error('Delete error'));
 
-    // Should still throw the original DB error
     await expect(handler.execute(command)).rejects.toThrow('DB Error');
 
     expect(loggerSpy).toHaveBeenCalledWith(
@@ -278,14 +260,13 @@ describe('UploadArtistAvatarHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      avatarId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue(null); // Orphaned
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(
+      artistBuilder({ id: 'artist-123', avatarId: 'img-old' }),
+    );
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue(null);
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const result = await handler.execute(command);
     const expectedNewKey = `artists/artist-123/avatar-${new Date('2024-01-01').getTime()}.webp`;
@@ -299,7 +280,6 @@ describe('UploadArtistAvatarHandler', () => {
     );
     expect(mockTx.image.delete).toHaveBeenCalledWith({ where: { id: 'img-old' } });
 
-    // Should NOT attempt to delete old file from storage because it wasn't found
     expect(storageService.deleteFile).not.toHaveBeenCalledWith(FileBucket.public, 'old-key');
   });
 });

--- a/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-avatar.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-avatar.handler.spec.ts
@@ -52,6 +52,9 @@ describe('UploadLibraryArtistAvatarHandler', () => {
     prismaService = createMock<PrismaService>();
 
     storageService.deleteFile.mockResolvedValue(undefined);
+    // DeepMocked<PrismaService> does not expose client/mainClient; these casts are a deliberate
+    // workaround to inject mocked implementations (image.findUnique, mainClient.$transaction with
+    // mockTx) so transactional code in the handler can be tested.
     (prismaService as any).client = {
       image: { findUnique: vi.fn() },
     };

--- a/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-banner.handler.spec.ts
+++ b/apps/api/src/features/library-artists/commands/handlers/upload-library-artist-banner.handler.spec.ts
@@ -9,16 +9,18 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileBucket } from '@repo/db';
-import { vi } from 'vitest';
+import { artistBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UploadLibraryArtistBannerCommand } from '../impl/upload-library-artist-banner.command';
 import { UploadLibraryArtistBannerHandler } from './upload-library-artist-banner.handler';
 
 describe('UploadLibraryArtistBannerHandler', () => {
   let handler: UploadLibraryArtistBannerHandler;
-  let artistRepository: ArtistRepository;
-  let storageService: StorageService;
-  let imageService: ImageService;
-  let prismaService: PrismaService;
+  let artistRepository: DeepMocked<ArtistRepository>;
+  let storageService: DeepMocked<StorageService>;
+  let imageService: DeepMocked<ImageService>;
+  let prismaService: DeepMocked<PrismaService>;
 
   const mockTx = {
     image: {
@@ -44,50 +46,33 @@ describe('UploadLibraryArtistBannerHandler', () => {
   };
 
   beforeEach(async () => {
+    artistRepository = createMock<ArtistRepository>();
+    storageService = createMock<StorageService>();
+    imageService = createMock<ImageService>();
+    prismaService = createMock<PrismaService>();
+
+    storageService.deleteFile.mockResolvedValue(undefined);
+    // DeepMocked<PrismaService> does not expose client/mainClient; these casts are a deliberate
+    // workaround to inject mocked implementations (image.findUnique, mainClient.$transaction with
+    // mockTx) so transactional code in the handler can be tested.
+    (prismaService as any).client = {
+      image: { findUnique: vi.fn() },
+    };
+    (prismaService as any).mainClient = {
+      $transaction: vi.fn((cb: (tx: typeof mockTx) => unknown) => cb(mockTx)),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UploadLibraryArtistBannerHandler,
-        {
-          provide: ArtistRepository,
-          useValue: {
-            findOne: vi.fn(),
-          },
-        },
-        {
-          provide: StorageService,
-          useValue: {
-            uploadFile: vi.fn(),
-            deleteFile: vi.fn().mockResolvedValue(undefined),
-          },
-        },
-        {
-          provide: ImageService,
-          useValue: {
-            validateImage: vi.fn(),
-            resizeToMaxDimension: vi.fn(),
-          },
-        },
-        {
-          provide: PrismaService,
-          useValue: {
-            client: {
-              image: {
-                findUnique: vi.fn(),
-              },
-            },
-            mainClient: {
-              $transaction: vi.fn((cb) => cb(mockTx)),
-            },
-          },
-        },
+        { provide: ArtistRepository, useValue: artistRepository },
+        { provide: StorageService, useValue: storageService },
+        { provide: ImageService, useValue: imageService },
+        { provide: PrismaService, useValue: prismaService },
       ],
     }).compile();
 
     handler = module.get<UploadLibraryArtistBannerHandler>(UploadLibraryArtistBannerHandler);
-    artistRepository = module.get<ArtistRepository>(ArtistRepository);
-    storageService = module.get<StorageService>(StorageService);
-    imageService = module.get<ImageService>(ImageService);
-    prismaService = module.get<PrismaService>(PrismaService);
 
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01'));
@@ -96,6 +81,8 @@ describe('UploadLibraryArtistBannerHandler', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should upload artist banner and cleanup old one successfully', async () => {
@@ -106,18 +93,16 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      bannerId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue({
+    const mockArtist = artistBuilder({ id: 'artist-123', bannerId: 'img-old' });
+    artistRepository.findOne.mockResolvedValue(mockArtist);
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue({
       id: 'img-old',
       bucket: FileBucket.public,
       key: 'old-key',
     } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const result = await handler.execute(command);
     const expectedNewKey = `artists/artist-123/banner-${new Date('2024-01-01').getTime()}.webp`;
@@ -142,15 +127,17 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockImplementation(async (_buf, _bucket, key) => ({
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockImplementation(async (_buf, _bucket, key) => ({
       url: 'new-url',
       key,
     }));
 
-    vi.mocked(prismaService.mainClient.$transaction).mockRejectedValue(new Error('DB Error'));
+    vi.mocked((prismaService as any).mainClient.$transaction).mockRejectedValue(
+      new Error('DB Error'),
+    );
 
     await expect(handler.execute(command)).rejects.toThrow('DB Error');
 
@@ -166,7 +153,7 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue(null);
+    artistRepository.findOne.mockResolvedValue(null);
 
     await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
   });
@@ -179,8 +166,8 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(false);
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(false);
 
     await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
   });
@@ -193,14 +180,14 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     vi.mocked(mockTx.image.create).mockResolvedValueOnce({
       id: 'img-new',
-      // missing required fields
+      // missing other required fields
     } as any);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
@@ -217,21 +204,20 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      bannerId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue({
+    artistRepository.findOne.mockResolvedValue(
+      artistBuilder({ id: 'artist-123', bannerId: 'img-old' }),
+    );
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue({
       id: 'img-old',
       bucket: FileBucket.public,
       key: 'old-key',
     } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const loggerSpy = vi.spyOn((handler as any).logger, 'error').mockImplementation(() => {});
-    vi.mocked(storageService.deleteFile).mockRejectedValue(new Error('Delete error'));
+    storageService.deleteFile.mockRejectedValue(new Error('Delete error'));
 
     await handler.execute(command);
 
@@ -249,15 +235,17 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({ id: 'artist-123' } as any);
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(artistBuilder({ id: 'artist-123' }));
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
-    vi.mocked(prismaService.mainClient.$transaction).mockRejectedValue(new Error('DB Error'));
+    vi.mocked((prismaService as any).mainClient.$transaction).mockRejectedValue(
+      new Error('DB Error'),
+    );
 
     const loggerSpy = vi.spyOn((handler as any).logger, 'error').mockImplementation(() => {});
-    vi.mocked(storageService.deleteFile).mockRejectedValue(new Error('Delete error'));
+    storageService.deleteFile.mockRejectedValue(new Error('Delete error'));
 
     await expect(handler.execute(command)).rejects.toThrow('DB Error');
 
@@ -275,14 +263,13 @@ describe('UploadLibraryArtistBannerHandler', () => {
       'user-123',
     );
 
-    vi.mocked(artistRepository.findOne).mockResolvedValue({
-      id: 'artist-123',
-      bannerId: 'img-old',
-    } as any);
-    vi.mocked(prismaService.client.image.findUnique).mockResolvedValue(null); // Orphaned
-    vi.mocked(imageService.validateImage).mockResolvedValue(true);
-    vi.mocked(imageService.resizeToMaxDimension).mockResolvedValue(Buffer.from('processed'));
-    vi.mocked(storageService.uploadFile).mockResolvedValue({ url: 'new-url', key: 'new-key' });
+    artistRepository.findOne.mockResolvedValue(
+      artistBuilder({ id: 'artist-123', bannerId: 'img-old' }),
+    );
+    vi.mocked((prismaService as any).client.image.findUnique).mockResolvedValue(null);
+    imageService.validateImage.mockResolvedValue(true);
+    imageService.resizeToMaxDimension.mockResolvedValue(Buffer.from('processed'));
+    storageService.uploadFile.mockResolvedValue({ url: 'new-url', key: 'new-key' });
 
     const result = await handler.execute(command);
     const expectedNewKey = `artists/artist-123/banner-${new Date('2024-01-01').getTime()}.webp`;
@@ -296,7 +283,6 @@ describe('UploadLibraryArtistBannerHandler', () => {
     );
     expect(mockTx.image.delete).toHaveBeenCalledWith({ where: { id: 'img-old' } });
 
-    // Should NOT attempt to delete old file from storage because it wasn't found
     expect(storageService.deleteFile).not.toHaveBeenCalledWith(FileBucket.public, 'old-key');
   });
 });

--- a/apps/api/src/features/library-artists/queries/handlers/get-library-artist-albums.handler.spec.ts
+++ b/apps/api/src/features/library-artists/queries/handlers/get-library-artist-albums.handler.spec.ts
@@ -1,52 +1,50 @@
 import { LibraryAlbumRepository } from '@/shared/repositories/library-album.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { libraryAlbumBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryArtistAlbumsQuery } from '../impl/get-library-artist-albums.query';
 import { GetLibraryArtistAlbumsHandler } from './get-library-artist-albums.handler';
 
 describe('GetLibraryArtistAlbumsHandler', () => {
   let handler: GetLibraryArtistAlbumsHandler;
-  let libraryRepository: LibraryRepository;
-  let libraryAlbumRepository: LibraryAlbumRepository;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let libraryAlbumRepository: DeepMocked<LibraryAlbumRepository>;
+
+  const userId = 'user-123';
+  const artistId = 'artist-123';
+  const libraryId = 'lib-123';
+  const mockLibrary = libraryBuilder({ id: libraryId, userId });
+  const mockAlbums = [libraryAlbumBuilder({ id: 'la-1', libraryId, albumId: 'a-1' })];
+  const mockTotal = 1;
 
   beforeEach(async () => {
+    libraryRepository = createMock<LibraryRepository>();
+    libraryAlbumRepository = createMock<LibraryAlbumRepository>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetLibraryArtistAlbumsHandler,
-        {
-          provide: LibraryRepository,
-          useValue: {
-            getByUserId: vi.fn(),
-          },
-        },
-        {
-          provide: LibraryAlbumRepository,
-          useValue: {
-            findMany: vi.fn(),
-            count: vi.fn(),
-          },
-        },
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: LibraryAlbumRepository, useValue: libraryAlbumRepository },
       ],
     }).compile();
 
     handler = module.get<GetLibraryArtistAlbumsHandler>(GetLibraryArtistAlbumsHandler);
-    libraryRepository = module.get<LibraryRepository>(LibraryRepository);
-    libraryAlbumRepository = module.get<LibraryAlbumRepository>(LibraryAlbumRepository);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('should return albums and total count when library exists', async () => {
-    const userId = 'user-123';
-    const artistId = 'artist-123';
-    const mockLibrary = { id: 'lib-123' };
-    const mockAlbums = [{ id: 'la-1', albumId: 'a-1' }];
-    const mockTotal = 1;
     const query = new GetLibraryArtistAlbumsQuery(userId, artistId, 1, 10, 'album');
 
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(mockLibrary as any);
-    vi.mocked(libraryAlbumRepository.findMany).mockResolvedValue(mockAlbums as any);
-    vi.mocked(libraryAlbumRepository.count).mockResolvedValue(mockTotal);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryAlbumRepository.findMany.mockResolvedValue(mockAlbums);
+    libraryAlbumRepository.count.mockResolvedValue(mockTotal);
 
     const result = await handler.execute(query);
 
@@ -77,11 +75,9 @@ describe('GetLibraryArtistAlbumsHandler', () => {
   });
 
   it('should throw PreconditionFailedException if library not found', async () => {
-    const userId = 'user-123';
-    const artistId = 'artist-123';
     const query = new GetLibraryArtistAlbumsQuery(userId, artistId, 1, 10);
 
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(null);
+    libraryRepository.getByUserId.mockResolvedValue(null);
 
     await expect(handler.execute(query)).rejects.toThrow(PreconditionFailedException);
     expect(libraryRepository.getByUserId).toHaveBeenCalledWith(userId);

--- a/apps/api/src/features/library-artists/queries/handlers/get-library-artist.handler.spec.ts
+++ b/apps/api/src/features/library-artists/queries/handlers/get-library-artist.handler.spec.ts
@@ -1,49 +1,51 @@
 import { LibraryArtistRepository } from '@/shared/repositories/library-artist.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { libraryArtistBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException, PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryArtistQuery } from '../impl/get-library-artist.query';
 import { GetLibraryArtistHandler } from './get-library-artist.handler';
 
 describe('GetLibraryArtistHandler', () => {
   let handler: GetLibraryArtistHandler;
-  let libraryRepository: LibraryRepository;
-  let libraryArtistRepository: LibraryArtistRepository;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let libraryArtistRepository: DeepMocked<LibraryArtistRepository>;
+
+  const userId = 'user-123';
+  const artistId = 'artist-123';
+  const libraryId = 'lib-123';
+  const mockLibrary = libraryBuilder({ id: libraryId, userId });
+  const mockLibraryArtist = libraryArtistBuilder({
+    id: 'la-123',
+    artistId,
+    libraryId,
+  });
 
   beforeEach(async () => {
+    libraryRepository = createMock<LibraryRepository>();
+    libraryArtistRepository = createMock<LibraryArtistRepository>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetLibraryArtistHandler,
-        {
-          provide: LibraryRepository,
-          useValue: {
-            getByUserId: vi.fn(),
-          },
-        },
-        {
-          provide: LibraryArtistRepository,
-          useValue: {
-            findOne: vi.fn(),
-          },
-        },
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: LibraryArtistRepository, useValue: libraryArtistRepository },
       ],
     }).compile();
 
     handler = module.get<GetLibraryArtistHandler>(GetLibraryArtistHandler);
-    libraryRepository = module.get<LibraryRepository>(LibraryRepository);
-    libraryArtistRepository = module.get<LibraryArtistRepository>(LibraryArtistRepository);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should return library artist if found', async () => {
-    const userId = 'user-123';
-    const artistId = 'artist-123';
-    const libraryId = 'lib-123';
-    const mockLibrary = { id: libraryId };
-    const mockLibraryArtist = { id: 'la-123', artistId, libraryId };
-
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(mockLibrary as any);
-    vi.mocked(libraryArtistRepository.findOne).mockResolvedValue(mockLibraryArtist as any);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryArtistRepository.findOne.mockResolvedValue(mockLibraryArtist);
 
     const query = new GetLibraryArtistQuery(userId, artistId);
     const result = await handler.execute(query);
@@ -57,10 +59,7 @@ describe('GetLibraryArtistHandler', () => {
   });
 
   it('should throw PreconditionFailedException if library not found', async () => {
-    const userId = 'user-123';
-    const artistId = 'artist-123';
-
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(null);
+    libraryRepository.getByUserId.mockResolvedValue(null);
 
     const query = new GetLibraryArtistQuery(userId, artistId);
 
@@ -70,13 +69,8 @@ describe('GetLibraryArtistHandler', () => {
   });
 
   it('should throw NotFoundException if artist not found in library', async () => {
-    const userId = 'user-123';
-    const artistId = 'artist-123';
-    const libraryId = 'lib-123';
-    const mockLibrary = { id: libraryId };
-
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(mockLibrary as any);
-    vi.mocked(libraryArtistRepository.findOne).mockResolvedValue(null);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryArtistRepository.findOne.mockResolvedValue(null);
 
     const query = new GetLibraryArtistQuery(userId, artistId);
 

--- a/apps/api/src/features/library-artists/queries/handlers/get-library-artists.handler.spec.ts
+++ b/apps/api/src/features/library-artists/queries/handlers/get-library-artists.handler.spec.ts
@@ -1,56 +1,52 @@
 import { LibraryArtistRepository } from '@/shared/repositories/library-artist.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
+import { libraryArtistBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryArtistsQuery } from '../impl/get-library-artists.query';
 import { GetLibraryArtistsHandler } from './get-library-artists.handler';
 
 describe('GetLibraryArtistsHandler', () => {
   let handler: GetLibraryArtistsHandler;
-  let libraryRepository: LibraryRepository;
-  let libraryArtistRepository: LibraryArtistRepository;
+  let libraryRepository: DeepMocked<LibraryRepository>;
+  let libraryArtistRepository: DeepMocked<LibraryArtistRepository>;
+
+  const userId = 'user-123';
+  const page = 1;
+  const limit = 10;
+  const libraryId = 'lib-123';
+  const mockLibrary = libraryBuilder({ id: libraryId, userId });
+  const mockItems = [
+    libraryArtistBuilder({ id: 'la-1', libraryId }),
+    libraryArtistBuilder({ id: 'la-2', libraryId }),
+  ];
+  const mockTotal = 2;
 
   beforeEach(async () => {
+    libraryRepository = createMock<LibraryRepository>();
+    libraryArtistRepository = createMock<LibraryArtistRepository>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetLibraryArtistsHandler,
-        {
-          provide: LibraryRepository,
-          useValue: {
-            getByUserId: vi.fn(),
-          },
-        },
-        {
-          provide: LibraryArtistRepository,
-          useValue: {
-            findMany: vi.fn(),
-            count: vi.fn(),
-          },
-        },
+        { provide: LibraryRepository, useValue: libraryRepository },
+        { provide: LibraryArtistRepository, useValue: libraryArtistRepository },
       ],
     }).compile();
 
     handler = module.get<GetLibraryArtistsHandler>(GetLibraryArtistsHandler);
-    libraryRepository = module.get<LibraryRepository>(LibraryRepository);
-    libraryArtistRepository = module.get<LibraryArtistRepository>(LibraryArtistRepository);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it('should return library artists list with metadata', async () => {
-    const userId = 'user-123';
-    const page = 1;
-    const limit = 10;
-    const libraryId = 'lib-123';
-    const mockLibrary = { id: libraryId };
-    const mockItems = [
-      { id: 'la-1', name: 'Artist 1' },
-      { id: 'la-2', name: 'Artist 2' },
-    ];
-    const mockTotal = 2;
-
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(mockLibrary as any);
-    vi.mocked(libraryArtistRepository.findMany).mockResolvedValue(mockItems as any);
-    vi.mocked(libraryArtistRepository.count).mockResolvedValue(mockTotal);
+    libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
+    libraryArtistRepository.findMany.mockResolvedValue(mockItems);
+    libraryArtistRepository.count.mockResolvedValue(mockTotal);
 
     const query = new GetLibraryArtistsQuery(userId, page, limit);
     const result = await handler.execute(query);
@@ -71,11 +67,7 @@ describe('GetLibraryArtistsHandler', () => {
   });
 
   it('should throw PreconditionFailedException if library not found', async () => {
-    const userId = 'user-123';
-    const page = 1;
-    const limit = 10;
-
-    vi.mocked(libraryRepository.getByUserId).mockResolvedValue(null);
+    libraryRepository.getByUserId.mockResolvedValue(null);
 
     const query = new GetLibraryArtistsQuery(userId, page, limit);
 

--- a/apps/api/src/features/library-tracks/commands/handlers/bulk-create-library-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/bulk-create-library-tracks.handler.spec.ts
@@ -7,7 +7,7 @@ import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TrackSchema } from '@repo/contracts';
-import { AlbumType, Track } from '@repo/db';
+import { AlbumType, Track, Visibility } from '@repo/db';
 import { albumBuilder, libraryBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -59,7 +59,7 @@ describe('BulkCreateLibraryTracksHandler', () => {
     totalDuration: 3000,
     releaseDate: new Date(),
     coverId: null,
-    visibility: 'private',
+    visibility: Visibility.private,
   });
 
   const mockTrack1: Track = trackBuilder({
@@ -70,7 +70,7 @@ describe('BulkCreateLibraryTracksHandler', () => {
     duration: 0,
     explicit: false,
     albumId,
-    visibility: 'private',
+    visibility: Visibility.private,
   });
 
   const mockTrack2: Track = trackBuilder({
@@ -81,7 +81,7 @@ describe('BulkCreateLibraryTracksHandler', () => {
     duration: 0,
     explicit: true,
     albumId,
-    visibility: 'private',
+    visibility: Visibility.private,
   });
 
   beforeEach(async () => {
@@ -136,7 +136,7 @@ describe('BulkCreateLibraryTracksHandler', () => {
       diskNumber: body.tracks[0].diskNumber,
       duration: 0,
       explicit: body.tracks[0].explicit,
-      visibility: 'private',
+      visibility: Visibility.private,
       album: { connect: { id: albumId } },
       artists: { connect: body.tracks[0].artistIds.map((id) => ({ id })) },
       access: {
@@ -152,7 +152,7 @@ describe('BulkCreateLibraryTracksHandler', () => {
       diskNumber: body.tracks[1].diskNumber,
       duration: 0,
       explicit: body.tracks[1].explicit,
-      visibility: 'private',
+      visibility: Visibility.private,
       album: { connect: { id: albumId } },
       artists: { connect: body.tracks[1].artistIds.map((id) => ({ id })) },
       access: {

--- a/apps/api/src/features/library-tracks/commands/handlers/bulk-create-library-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/bulk-create-library-tracks.handler.spec.ts
@@ -3,12 +3,14 @@ import { LibraryTrackRepository } from '@/shared/repositories/library-track.repo
 import { LibraryRepository } from '@/shared/repositories/library.repository';
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TrackSchema } from '@repo/contracts';
-import { Album, Library, Track } from '@repo/db';
+import { AlbumType, Track } from '@repo/db';
+import { albumBuilder, libraryBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { BulkCreateLibraryTracksCommand } from '../impl/bulk-create-library-tracks.command';
 import { BulkCreateLibraryTracksHandler } from './bulk-create-library-tracks.handler';
 
@@ -43,60 +45,44 @@ describe('BulkCreateLibraryTracksHandler', () => {
     ],
   };
 
-  const mockLibrary: Library = {
+  const mockLibrary = libraryBuilder({
     id: libraryId,
     userId,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
-  const mockAlbum: Album = {
+  const mockAlbum = albumBuilder({
     id: albumId,
     name: 'Test Album',
     description: 'Test Description',
-    type: 'album',
+    type: AlbumType.album,
     totalTracks: 10,
     totalDuration: 3000,
     releaseDate: new Date(),
     coverId: null,
     visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
-  const mockTrack1: Track = {
+  const mockTrack1: Track = trackBuilder({
     id: 'track-1',
     title: 'Track 1',
     trackNumber: 1,
     diskNumber: 1,
     duration: 0,
     explicit: false,
-    lyrics: null,
-    listenedCount: 0,
     albumId,
     visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
-  const mockTrack2: Track = {
+  const mockTrack2: Track = trackBuilder({
     id: 'track-2',
     title: 'Track 2',
     trackNumber: 2,
     diskNumber: 1,
     duration: 0,
     explicit: true,
-    lyrics: null,
-    listenedCount: 0,
     albumId,
     visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -231,12 +217,13 @@ describe('BulkCreateLibraryTracksHandler', () => {
 
     libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     albumRepository.findOne.mockResolvedValue(mockAlbum);
-    trackRepository.create.mockResolvedValue({ ...mockTrack1, title: 123 } as any);
+    // @ts-expect-error - we are testing the validation failure
+    trackRepository.create.mockResolvedValue({ ...mockTrack1, title: 123 });
 
     vi.spyOn(TrackSchema, 'safeParse').mockReturnValue({
       success: false,
-      error: { format: () => ({}) },
-    } as any);
+      error: new z.ZodError([]),
+    } as ReturnType<typeof TrackSchema.safeParse>);
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
     await expect(handler.execute(command)).rejects.toThrow('Failed to parse track');

--- a/apps/api/src/features/library-tracks/commands/handlers/bulk-upload-track-audio.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/bulk-upload-track-audio.handler.spec.ts
@@ -1,31 +1,23 @@
 import { AudioFileRepository } from '@/shared/repositories/audio-file.repository';
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { StorageService } from '@/shared/services/storage.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
 import { getQueueToken } from '@nestjs/bullmq';
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AudioFileSchema } from '@repo/contracts';
-import { AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
+import { AccessRole, AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
+import {
+  audioFileBuilder,
+  createMockFile,
+  trackWithAccessBuilder,
+  type TrackWithAccessAndAlbumId,
+} from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { Queue } from 'bullmq';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { BulkUploadTrackAudioCommand } from '../impl/bulk-upload-track-audio.command';
 import { BulkUploadTrackAudioHandler } from './bulk-upload-track-audio.handler';
-
-const createMockFile = (overrides: Partial<Express.Multer.File> = {}): Express.Multer.File =>
-  ({
-    buffer: Buffer.from('test audio content'),
-    mimetype: 'audio/mpeg',
-    originalname: 'test-song.mp3',
-    size: 1024,
-    fieldname: 'file',
-    encoding: '7bit',
-    destination: '',
-    filename: '',
-    path: '',
-    stream: null as any,
-    ...overrides,
-  }) as Express.Multer.File;
 
 describe('BulkUploadTrackAudioHandler', () => {
   let handler: BulkUploadTrackAudioHandler;
@@ -39,32 +31,26 @@ describe('BulkUploadTrackAudioHandler', () => {
   const trackId1 = 'track-1';
   const trackId2 = 'track-2';
 
-  const mockTrackWithAccess = (trackId: string, albumIdParam: string) => ({
-    id: trackId,
-    albumId: albumIdParam,
-    access: [{ userId, role: 'owner' }],
-  });
+  const mockTrackWithAccess = (trackId: string, albumIdParam: string): TrackWithAccessAndAlbumId =>
+    trackWithAccessBuilder({
+      id: trackId,
+      albumId: albumIdParam,
+      userId,
+      role: AccessRole.owner,
+    }) as TrackWithAccessAndAlbumId;
 
-  const mockAudioFile = (id: string, trackId: string) => ({
-    id,
-    bucket: FileBucket.private,
-    key: `tracks/${trackId}/originals/key`,
-    url: 'https://storage.url/file',
-    mimeType: 'audio/mpeg',
-    size: 1024,
-    format: AudioFormat.mp3,
-    duration: null,
-    bitrate: null,
-    sampleRate: null,
-    channels: null,
-    isOriginal: true,
-    waveformJson: null,
-    trackId,
-    quality: 'original' as const,
-    status: ProcessingStatus.pending,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+  const mockAudioFileForTrack = (id: string, trackIdParam: string) =>
+    audioFileBuilder({
+      id,
+      trackId: trackIdParam,
+      bucket: FileBucket.private,
+      key: `tracks/${trackIdParam}/originals/key`,
+      url: 'https://storage.url/file',
+      mimeType: 'audio/mpeg',
+      size: 1024,
+      format: AudioFormat.mp3,
+      status: ProcessingStatus.pending,
+    });
 
   beforeEach(async () => {
     trackRepository = createMock<TrackRepository>();
@@ -142,7 +128,7 @@ describe('BulkUploadTrackAudioHandler', () => {
     });
 
     it('should throw BadRequestException when file has no buffer', async () => {
-      const invalidFile = createMockFile({ buffer: undefined as any });
+      const invalidFile = createMockFile({ buffer: undefined });
       const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [invalidFile], userId);
 
       await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
@@ -183,9 +169,9 @@ describe('BulkUploadTrackAudioHandler', () => {
         [file1, invalidMimeFile],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId) as any);
+      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId));
       storageService.uploadFile.mockResolvedValue({ url: 'https://s3.url/file', key: 'key' });
-      audioFileRepository.create.mockResolvedValue(mockAudioFile('af-1', trackId1) as any);
+      audioFileRepository.create.mockResolvedValue(mockAudioFileForTrack('af-1', trackId1));
 
       await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -194,7 +180,8 @@ describe('BulkUploadTrackAudioHandler', () => {
     });
 
     it('should throw BadRequestException when file is null', async () => {
-      const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [null as any], userId);
+      // @ts-expect-error - we are testing invalid input (null file)
+      const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [null], userId);
 
       await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
       await expect(handler.execute(command)).rejects.toThrow('File at index 0 is empty or invalid');
@@ -220,9 +207,7 @@ describe('BulkUploadTrackAudioHandler', () => {
         [createMockFile()],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue(
-        mockTrackWithAccess(trackId1, 'other-album-id') as any,
-      );
+      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, 'other-album-id'));
 
       await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -237,11 +222,13 @@ describe('BulkUploadTrackAudioHandler', () => {
         [createMockFile()],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithOtherOwner = trackWithAccessBuilder({
         id: trackId1,
         albumId,
-        access: [{ userId: 'other-user', role: 'owner' }],
-      } as any);
+        userId: 'other-user',
+        role: AccessRole.owner,
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithOtherOwner);
 
       await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -256,11 +243,13 @@ describe('BulkUploadTrackAudioHandler', () => {
         [createMockFile()],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithViewerAccess = trackWithAccessBuilder({
         id: trackId1,
         albumId,
-        access: [{ userId, role: 'viewer' }],
-      } as any);
+        userId,
+        role: AccessRole.viewer,
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithViewerAccess);
 
       await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -275,10 +264,12 @@ describe('BulkUploadTrackAudioHandler', () => {
         [createMockFile()],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithoutAccess = trackWithAccessBuilder({
         id: trackId1,
         albumId,
-      } as any);
+        access: [],
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithoutAccess);
 
       await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -289,13 +280,15 @@ describe('BulkUploadTrackAudioHandler', () => {
     it('should allow editor role', async () => {
       const file = createMockFile();
       const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [file], userId);
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithEditorAccess = trackWithAccessBuilder({
         id: trackId1,
         albumId,
-        access: [{ userId, role: 'editor' }],
-      } as any);
+        userId,
+        role: AccessRole.editor,
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithEditorAccess);
       storageService.uploadFile.mockResolvedValue({ url: 'https://s3.url/file', key: 'key' });
-      audioFileRepository.create.mockResolvedValue(mockAudioFile('af-1', trackId1) as any);
+      audioFileRepository.create.mockResolvedValue(mockAudioFileForTrack('af-1', trackId1));
 
       const result = await handler.execute(command);
 
@@ -313,9 +306,9 @@ describe('BulkUploadTrackAudioHandler', () => {
     it('should succeed when file size is exactly 100MB', async () => {
       const file = createMockFile({ size: 100 * 1024 * 1024 });
       const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [file], userId);
-      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId) as any);
+      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId));
       storageService.uploadFile.mockResolvedValue({ url: 'https://s3.url/file', key: 'key' });
-      audioFileRepository.create.mockResolvedValue(mockAudioFile('af-1', trackId1) as any);
+      audioFileRepository.create.mockResolvedValue(mockAudioFileForTrack('af-1', trackId1));
 
       const result = await handler.execute(command);
 
@@ -335,14 +328,14 @@ describe('BulkUploadTrackAudioHandler', () => {
       );
 
       trackRepository.findOne
-        .mockResolvedValueOnce(mockTrackWithAccess(trackId1, albumId) as any)
-        .mockResolvedValueOnce(mockTrackWithAccess(trackId2, albumId) as any);
+        .mockResolvedValueOnce(mockTrackWithAccess(trackId1, albumId))
+        .mockResolvedValueOnce(mockTrackWithAccess(trackId2, albumId));
 
       storageService.uploadFile.mockResolvedValue({ url: 'https://s3.url/file', key: 'key' });
 
       audioFileRepository.create
-        .mockResolvedValueOnce(mockAudioFile('af-1', trackId1) as any)
-        .mockResolvedValueOnce(mockAudioFile('af-2', trackId2) as any);
+        .mockResolvedValueOnce(mockAudioFileForTrack('af-1', trackId1))
+        .mockResolvedValueOnce(mockAudioFileForTrack('af-2', trackId2));
 
       const result = await handler.execute(command);
 
@@ -400,14 +393,14 @@ describe('BulkUploadTrackAudioHandler', () => {
         [createMockFile()],
         userId,
       );
-      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId) as any);
+      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId));
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
-      audioFileRepository.create.mockResolvedValue({ invalid: 'data' } as any);
+      audioFileRepository.create.mockResolvedValue(audioFileBuilder({ id: 'af-1' }));
 
       vi.spyOn(AudioFileSchema, 'safeParse').mockReturnValue({
         success: false,
-        error: { format: () => ({}) },
-      } as any);
+        error: new z.ZodError([]),
+      } as ReturnType<typeof AudioFileSchema.safeParse>);
 
       await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
       await expect(handler.execute(command)).rejects.toThrow(
@@ -426,11 +419,11 @@ describe('BulkUploadTrackAudioHandler', () => {
       );
 
       trackRepository.findOne
-        .mockResolvedValueOnce(mockTrackWithAccess(trackId1, albumId) as any)
+        .mockResolvedValueOnce(mockTrackWithAccess(trackId1, albumId))
         .mockResolvedValueOnce(null);
 
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
-      audioFileRepository.create.mockResolvedValue(mockAudioFile('af-1', trackId1) as any);
+      audioFileRepository.create.mockResolvedValue(mockAudioFileForTrack('af-1', trackId1));
 
       await expect(handler.execute(command)).rejects.toThrow(
         new NotFoundException(`Track ${trackId2} not found`),
@@ -541,9 +534,9 @@ describe('BulkUploadTrackAudioHandler', () => {
       const file = createMockFile({ mimetype, originalname });
       const command = new BulkUploadTrackAudioCommand(albumId, [trackId1], [file], userId);
 
-      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId) as any);
+      trackRepository.findOne.mockResolvedValue(mockTrackWithAccess(trackId1, albumId));
       storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
-      audioFileRepository.create.mockResolvedValue(mockAudioFile('af-1', trackId1) as any);
+      audioFileRepository.create.mockResolvedValue(mockAudioFileForTrack('af-1', trackId1));
 
       await handler.execute(command);
 

--- a/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/create-library-track.handler.spec.ts
@@ -3,10 +3,11 @@ import { LibraryTrackRepository } from '@/shared/repositories/library-track.repo
 import { LibraryRepository } from '@/shared/repositories/library.repository';
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Album, Library, Track } from '@repo/db';
+import { AlbumType, Track, Visibility } from '@repo/db';
+import { albumBuilder, libraryBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateLibraryTrackCommand } from '../impl/create-library-track.command';
 import { CreateLibraryTrackHandler } from './create-library-track.handler';
@@ -32,44 +33,33 @@ describe('CreateLibraryTrackHandler', () => {
     userId,
   );
 
-  const mockLibrary: Library = {
+  const mockLibrary = libraryBuilder({
     id: 'library-123',
     userId,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
-  const mockAlbum: Album = {
+  const mockAlbum = albumBuilder({
     id: 'album-123',
     name: 'Test Album',
     description: 'Test Description',
-    type: 'album',
+    type: AlbumType.album,
     totalTracks: 10,
     totalDuration: 3000,
     releaseDate: new Date(),
     coverId: null,
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+    visibility: Visibility.private,
+  });
 
-  const mockTrack: Track = {
+  const mockTrack: Track = trackBuilder({
     id: 'track-123',
     title: 'Test Track',
     trackNumber: 1,
     diskNumber: 1,
     duration: 180,
     explicit: false,
-    lyrics: null,
-    listenedCount: 0,
     albumId: 'album-123',
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+    visibility: Visibility.private,
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -131,7 +121,8 @@ describe('CreateLibraryTrackHandler', () => {
   it('should throw InternalServerErrorException if Zod validation fails', async () => {
     libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
     albumRepository.findOne.mockResolvedValue(mockAlbum);
-    trackRepository.create.mockResolvedValue({ ...mockTrack, title: 123 as any }); // Invalid title
+    // @ts-expect-error - we are testing the validation failure
+    trackRepository.create.mockResolvedValue({ ...mockTrack, title: 123 });
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
   });

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
@@ -6,7 +6,7 @@ import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
 import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { type Track, AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
+import { type Track, AudioFormat, FileBucket, ProcessingStatus, Visibility } from '@repo/db';
 import { audioFileBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
@@ -31,7 +31,7 @@ describe('DeleteLibraryTrackHandler', () => {
     diskNumber: 1,
     duration: 180,
     albumId: 'album-123',
-    visibility: 'private',
+    visibility: Visibility.private,
   });
 
   beforeEach(async () => {

--- a/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/delete-library-track.handler.spec.ts
@@ -3,10 +3,11 @@ import { LibraryTrackRepository } from '@/shared/repositories/library-track.repo
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { StorageService } from '@/shared/services/storage.service';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { FileBucket, Track } from '@repo/db';
+import { type Track, AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
+import { audioFileBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeleteLibraryTrackCommand } from '../impl/delete-library-track.command';
 import { DeleteLibraryTrackHandler } from './delete-library-track.handler';
@@ -23,21 +24,15 @@ describe('DeleteLibraryTrackHandler', () => {
   const trackId = 'track-123';
   const command = new DeleteLibraryTrackCommand(trackId, userId);
 
-  const mockTrack: Track = {
+  const mockTrack: Track = trackBuilder({
     id: trackId,
     title: 'Test Track',
     trackNumber: 1,
     diskNumber: 1,
     duration: 180,
-    listenedCount: 0,
-    explicit: false,
-    lyrics: null,
     albumId: 'album-123',
     visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -73,28 +68,22 @@ describe('DeleteLibraryTrackHandler', () => {
   });
 
   it('should soft delete track, remove library tracks, and delete audio files', async () => {
-    const mockAudioFile = {
+    const mockAudioFile = audioFileBuilder({
       id: 'audio-1',
       trackId,
       bucket: FileBucket.private,
       key: 'audio/key',
-      url: null,
       mimeType: 'audio/mpeg',
       size: 1000,
-      format: 'mp3',
+      format: AudioFormat.mp3,
       duration: 180,
       bitrate: 320,
       sampleRate: 44100,
       channels: 2,
-      isOriginal: true,
-      waveformJson: null,
-      quality: 'original',
-      status: 'complete',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+      status: ProcessingStatus.complete,
+    });
     trackRepository.findOne.mockResolvedValue(mockTrack);
-    audioFileRepository.findMany.mockResolvedValue([mockAudioFile as any]);
+    audioFileRepository.findMany.mockResolvedValue([mockAudioFile]);
 
     const result = await handler.execute(command);
 
@@ -145,33 +134,27 @@ describe('DeleteLibraryTrackHandler', () => {
   });
 
   it('should delete multiple audio files and cleanup from storage', async () => {
-    const mockAudioFile1 = {
+    const mockAudioFile1 = audioFileBuilder({
       id: 'audio-1',
       trackId,
       bucket: FileBucket.private,
       key: 'audio/key1',
-      url: null,
       mimeType: 'audio/mpeg',
       size: 1000,
-      format: 'mp3',
+      format: AudioFormat.mp3,
       duration: 180,
       bitrate: 320,
       sampleRate: 44100,
       channels: 2,
-      isOriginal: true,
-      waveformJson: null,
-      quality: 'original',
-      status: 'complete',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    const mockAudioFile2 = {
+      status: ProcessingStatus.complete,
+    });
+    const mockAudioFile2 = audioFileBuilder({
       ...mockAudioFile1,
       id: 'audio-2',
       key: 'audio/key2',
-    };
+    });
     trackRepository.findOne.mockResolvedValue(mockTrack);
-    audioFileRepository.findMany.mockResolvedValue([mockAudioFile1 as any, mockAudioFile2 as any]);
+    audioFileRepository.findMany.mockResolvedValue([mockAudioFile1, mockAudioFile2]);
 
     const result = await handler.execute(command);
 
@@ -183,28 +166,22 @@ describe('DeleteLibraryTrackHandler', () => {
   });
 
   it('should log error when storage delete fails but still return track', async () => {
-    const mockAudioFile = {
+    const mockAudioFile = audioFileBuilder({
       id: 'audio-1',
       trackId,
       bucket: FileBucket.private,
       key: 'audio/key',
-      url: null,
       mimeType: 'audio/mpeg',
       size: 1000,
-      format: 'mp3',
+      format: AudioFormat.mp3,
       duration: 180,
       bitrate: 320,
       sampleRate: 44100,
       channels: 2,
-      isOriginal: true,
-      waveformJson: null,
-      quality: 'original',
-      status: 'complete',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+      status: ProcessingStatus.complete,
+    });
     trackRepository.findOne.mockResolvedValue(mockTrack);
-    audioFileRepository.findMany.mockResolvedValue([mockAudioFile as any]);
+    audioFileRepository.findMany.mockResolvedValue([mockAudioFile]);
     storageService.deleteFile.mockRejectedValue(new Error('S3 delete failed'));
 
     const loggerSpy = vi.spyOn(handler['logger'], 'error');

--- a/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/update-library-track.handler.spec.ts
@@ -1,9 +1,10 @@
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { UnitOfWorkService } from '@/shared/services/unit-of-work.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Track } from '@repo/db';
+import { trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateLibraryTrackCommand } from '../impl/update-library-track.command';
 import { UpdateLibraryTrackHandler } from './update-library-track.handler';
@@ -24,21 +25,15 @@ describe('UpdateLibraryTrackHandler', () => {
     userId,
   );
 
-  const mockTrack: Track = {
+  const mockTrack: Track = trackBuilder({
     id: trackId,
     title: 'Test Track',
     trackNumber: 1,
     diskNumber: 1,
     duration: 180,
-    listenedCount: 0,
-    explicit: false,
-    lyrics: null,
     albumId: 'album-123',
     visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     unitOfWork = createMock<UnitOfWorkService>();
@@ -114,8 +109,8 @@ describe('UpdateLibraryTrackHandler', () => {
 
   it('should throw InternalServerErrorException if Zod validation fails', async () => {
     trackRepository.findOne.mockResolvedValue(mockTrack);
-    // Return track with invalid data for schema
-    trackRepository.update.mockResolvedValue({ ...mockTrack, title: 123 as any });
+    // @ts-expect-error - we are testing the validation failure
+    trackRepository.update.mockResolvedValue({ ...mockTrack, title: 123 });
 
     await expect(handler.execute(command)).rejects.toThrow(InternalServerErrorException);
   });

--- a/apps/api/src/features/library-tracks/commands/handlers/upload-track-audio.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/commands/handlers/upload-track-audio.handler.spec.ts
@@ -1,15 +1,16 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
-import { getQueueToken } from '@nestjs/bullmq';
-import { AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
-import { Queue } from 'bullmq';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AudioFileRepository } from '@/shared/repositories/audio-file.repository';
 import { TrackRepository } from '@/shared/repositories/track.repository';
 import { StorageService } from '@/shared/services/storage.service';
-import { UploadTrackAudioHandler } from './upload-track-audio.handler';
+import { getQueueToken } from '@nestjs/bullmq';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AccessRole, AudioFormat, FileBucket, ProcessingStatus } from '@repo/db';
+import { audioFileBuilder, createMockFile, trackWithAccessBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { Queue } from 'bullmq';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UploadTrackAudioCommand } from '../impl/upload-track-audio.command';
+import { UploadTrackAudioHandler } from './upload-track-audio.handler';
 
 describe('UploadTrackAudioHandler', () => {
   let handler: UploadTrackAudioHandler;
@@ -49,20 +50,14 @@ describe('UploadTrackAudioHandler', () => {
   });
 
   describe('execute', () => {
-    const mockFile: Express.Multer.File = {
-      buffer: Buffer.from('test audio content'),
-      mimetype: 'audio/mpeg',
-      originalname: 'test-song.mp3',
-      size: 1024,
-      fieldname: 'file',
-      encoding: '7bit',
-      destination: '',
-      filename: '',
-      path: '',
-      stream: null as any,
-    };
-
+    const mockFile = createMockFile();
     const mockCommand = new UploadTrackAudioCommand(mockTrackId, mockUserId, mockFile);
+
+    const mockTrackWithOwnerAccess = trackWithAccessBuilder({
+      id: mockTrackId,
+      userId: mockUserId,
+      role: AccessRole.owner,
+    });
 
     it('should throw NotFoundException if track does not exist', async () => {
       trackRepository.findOne.mockResolvedValue(null);
@@ -71,35 +66,35 @@ describe('UploadTrackAudioHandler', () => {
     });
 
     it('should throw ForbiddenException if user has no access', async () => {
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithOtherOwner = trackWithAccessBuilder({
         id: mockTrackId,
-        access: [{ userId: 'other-user', role: 'owner' }],
-      } as any);
+        userId: 'other-user',
+        role: AccessRole.owner,
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithOtherOwner);
 
       await expect(handler.execute(mockCommand)).rejects.toThrow(ForbiddenException);
     });
 
     it('should throw ForbiddenException if user role is viewer', async () => {
-      trackRepository.findOne.mockResolvedValue({
+      const trackWithViewerAccess = trackWithAccessBuilder({
         id: mockTrackId,
-        access: [{ userId: mockUserId, role: 'viewer' }],
-      } as any);
+        userId: mockUserId,
+        role: AccessRole.viewer,
+      });
+      trackRepository.findOne.mockResolvedValue(trackWithViewerAccess);
 
       await expect(handler.execute(mockCommand)).rejects.toThrow(ForbiddenException);
     });
 
     it('should upload file, create audio file record, and dispatch job on success', async () => {
-      trackRepository.findOne.mockResolvedValue({
-        id: mockTrackId,
-        access: [{ userId: mockUserId, role: 'owner' }],
-      } as any);
+      trackRepository.findOne.mockResolvedValue(mockTrackWithOwnerAccess);
 
       const mockUrl = 'https://s3.url/path';
       storageService.uploadFile.mockResolvedValue({ url: mockUrl, key: 'test-key' });
 
-      audioFileRepository.create.mockResolvedValue({
-        id: 'audio-id-123',
-      } as any);
+      const mockAudioFile = audioFileBuilder({ id: 'audio-id-123' });
+      audioFileRepository.create.mockResolvedValue(mockAudioFile);
 
       const result = await handler.execute(mockCommand);
 
@@ -129,7 +124,7 @@ describe('UploadTrackAudioHandler', () => {
         userId: mockUserId,
       });
 
-      expect(result).toEqual({ audioFile: { id: 'audio-id-123' } });
+      expect(result).toEqual({ audioFile: mockAudioFile });
     });
 
     describe('format detection', () => {
@@ -214,14 +209,11 @@ describe('UploadTrackAudioHandler', () => {
       ];
 
       it.each(scenarios)('$description', async ({ mimetype, originalname, expectedFormat }) => {
-        trackRepository.findOne.mockResolvedValue({
-          id: mockTrackId,
-          access: [{ userId: mockUserId, role: 'owner' }],
-        } as any);
+        trackRepository.findOne.mockResolvedValue(mockTrackWithOwnerAccess);
         storageService.uploadFile.mockResolvedValue({ url: 'url', key: 'key' });
-        audioFileRepository.create.mockResolvedValue({ id: 'id' } as any);
+        audioFileRepository.create.mockResolvedValue(audioFileBuilder({ id: 'id' }));
 
-        const file = { ...mockFile, mimetype, originalname };
+        const file = createMockFile({ mimetype, originalname });
         await handler.execute(new UploadTrackAudioCommand(mockTrackId, mockUserId, file));
         expect(audioFileRepository.create).toHaveBeenCalledWith(
           expect.objectContaining({ format: expectedFormat }),

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
@@ -1,8 +1,9 @@
 import { TrackRepository } from '@/shared/repositories/track.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Track } from '@repo/db';
+import { trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryTrackQuery } from '../impl/get-library-track.query';
 import { GetLibraryTrackHandler } from './get-library-track.handler';
@@ -15,21 +16,9 @@ describe('GetLibraryTrackHandler', () => {
   const trackId = 'track-123';
   const query = new GetLibraryTrackQuery(trackId, userId);
 
-  const mockTrack: Track = {
+  const mockTrack: Track = trackBuilder({
     id: trackId,
-    title: 'Test Track',
-    trackNumber: 1,
-    diskNumber: 1,
-    duration: 180,
-    listenedCount: 0,
-    explicit: false,
-    lyrics: null,
-    albumId: 'album-123',
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     trackRepository = createMock<TrackRepository>();
@@ -61,7 +50,8 @@ describe('GetLibraryTrackHandler', () => {
   });
 
   it('should throw InternalServerErrorException if Zod validation fails', async () => {
-    trackRepository.findOne.mockResolvedValue({ ...mockTrack, title: 123 as any });
+    // @ts-expect-error - we are testing the validation failure
+    trackRepository.findOne.mockResolvedValue(trackBuilder({ ...mockTrack, title: 123 }));
 
     await expect(handler.execute(query)).rejects.toThrow(InternalServerErrorException);
   });

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-track.handler.spec.ts
@@ -50,8 +50,7 @@ describe('GetLibraryTrackHandler', () => {
   });
 
   it('should throw InternalServerErrorException if Zod validation fails', async () => {
-    // @ts-expect-error - we are testing the validation failure
-    trackRepository.findOne.mockResolvedValue(trackBuilder({ ...mockTrack, title: 123 }));
+    trackRepository.findOne.mockResolvedValue(trackBuilder({ title: 123 } as any));
 
     await expect(handler.execute(query)).rejects.toThrow(InternalServerErrorException);
   });

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
@@ -80,7 +80,8 @@ describe('GetLibraryTracksHandler', () => {
   it('should filter by albumId if provided', async () => {
     const albumQuery = new GetLibraryTracksQuery(userId, 1, 10, 'album-123');
     libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
-    libraryTrackRepository.findMany.mockResolvedValue([mockLibraryTrack]);
+    const mockItem: LibraryTrackWithTrack = { ...mockLibraryTrack, track: mockTrack };
+    libraryTrackRepository.findMany.mockResolvedValue([mockItem]);
     libraryTrackRepository.count.mockResolvedValue(1);
 
     await handler.execute(albumQuery);

--- a/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-library-tracks.handler.spec.ts
@@ -1,12 +1,17 @@
 import { LibraryTrackRepository } from '@/shared/repositories/library-track.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Library, LibraryTrack } from '@repo/db';
+import { Library, LibraryTrack, LibraryTrackGetPayload, Track } from '@repo/db';
+import { libraryBuilder, libraryTrackBuilder, trackBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryTracksQuery } from '../impl/get-library-tracks.query';
 import { GetLibraryTracksHandler } from './get-library-tracks.handler';
+
+type LibraryTrackWithTrack = LibraryTrackGetPayload<{
+  include: { track: true };
+}>;
 
 describe('GetLibraryTracksHandler', () => {
   let handler: GetLibraryTracksHandler;
@@ -16,24 +21,18 @@ describe('GetLibraryTracksHandler', () => {
   const userId = 'user-123';
   const query = new GetLibraryTracksQuery(userId, 1, 10);
 
-  const mockLibrary: Library = {
+  const mockLibrary: Library = libraryBuilder({
     id: 'library-123',
     userId,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+  });
 
-  const mockLibraryTrack: LibraryTrack = {
+  const mockTrack: Track = trackBuilder({ id: 'track-123' });
+
+  const mockLibraryTrack: LibraryTrack = libraryTrackBuilder({
     id: 'lib-track-123',
     libraryId: mockLibrary.id,
-    trackId: 'track-123',
-    listenedCount: 0,
-    listenCountResetAt: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-  };
+    trackId: mockTrack.id,
+  });
 
   beforeEach(async () => {
     libraryRepository = createMock<LibraryRepository>();
@@ -56,14 +55,18 @@ describe('GetLibraryTracksHandler', () => {
 
   it('should return paginated library tracks', async () => {
     libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
-    libraryTrackRepository.findMany.mockResolvedValue([
-      { ...mockLibraryTrack, track: mockLibraryTrack } as any,
-    ]);
+
+    const mockItem: LibraryTrackWithTrack = {
+      ...mockLibraryTrack,
+      track: mockTrack,
+    };
+
+    libraryTrackRepository.findMany.mockResolvedValue([mockItem]);
     libraryTrackRepository.count.mockResolvedValue(1);
 
-    const result = (await handler.execute(query)) as any;
+    const result = await handler.execute(query);
 
-    expect(result.items).toEqual([mockLibraryTrack]);
+    expect(result.items).toEqual([mockTrack]);
     expect(result.total).toBe(1);
     expect(libraryRepository.getByUserId).toHaveBeenCalledWith(userId);
     expect(libraryTrackRepository.findMany).toHaveBeenCalledWith({

--- a/apps/api/src/features/library-tracks/queries/handlers/get-track-stream-qualities.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-track-stream-qualities.handler.spec.ts
@@ -1,10 +1,11 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
-import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '@/shared/services/prisma.service';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { Test, TestingModule } from '@nestjs/testing';
 import { StreamAudioQuality } from '@repo/contracts';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GetTrackStreamQualitiesHandler } from './get-track-stream-qualities.handler';
+import { AudioFormat, AudioQuality } from '@repo/db';
+import { audioFileBuilder } from '@repo/testing';
 import { GetTrackStreamQualitiesQuery } from '../impl/get-track-stream-qualities.query';
+import { GetTrackStreamQualitiesHandler } from './get-track-stream-qualities.handler';
 
 describe('GetTrackStreamQualitiesHandler', () => {
   let handler: GetTrackStreamQualitiesHandler;
@@ -41,12 +42,12 @@ describe('GetTrackStreamQualitiesHandler', () => {
 
     it('should correctly map audio formats to qualities', async () => {
       prismaService.client.audioFile.findMany.mockResolvedValue([
-        { format: 'flac', quality: 'original' },
-        { format: 'wav', quality: 'original' },
-        { format: 'mp3', quality: 'high' },
-        { format: 'opus', quality: 'standard' },
-        { format: 'mp3', quality: 'low' },
-      ] as any);
+        audioFileBuilder({ format: AudioFormat.flac, quality: AudioQuality.original }),
+        audioFileBuilder({ format: AudioFormat.wav, quality: AudioQuality.original }),
+        audioFileBuilder({ format: AudioFormat.mp3, quality: AudioQuality.high }),
+        audioFileBuilder({ format: AudioFormat.opus, quality: AudioQuality.standard }),
+        audioFileBuilder({ format: AudioFormat.mp3, quality: AudioQuality.low }),
+      ]);
 
       const result = await handler.execute(new GetTrackStreamQualitiesQuery('track-1'));
 
@@ -59,10 +60,12 @@ describe('GetTrackStreamQualitiesHandler', () => {
 
     it('should normalize uppercase formats and qualities to StreamAudioQuality values', async () => {
       prismaService.client.audioFile.findMany.mockResolvedValue([
-        { format: 'FLAC', quality: 'ORIGINAL' },
-        { format: 'MP3', quality: 'HIGH' },
-        { format: null, quality: null },
-      ] as any);
+        audioFileBuilder({ format: AudioFormat.flac, quality: AudioQuality.original }),
+        // @ts-expect-error - we are testing the normalization of uppercase formats and qualities
+        audioFileBuilder({ format: 'MP3', quality: 'HIGH' }),
+        // @ts-expect-error - we are testing normalization of null format and quality values
+        audioFileBuilder({ format: null, quality: null }),
+      ]);
 
       const result = await handler.execute(new GetTrackStreamQualitiesQuery('track-1'));
 

--- a/apps/api/src/features/library-tracks/queries/handlers/get-track-stream.handler.spec.ts
+++ b/apps/api/src/features/library-tracks/queries/handlers/get-track-stream.handler.spec.ts
@@ -1,10 +1,11 @@
 import { AudioFileRepository } from '@/shared/repositories/audio-file.repository';
 import { StorageService } from '@/shared/services/storage.service';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StreamAudioQuality } from '@repo/contracts';
 import { AudioFormat, AudioQuality, FileBucket } from '@repo/db';
+import { audioFileBuilder } from '@repo/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetTrackStreamQuery } from '../impl/get-track-stream.query';
 import { GetTrackStreamHandler } from './get-track-stream.handler';
@@ -48,31 +49,31 @@ describe('GetTrackStreamHandler', () => {
 
     describe('Quality Selection', () => {
       const mockFiles = [
-        {
-          id: '1',
+        audioFileBuilder({
+          id: 'audio-file-1',
           format: AudioFormat.flac,
           quality: AudioQuality.original,
           size: 100,
           bucket: FileBucket.private,
           key: 'lossless-flac',
-        },
-        {
-          id: '2',
+        }),
+        audioFileBuilder({
+          id: 'audio-file-2',
           format: AudioFormat.mp3,
           quality: AudioQuality.high,
           size: 80,
           bucket: FileBucket.private,
           key: 'high-mp3',
-        },
-        {
-          id: '3',
+        }),
+        audioFileBuilder({
+          id: 'audio-file-3',
           format: AudioFormat.mp3,
           quality: AudioQuality.low,
           size: 20,
           bucket: FileBucket.private,
           key: 'low-mp3',
-        },
-      ] as any[];
+        }),
+      ];
 
       beforeEach(() => {
         audioFileRepository.findMany.mockResolvedValue(mockFiles);
@@ -95,15 +96,15 @@ describe('GetTrackStreamHandler', () => {
 
       it('should return exact match for high quality mp3 when only mp3 is available', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '2',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.mp3,
             quality: AudioQuality.high,
             size: 80,
             bucket: FileBucket.public,
             key: 'high-mp3',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.high, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -115,23 +116,23 @@ describe('GetTrackStreamHandler', () => {
 
       it('should prefer high quality opus over high quality mp3 when both are available', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '1',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.opus,
             quality: AudioQuality.high,
             size: 80,
             bucket: FileBucket.public,
             key: 'high-opus',
-          },
-          {
-            id: '2',
+          }),
+          audioFileBuilder({
+            id: 'audio-file-2',
             format: AudioFormat.mp3,
             quality: AudioQuality.high,
             size: 80,
             bucket: FileBucket.public,
             key: 'high-mp3',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.high, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -143,8 +144,13 @@ describe('GetTrackStreamHandler', () => {
 
       it('should score standard opus specially', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.opus, quality: AudioQuality.standard, size: 80 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.opus,
+            quality: AudioQuality.standard,
+            size: 80,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -152,8 +158,13 @@ describe('GetTrackStreamHandler', () => {
 
       it('should score standard other format normally', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: AudioQuality.standard, size: 80 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.mp3,
+            quality: AudioQuality.standard,
+            size: 80,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -161,9 +172,19 @@ describe('GetTrackStreamHandler', () => {
 
       it('should return 0 for unhandled formats in high/standard qualities', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.aac, quality: AudioQuality.high, size: 80 },
-          { id: '2', format: AudioFormat.aac, quality: AudioQuality.standard, size: 80 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.aac,
+            quality: AudioQuality.high,
+            size: 80,
+          }),
+          audioFileBuilder({
+            id: 'audio-file-2',
+            format: AudioFormat.aac,
+            quality: AudioQuality.standard,
+            size: 80,
+          }),
+        ]);
 
         const queryHigh = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.high, '');
         await handler.execute(queryHigh); // Will fallback since score is 0
@@ -176,8 +197,13 @@ describe('GetTrackStreamHandler', () => {
 
       it('should test default fallback quality score', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: 'unknown' as any, size: 80 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.mp3,
+            quality: 'unknown' as any,
+            size: 80,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, 'unknown' as any, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -185,15 +211,15 @@ describe('GetTrackStreamHandler', () => {
 
       it('should return exact match for low quality mp3 when only mp3 is available', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '2',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.mp3,
             quality: AudioQuality.low,
             size: 20,
             bucket: FileBucket.public,
             key: 'low-mp3',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.low, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -205,23 +231,23 @@ describe('GetTrackStreamHandler', () => {
 
       it('should prefer low quality opus over low quality mp3 when both are available', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '1',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.opus,
             quality: AudioQuality.low,
             size: 20,
             bucket: FileBucket.public,
             key: 'low-opus',
-          },
-          {
-            id: '2',
+          }),
+          audioFileBuilder({
+            id: 'audio-file-2',
             format: AudioFormat.mp3,
             quality: AudioQuality.low,
             size: 20,
             bucket: FileBucket.public,
             key: 'low-mp3',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.low, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -240,8 +266,13 @@ describe('GetTrackStreamHandler', () => {
 
       it('should fallback to higher quality if lower is missing AND lower check yields nothing', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.flac, quality: AudioQuality.original, size: 100 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.flac,
+            quality: AudioQuality.original,
+            size: 100,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.low, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -249,9 +280,19 @@ describe('GetTrackStreamHandler', () => {
 
       it('should sort fallback lower qualities by score', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: AudioQuality.low, size: 20 },
-          { id: '2', format: AudioFormat.mp3, quality: AudioQuality.low, size: 30 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.mp3,
+            quality: AudioQuality.low,
+            size: 20,
+          }),
+          audioFileBuilder({
+            id: 'audio-file-2',
+            format: AudioFormat.mp3,
+            quality: AudioQuality.low,
+            size: 30,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -259,9 +300,19 @@ describe('GetTrackStreamHandler', () => {
 
       it('should sort fallback higher qualities by score', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.flac, quality: AudioQuality.original, size: 100 },
-          { id: '2', format: AudioFormat.wav, quality: AudioQuality.original, size: 100 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.flac,
+            quality: AudioQuality.original,
+            size: 100,
+          }),
+          audioFileBuilder({
+            id: 'audio-file-2',
+            format: AudioFormat.wav,
+            quality: AudioQuality.original,
+            size: 100,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.high, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -269,8 +320,13 @@ describe('GetTrackStreamHandler', () => {
 
       it('should fallback to first file if all else fails', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.aac, quality: AudioQuality.original, size: 100 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.aac,
+            quality: AudioQuality.original,
+            size: 100,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalled();
@@ -278,15 +334,15 @@ describe('GetTrackStreamHandler', () => {
 
       it('should return 0 for low quality when format is not opus or mp3 and use final fallback', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '1',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.aac,
             quality: AudioQuality.low,
             size: 50,
             bucket: FileBucket.private,
             key: 'low-aac',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.low, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -298,15 +354,15 @@ describe('GetTrackStreamHandler', () => {
 
       it('should select wav for lossless when wav is available', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '1',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.wav,
             quality: AudioQuality.original,
             size: 200,
             bucket: FileBucket.private,
             key: 'lossless-wav',
-          },
-        ] as any[]);
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.lossless, '');
         await handler.execute(query);
         expect(storageService.getFileStream).toHaveBeenCalledWith(
@@ -318,10 +374,20 @@ describe('GetTrackStreamHandler', () => {
     });
 
     describe('Range Handling', () => {
+      const mockKey = 'audio-file-1';
+      const mockBucket = FileBucket.private;
+
       beforeEach(() => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: AudioQuality.standard, size: 1000 },
-        ] as any[]);
+          audioFileBuilder({
+            id: mockKey,
+            format: AudioFormat.mp3,
+            quality: AudioQuality.standard,
+            size: 1000,
+            bucket: mockBucket,
+            key: mockKey,
+          }),
+        ]);
         storageService.getFileStream.mockResolvedValue({
           stream: {} as any,
           size: 1000,
@@ -336,7 +402,7 @@ describe('GetTrackStreamHandler', () => {
           'bytes=0-499',
         );
         await handler.execute(query);
-        expect(storageService.getFileStream).toHaveBeenCalledWith(undefined, undefined, {
+        expect(storageService.getFileStream).toHaveBeenCalledWith(mockBucket, mockKey, {
           start: 0,
           end: 499,
         });
@@ -349,7 +415,7 @@ describe('GetTrackStreamHandler', () => {
           'bytes=500-',
         );
         await handler.execute(query);
-        expect(storageService.getFileStream).toHaveBeenCalledWith(undefined, undefined, {
+        expect(storageService.getFileStream).toHaveBeenCalledWith(mockBucket, mockKey, {
           start: 500,
           end: 999,
         });
@@ -358,7 +424,7 @@ describe('GetTrackStreamHandler', () => {
       it('should parse range with only start (no hyphen, parts[1] undefined)', async () => {
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, 'bytes=0');
         await handler.execute(query);
-        expect(storageService.getFileStream).toHaveBeenCalledWith(undefined, undefined, {
+        expect(storageService.getFileStream).toHaveBeenCalledWith(mockBucket, mockKey, {
           start: 0,
           end: 999,
         });
@@ -380,7 +446,7 @@ describe('GetTrackStreamHandler', () => {
           'bytes=-500',
         );
         await handler.execute(query);
-        expect(storageService.getFileStream).toHaveBeenCalledWith(undefined, undefined, {
+        expect(storageService.getFileStream).toHaveBeenCalledWith(mockBucket, mockKey, {
           start: 500,
           end: 999,
         });
@@ -420,8 +486,14 @@ describe('GetTrackStreamHandler', () => {
 
       it('should fallback mp3 mimetype properly', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: AudioQuality.standard, size: 1000 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.mp3,
+            quality: AudioQuality.standard,
+            size: 1000,
+            mimeType: 'audio/mpeg',
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         const res = await handler.execute(query);
         expect(res.metadata.mimeType).toBe('audio/mpeg');
@@ -429,14 +501,14 @@ describe('GetTrackStreamHandler', () => {
 
       it('should fallback to audio/unknown when mimeType is missing and format is not mp3', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          {
-            id: '1',
+          audioFileBuilder({
+            id: 'audio-file-1',
             format: AudioFormat.opus,
             quality: AudioQuality.standard,
             size: 1000,
-            mimeType: null,
-          },
-        ] as any[]);
+            mimeType: null as any,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(mockTrackId, StreamAudioQuality.standard, '');
         const res = await handler.execute(query);
         expect(res.metadata.mimeType).toBe('audio/unknown');
@@ -444,8 +516,15 @@ describe('GetTrackStreamHandler', () => {
 
       it('should set isPartial when range is provided', async () => {
         audioFileRepository.findMany.mockResolvedValue([
-          { id: '1', format: AudioFormat.mp3, quality: AudioQuality.standard, size: 1000 },
-        ] as any[]);
+          audioFileBuilder({
+            id: 'audio-file-1',
+            format: AudioFormat.mp3,
+            quality: AudioQuality.standard,
+            size: 1000,
+            bucket: mockBucket,
+            key: mockKey,
+          }),
+        ]);
         const query = new GetTrackStreamQuery(
           mockTrackId,
           StreamAudioQuality.standard,
@@ -453,7 +532,7 @@ describe('GetTrackStreamHandler', () => {
         );
         const res = await handler.execute(query);
         expect(res.metadata.isPartial).toBe(true);
-        expect(storageService.getFileStream).toHaveBeenCalledWith(undefined, undefined, {
+        expect(storageService.getFileStream).toHaveBeenCalledWith(mockBucket, mockKey, {
           start: 100,
           end: 200,
         });

--- a/apps/api/src/features/library/commands/handlers/create-library.handler.spec.ts
+++ b/apps/api/src/features/library/commands/handlers/create-library.handler.spec.ts
@@ -1,8 +1,9 @@
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { ConflictException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateLibraryCommand } from '../impl/create-library.command';
 import { CreateLibraryHandler } from './create-library.handler';
 
@@ -23,10 +24,14 @@ describe('CreateLibraryHandler', () => {
     handler = module.get<CreateLibraryHandler>(CreateLibraryHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should create a library if it does not exist', async () => {
     const userId = 'user-123';
     const command = new CreateLibraryCommand(userId);
-    const mockLibrary = { id: 'lib-123', userId } as any;
+    const mockLibrary = libraryBuilder({ id: 'lib-123', userId });
 
     libraryRepository.getByUserId.mockResolvedValue(null);
     libraryRepository.create.mockResolvedValue(mockLibrary);
@@ -43,7 +48,7 @@ describe('CreateLibraryHandler', () => {
   it('should throw ConflictException if library already exists', async () => {
     const userId = 'user-123';
     const command = new CreateLibraryCommand(userId);
-    const existingLibrary = { id: 'lib-123', userId } as any;
+    const existingLibrary = libraryBuilder({ id: 'lib-123', userId });
 
     libraryRepository.getByUserId.mockResolvedValue(existingLibrary);
 

--- a/apps/api/src/features/library/queries/handlers/get-library-albums.handler.spec.ts
+++ b/apps/api/src/features/library/queries/handlers/get-library-albums.handler.spec.ts
@@ -1,9 +1,10 @@
 import { LibraryAlbumRepository } from '@/shared/repositories/library-album.repository';
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { libraryAlbumBuilder, libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { PreconditionFailedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryAlbumsQuery } from '../impl/get-library-albums.query';
 import { GetLibraryAlbumsHandler } from './get-library-albums.handler';
 
@@ -27,28 +28,19 @@ describe('GetLibraryAlbumsHandler', () => {
     handler = module.get<GetLibraryAlbumsHandler>(GetLibraryAlbumsHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should return library albums with pagination metadata', async () => {
     const userId = 'user-123';
+    const libraryId = 'lib-123';
     const query = new GetLibraryAlbumsQuery(userId, 1, 10);
-    const library = { id: 'lib-123' } as any;
+    const library = libraryBuilder({ id: libraryId });
     const albums = [
-      {
-        id: 'lib-album-1',
-        libraryId: 'lib-123',
-        albumId: 'album-1',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      },
-      {
-        id: 'lib-album-2',
-        libraryId: 'lib-123',
-        albumId: 'album-2',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      },
-    ] as any[];
+      libraryAlbumBuilder({ id: 'lib-album-1', libraryId, albumId: 'album-1' }),
+      libraryAlbumBuilder({ id: 'lib-album-2', libraryId, albumId: 'album-2' }),
+    ];
     const total = 2;
 
     libraryRepository.getByUserId.mockResolvedValue(library);
@@ -85,7 +77,7 @@ describe('GetLibraryAlbumsHandler', () => {
   it('should throw PreconditionFailedException if failed to parse library albums', async () => {
     const userId = 'user-123';
     const query = new GetLibraryAlbumsQuery(userId, 1, 10);
-    const library = { id: 'lib-123' } as any;
+    const library = libraryBuilder({ id: 'lib-123' });
     const invalidAlbums = [{ invalidField: 'test' }] as any[];
     const total = 1;
 

--- a/apps/api/src/features/library/queries/handlers/get-library.handler.spec.ts
+++ b/apps/api/src/features/library/queries/handlers/get-library.handler.spec.ts
@@ -1,8 +1,9 @@
 import { LibraryRepository } from '@/shared/repositories/library.repository';
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { libraryBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GetLibraryQuery } from '../impl/get-library.query';
 import { GetLibraryHandler } from './get-library.handler';
 
@@ -20,10 +21,14 @@ describe('GetLibraryHandler', () => {
     handler = module.get<GetLibraryHandler>(GetLibraryHandler);
   });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should return library if it exists', async () => {
     const userId = 'user-123';
     const query = new GetLibraryQuery(userId);
-    const mockLibrary = { id: 'lib-123', userId } as any;
+    const mockLibrary = libraryBuilder({ id: 'lib-123', userId });
 
     libraryRepository.getByUserId.mockResolvedValue(mockLibrary);
 

--- a/apps/api/src/shared/guards/album-access.guard.spec.ts
+++ b/apps/api/src/shared/guards/album-access.guard.spec.ts
@@ -2,49 +2,39 @@ import { CHECK_ALBUM_ACCESS_KEY } from '@/common/decorators/check-album-access.d
 import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AlbumRepository } from '../repositories/album.repository';
 import { AlbumAccessGuard } from './album-access.guard';
 
 describe('AlbumAccessGuard', () => {
   let guard: AlbumAccessGuard;
-  let reflector: Reflector;
-  let albumRepository: AlbumRepository;
-
-  const mockReflector = {
-    get: vi.fn(),
-  };
-
-  const mockAlbumRepository = {
-    checkAccess: vi.fn(),
-    exists: vi.fn(),
-  };
-
-  const mockExecutionContext = {
-    getHandler: vi.fn(),
-    switchToHttp: vi.fn().mockReturnThis(),
-    getRequest: vi.fn(),
-  } as unknown as ExecutionContext;
+  let reflector: DeepMocked<Reflector>;
+  let albumRepository: DeepMocked<AlbumRepository>;
+  let mockExecutionContext: DeepMocked<ExecutionContext>;
 
   beforeEach(async () => {
+    const httpHost = createMock<ReturnType<ExecutionContext['switchToHttp']>>();
+
+    reflector = createMock<Reflector>();
+    albumRepository = createMock<AlbumRepository>();
+    mockExecutionContext = createMock<ExecutionContext>({ switchToHttp: () => httpHost });
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AlbumAccessGuard,
-        {
-          provide: Reflector,
-          useValue: mockReflector,
-        },
-        {
-          provide: AlbumRepository,
-          useValue: mockAlbumRepository,
-        },
+        { provide: Reflector, useValue: reflector },
+        { provide: AlbumRepository, useValue: albumRepository },
       ],
     }).compile();
 
     guard = module.get<AlbumAccessGuard>(AlbumAccessGuard);
-    reflector = module.get<Reflector>(Reflector);
-    albumRepository = module.get<AlbumRepository>(AlbumRepository);
 
+    vi.clearAllMocks();
+    mockExecutionContext.getHandler.mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
     vi.clearAllMocks();
   });
 

--- a/apps/api/src/shared/guards/artist-access.guard.spec.ts
+++ b/apps/api/src/shared/guards/artist-access.guard.spec.ts
@@ -1,50 +1,40 @@
 import { CHECK_ARTIST_ACCESS_KEY } from '@/common/decorators/check-artist-access.decorator';
 import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ArtistRepository } from '../repositories/artist.repository';
 import { ArtistAccessGuard } from './artist-access.guard';
 
 describe('ArtistAccessGuard', () => {
   let guard: ArtistAccessGuard;
-  let reflector: Reflector;
-  let artistRepository: ArtistRepository;
-
-  const mockReflector = {
-    get: vi.fn(),
-  };
-
-  const mockArtistRepository = {
-    checkAccess: vi.fn(),
-    exists: vi.fn(),
-  };
-
-  const mockExecutionContext = {
-    getHandler: vi.fn(),
-    switchToHttp: vi.fn().mockReturnThis(),
-    getRequest: vi.fn(),
-  } as unknown as ExecutionContext;
+  let reflector: DeepMocked<Reflector>;
+  let artistRepository: DeepMocked<ArtistRepository>;
+  let mockExecutionContext: DeepMocked<ExecutionContext>;
 
   beforeEach(async () => {
+    const httpHost = createMock<ReturnType<ExecutionContext['switchToHttp']>>();
+
+    reflector = createMock<Reflector>();
+    artistRepository = createMock<ArtistRepository>();
+    mockExecutionContext = createMock<ExecutionContext>({ switchToHttp: () => httpHost });
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ArtistAccessGuard,
-        {
-          provide: Reflector,
-          useValue: mockReflector,
-        },
-        {
-          provide: ArtistRepository,
-          useValue: mockArtistRepository,
-        },
+        { provide: Reflector, useValue: reflector },
+        { provide: ArtistRepository, useValue: artistRepository },
       ],
     }).compile();
 
     guard = module.get<ArtistAccessGuard>(ArtistAccessGuard);
-    reflector = module.get<Reflector>(Reflector);
-    artistRepository = module.get<ArtistRepository>(ArtistRepository);
 
+    vi.clearAllMocks();
+    mockExecutionContext.getHandler.mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
     vi.clearAllMocks();
   });
 

--- a/apps/api/src/shared/guards/track-access.guard.spec.ts
+++ b/apps/api/src/shared/guards/track-access.guard.spec.ts
@@ -2,49 +2,40 @@ import { CHECK_TRACK_ACCESS_KEY } from '@/common/decorators/check-track-access.d
 import { ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Visibility } from '@repo/db';
+import { trackBuilder } from '@repo/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TrackRepository } from '../repositories/track.repository';
 import { TrackAccessGuard } from './track-access.guard';
 
 describe('TrackAccessGuard', () => {
   let guard: TrackAccessGuard;
-  let reflector: Reflector;
-  let trackRepository: TrackRepository;
-
-  const mockReflector = {
-    get: vi.fn(),
-  };
-
-  const mockTrackRepository = {
-    checkAccess: vi.fn(),
-    findOne: vi.fn(),
-  };
-
-  const mockExecutionContext = {
-    getHandler: vi.fn(),
-    switchToHttp: vi.fn().mockReturnThis(),
-    getRequest: vi.fn(),
-  } as unknown as ExecutionContext;
+  let reflector: DeepMocked<Reflector>;
+  let trackRepository: DeepMocked<TrackRepository>;
+  let mockExecutionContext: DeepMocked<ExecutionContext>;
 
   beforeEach(async () => {
+    reflector = createMock<Reflector>();
+    trackRepository = createMock<TrackRepository>();
+    mockExecutionContext = createMock<ExecutionContext>({
+      switchToHttp: vi.fn().mockReturnThis(),
+    } as any);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TrackAccessGuard,
-        {
-          provide: Reflector,
-          useValue: mockReflector,
-        },
-        {
-          provide: TrackRepository,
-          useValue: mockTrackRepository,
-        },
+        { provide: Reflector, useValue: reflector },
+        { provide: TrackRepository, useValue: trackRepository },
       ],
     }).compile();
 
     guard = module.get<TrackAccessGuard>(TrackAccessGuard);
-    reflector = module.get<Reflector>(Reflector);
-    trackRepository = module.get<TrackRepository>(TrackRepository);
 
+    mockExecutionContext.getHandler.mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
     vi.clearAllMocks();
   });
 
@@ -111,8 +102,7 @@ describe('TrackAccessGuard', () => {
     });
     vi.mocked(trackRepository.checkAccess).mockResolvedValue(false);
 
-    // Create a complete mock track object to satisfy the Track type
-    const mockTrack = {
+    const mockTrack = trackBuilder({
       id: '123',
       title: 'Test Track',
       trackNumber: 1,
@@ -121,14 +111,12 @@ describe('TrackAccessGuard', () => {
       listenedCount: 0,
       explicit: false,
       lyrics: null,
-      visibility: 'PUBLIC',
+      visibility: Visibility.public,
       albumId: 'album-123',
-      createdAt: new Date(),
-      updatedAt: new Date(),
       deletedAt: null,
-    };
+    });
 
-    vi.mocked(trackRepository.findOne).mockResolvedValue(mockTrack as any);
+    vi.mocked(trackRepository.findOne).mockResolvedValue(mockTrack);
 
     await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(ForbiddenException);
   });

--- a/apps/api/src/shared/guards/track-access.guard.spec.ts
+++ b/apps/api/src/shared/guards/track-access.guard.spec.ts
@@ -16,11 +16,11 @@ describe('TrackAccessGuard', () => {
   let mockExecutionContext: DeepMocked<ExecutionContext>;
 
   beforeEach(async () => {
+    const httpHost = createMock<ReturnType<ExecutionContext['switchToHttp']>>();
+
     reflector = createMock<Reflector>();
     trackRepository = createMock<TrackRepository>();
-    mockExecutionContext = createMock<ExecutionContext>({
-      switchToHttp: vi.fn().mockReturnThis(),
-    } as any);
+    mockExecutionContext = createMock<ExecutionContext>({ switchToHttp: () => httpHost });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/api/src/shared/repositories/album.repository.spec.ts
+++ b/apps/api/src/shared/repositories/album.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { albumBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Album, PrismaClient } from '@repo/db';
+import { AlbumType, PrismaClient, Visibility } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { AlbumRepository } from './album.repository';
@@ -9,20 +10,17 @@ describe('AlbumRepository', () => {
   let repository: AlbumRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockAlbum: Album = {
+  const mockAlbum = albumBuilder({
     id: 'album-123',
     name: 'Test Album',
     description: null,
-    type: 'album',
-    releaseDate: new Date(),
-    visibility: 'private',
+    type: AlbumType.album,
+    visibility: Visibility.private,
     coverId: null,
     totalTracks: 0,
     totalDuration: 0,
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();
@@ -170,11 +168,11 @@ describe('AlbumRepository', () => {
   describe('count', () => {
     it('should count albums with deletedAt: null filter', async () => {
       mockTx.album.count.mockResolvedValue(10);
-      const result = await repository.count({ type: 'album' });
+      const result = await repository.count({ type: AlbumType.album });
       expect(result).toBe(10);
       expect(mockTx.album.count).toHaveBeenCalledWith({
         where: {
-          type: 'album',
+          type: AlbumType.album,
           deletedAt: null,
         },
       });
@@ -184,7 +182,11 @@ describe('AlbumRepository', () => {
   describe('create', () => {
     it('should create an album', async () => {
       mockTx.album.create.mockResolvedValue(mockAlbum);
-      const data = { name: 'New Album', type: 'album', visibility: 'private' } as any;
+      const data = {
+        name: 'New Album',
+        type: AlbumType.album,
+        visibility: Visibility.private,
+      } as any;
       const result = await repository.create(data);
       expect(result).toEqual(mockAlbum);
       expect(mockTx.album.create).toHaveBeenCalledWith({ data });

--- a/apps/api/src/shared/repositories/artist.repository.spec.ts
+++ b/apps/api/src/shared/repositories/artist.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { artistBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Artist, PrismaClient } from '@repo/db';
+import { PrismaClient, Visibility } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { ArtistRepository } from './artist.repository';
@@ -9,7 +10,7 @@ describe('ArtistRepository', () => {
   let repository: ArtistRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockArtist: Artist = {
+  const mockArtist = artistBuilder({
     id: 'artist-123',
     name: 'Test Artist',
     description: null,
@@ -17,11 +18,9 @@ describe('ArtistRepository', () => {
     verified: false,
     bannerId: null,
     avatarId: null,
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    visibility: Visibility.private,
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/audio-file.repository.spec.ts
+++ b/apps/api/src/shared/repositories/audio-file.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { audioFileBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { AudioFile, PrismaClient } from '@repo/db';
+import { AudioFormat, AudioQuality, FileBucket, PrismaClient, ProcessingStatus } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { AudioFileRepository } from './audio-file.repository';
@@ -9,14 +10,14 @@ describe('AudioFileRepository', () => {
   let repository: AudioFileRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockAudioFile: AudioFile = {
+  const mockAudioFile = audioFileBuilder({
     id: 'audio-123',
-    bucket: 'private',
+    bucket: FileBucket.private,
     key: 'tracks/track-123/audio.mp3',
     url: 'http://localhost:9000/private/tracks/track-123/audio.mp3',
     mimeType: 'audio/mpeg',
     size: 5242880,
-    format: 'mp3',
+    format: AudioFormat.mp3,
     duration: 180.5,
     bitrate: 320000,
     sampleRate: 44100,
@@ -24,11 +25,9 @@ describe('AudioFileRepository', () => {
     isOriginal: true,
     waveformJson: '[0.1, 0.2, 0.3]',
     trackId: 'track-123',
-    quality: 'original',
-    status: 'complete',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
+    quality: AudioQuality.original,
+    status: ProcessingStatus.complete,
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/email-address.repository.spec.ts
+++ b/apps/api/src/shared/repositories/email-address.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { emailAddressBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { EmailAddress, EmailStatus, EmailType, PrismaClient } from '@repo/db';
+import { EmailStatus, EmailType, PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { EmailAddressRepository } from './email-address.repository';
@@ -9,17 +10,15 @@ describe('EmailAddressRepository', () => {
   let repository: EmailAddressRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockEmail: EmailAddress = {
+  const mockEmail = emailAddressBuilder({
     id: 'email-id-123',
     email: 'test@example.com',
     userId: 'user-id-123',
     type: EmailType.primary,
     status: EmailStatus.pending,
-    createdAt: new Date(),
-    updatedAt: new Date(),
     verifiedAt: null,
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/image.repository.spec.ts
+++ b/apps/api/src/shared/repositories/image.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { imageBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaClient, Image, FileBucket } from '@repo/db';
+import { FileBucket, ImageUploadStatus, PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { ImageRepository } from './image.repository';
@@ -9,7 +10,7 @@ describe('ImageRepository', () => {
   let repository: ImageRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockImage: Image = {
+  const mockImage = imageBuilder({
     id: 'image-123',
     bucket: FileBucket.private,
     key: 'test-key.jpg',
@@ -17,12 +18,10 @@ describe('ImageRepository', () => {
     mimeType: 'image/jpeg',
     alt: null,
     reportId: null,
-    uploadStatus: 'pending',
+    uploadStatus: ImageUploadStatus.pending,
     blurhash: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/library-album.repository.spec.ts
+++ b/apps/api/src/shared/repositories/library-album.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { libraryAlbumBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { LibraryAlbum, PrismaClient } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { LibraryAlbumRepository } from './library-album.repository';
@@ -9,14 +10,12 @@ describe('LibraryAlbumRepository', () => {
   let repository: LibraryAlbumRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockLibraryAlbum: LibraryAlbum = {
+  const mockLibraryAlbum = libraryAlbumBuilder({
     id: 'lib-album-123',
     libraryId: 'user-123',
     albumId: 'album-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  } as any;
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/library-artist.repository.spec.ts
+++ b/apps/api/src/shared/repositories/library-artist.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { libraryArtistBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { LibraryArtist, PrismaClient } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { LibraryArtistRepository } from './library-artist.repository';
@@ -9,14 +10,12 @@ describe('LibraryArtistRepository', () => {
   let repository: LibraryArtistRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockLibraryArtist: LibraryArtist = {
+  const mockLibraryArtist = libraryArtistBuilder({
     id: 'la-123',
     libraryId: 'lib-123',
     artistId: 'artist-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/library-track.repository.spec.ts
+++ b/apps/api/src/shared/repositories/library-track.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { libraryTrackBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { LibraryTrack, PrismaClient } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { LibraryTrackRepository } from './library-track.repository';
@@ -9,16 +10,14 @@ describe('LibraryTrackRepository', () => {
   let repository: LibraryTrackRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockLibraryTrack: LibraryTrack = {
+  const mockLibraryTrack = libraryTrackBuilder({
     id: 'lib-track-123',
     libraryId: 'library-123',
     trackId: 'track-123',
     listenedCount: 0,
     listenCountResetAt: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/library.repository.spec.ts
+++ b/apps/api/src/shared/repositories/library.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { libraryBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Library, PrismaClient } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { LibraryRepository } from './library.repository';
@@ -9,13 +10,11 @@ describe('LibraryRepository', () => {
   let repository: LibraryRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockLibrary: Library = {
+  const mockLibrary = libraryBuilder({
     id: 'lib-123',
     userId: 'user-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/refresh-token.repository.spec.ts
+++ b/apps/api/src/shared/repositories/refresh-token.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { refreshTokenBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaClient, RefreshToken } from '@repo/db';
+import { PrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { RefreshTokenRepository } from './refresh-token.repository';
@@ -9,15 +10,13 @@ describe('RefreshTokenRepository', () => {
   let repository: RefreshTokenRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockToken: RefreshToken = {
+  const mockToken = refreshTokenBuilder({
     id: 'rt-id-123',
     token: 'token-string',
     sessionId: 'session-id-123',
-    createdAt: new Date(),
-    updatedAt: new Date(),
     revokedAt: null,
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/session.repository.spec.ts
+++ b/apps/api/src/shared/repositories/session.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { sessionBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaClient, Session, SessionType } from '@repo/db';
+import { PrismaClient, SessionType } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { SessionRepository } from './session.repository';
@@ -8,21 +9,19 @@ import { SessionRepository } from './session.repository';
 describe('SessionRepository', () => {
   let repository: SessionRepository;
   let mockTx: DeepMocked<PrismaClient>;
-
-  const mockSession: Session = {
-    id: 'session-id-123',
-    userId: 'user-id-123',
-    type: 'web' as SessionType,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    revokedAt: null,
-    deletedAt: null,
-    expiresAt: null,
-    refreshedAt: null,
-  };
+  let mockSession: ReturnType<typeof sessionBuilder>;
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();
+    mockSession = sessionBuilder({
+      id: 'session-id-123',
+      userId: 'user-id-123',
+      type: SessionType.user,
+      revokedAt: null,
+      deletedAt: null,
+      expiresAt: null,
+      refreshedAt: null,
+    });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SessionRepository,

--- a/apps/api/src/shared/repositories/track.repository.spec.ts
+++ b/apps/api/src/shared/repositories/track.repository.spec.ts
@@ -1,6 +1,7 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { trackBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaClient, Track } from '@repo/db';
+import { PrismaClient, Visibility } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '../services/prisma.service';
 import { TrackRepository } from './track.repository';
@@ -9,7 +10,7 @@ describe('TrackRepository', () => {
   let repository: TrackRepository;
   let mockTx: DeepMocked<PrismaClient>;
 
-  const mockTrack: Track = {
+  const mockTrack = trackBuilder({
     id: 'track-123',
     title: 'Test Track',
     duration: 180,
@@ -19,11 +20,9 @@ describe('TrackRepository', () => {
     explicit: false,
     lyrics: null,
     albumId: 'album-123',
-    visibility: 'private',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    visibility: Visibility.private,
     deletedAt: null,
-  };
+  });
 
   beforeEach(async () => {
     mockTx = createMock<PrismaClient>();

--- a/apps/api/src/shared/repositories/user.repository.spec.ts
+++ b/apps/api/src/shared/repositories/user.repository.spec.ts
@@ -1,4 +1,5 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { emailAddressBuilder, userBuilder } from '@repo/testing';
 import { Test, TestingModule } from '@nestjs/testing';
 import { EmailAddress, EmailType, Gender, PrismaClient, User, UserCreateInput } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,7 +9,7 @@ import { UserRepository } from './user.repository';
 describe('UserRepository', () => {
   let repository: UserRepository;
 
-  const mockUser: User = {
+  const mockUser = userBuilder({
     id: 'user-id-123',
     username: 'testuser',
     password: 'hashed-password',
@@ -16,12 +17,10 @@ describe('UserRepository', () => {
     lastName: 'Doe',
     birthDate: '01-01-2000',
     gender: Gender.male,
-    createdAt: new Date(),
-    updatedAt: new Date(),
     avatarId: null,
     description: null,
     deletedAt: null,
-  };
+  });
 
   let mockTx: DeepMocked<PrismaClient>;
 
@@ -77,14 +76,14 @@ describe('UserRepository', () => {
 
   describe('getByEmail', () => {
     it('should return user associated with primary email', async () => {
-      mockTx.emailAddress.findFirst.mockResolvedValue(
-        createMock<EmailAddress & { user: User }>({
+      mockTx.emailAddress.findFirst.mockResolvedValue({
+        ...emailAddressBuilder({
           id: 'email-id',
           email: 'test@example.com',
           type: EmailType.primary,
-          user: mockUser,
         }),
-      );
+        user: mockUser,
+      } as EmailAddress & { user: User });
 
       const result = await repository.getByEmail('test@example.com');
       expect(result).toEqual(mockUser);

--- a/apps/api/src/shared/services/image.service.spec.ts
+++ b/apps/api/src/shared/services/image.service.spec.ts
@@ -1,4 +1,5 @@
 import sharp from 'sharp';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { ImageService } from './image.service';
 
 vi.mock('sharp', async (importOriginal) => {
@@ -30,6 +31,10 @@ describe('ImageService', () => {
     })
       .jpeg()
       .toBuffer();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   describe('getMetadata', () => {

--- a/apps/api/src/shared/services/prisma.service.spec.ts
+++ b/apps/api/src/shared/services/prisma.service.spec.ts
@@ -1,4 +1,4 @@
-import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { Test, TestingModule } from '@nestjs/testing';
 import { createPrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/apps/api/src/shared/services/storage.service.spec.ts
+++ b/apps/api/src/shared/services/storage.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { FileBucket } from '@repo/db';
-import { mockDeep, mockReset } from 'vitest-mock-extended';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { StorageService } from './storage.service';
 
 const mocks = vi.hoisted(() => ({
@@ -42,10 +43,10 @@ vi.mock('@aws-sdk/s3-request-presigner', () => ({
 
 describe('StorageService', () => {
   let service: StorageService;
-  const configServiceMock = mockDeep<ConfigService>();
+  let configServiceMock: DeepMocked<ConfigService>;
 
   beforeEach(() => {
-    mockReset(configServiceMock);
+    configServiceMock = createMock<ConfigService>();
     mocks.s3Send.mockReset();
     mocks.getSignedUrl.mockReset();
 
@@ -72,6 +73,10 @@ describe('StorageService', () => {
     });
 
     service = new StorageService(configServiceMock as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   describe('uploadFile', () => {

--- a/apps/api/src/shared/services/unit-of-work.service.spec.ts
+++ b/apps/api/src/shared/services/unit-of-work.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UnitOfWorkService } from './unit-of-work.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from './prisma.service';
+import { UnitOfWorkService } from './unit-of-work.service';
 
 describe('UnitOfWorkService', () => {
   let service: UnitOfWorkService;

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -29,8 +29,17 @@ export default defineConfig({
     tsconfigPaths(),
     // This is required to build the test files with SWC
     swc.vite({
-      // Explicitly set the module type to avoid issues with NestJS
       module: { type: 'es6' },
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          decorators: true,
+        },
+        transform: {
+          legacyDecorator: true,
+          decoratorMetadata: true,
+        },
+      },
     }),
   ],
 });

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@nestjs/common": "^11.0.1",
+    "@types/multer": "^2.0.0",
     "@repo/configs": "workspace:*",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-router": "^1.157.16",

--- a/packages/testing/src/builders/index.ts
+++ b/packages/testing/src/builders/index.ts
@@ -12,5 +12,6 @@ export * from "./library.builder";
 export * from "./refresh-token.builder";
 export * from "./session.builder";
 export * from "./track-access.builder";
+export * from "./track-with-access.builder";
 export * from "./track.builder";
 export * from "./user.builder";

--- a/packages/testing/src/builders/track-with-access.builder.ts
+++ b/packages/testing/src/builders/track-with-access.builder.ts
@@ -23,6 +23,22 @@ export type TrackWithAccessAndAlbumId = TrackWithAccess & {
  * Pass access to customize, or userId/role for default owner access.
  */
 export function trackWithAccessBuilder(
+  overrides: Partial<Track> & {
+    access?: Array<{ userId: string; role: AccessRole }>;
+    albumId: string;
+    userId?: string;
+    role?: AccessRole;
+  },
+): TrackWithAccessAndAlbumId;
+export function trackWithAccessBuilder(
+  overrides?: Partial<Track> & {
+    access?: Array<{ userId: string; role: AccessRole }>;
+    albumId?: string;
+    userId?: string;
+    role?: AccessRole;
+  },
+): TrackWithAccess;
+export function trackWithAccessBuilder(
   overrides?: Partial<Track> & {
     access?: Array<{ userId: string; role: AccessRole }>;
     albumId?: string;

--- a/packages/testing/src/builders/track-with-access.builder.ts
+++ b/packages/testing/src/builders/track-with-access.builder.ts
@@ -1,0 +1,52 @@
+import type { Track } from "@repo/db";
+import { AccessRole } from "@repo/db";
+import { trackAccessBuilder } from "./track-access.builder";
+import { trackBuilder } from "./track.builder";
+
+/**
+ * Track with access array - used when repository returns track with include: { access: true }.
+ * Use for permission/authorization tests (upload, delete, update).
+ */
+export type TrackWithAccess = Track & {
+  access: Array<{ userId: string; role: AccessRole }>;
+};
+
+/**
+ * Track with access and optional albumId - used for bulk upload where album scoping is validated.
+ */
+export type TrackWithAccessAndAlbumId = TrackWithAccess & {
+  albumId?: string;
+};
+
+/**
+ * Builds a track with access array for permission tests.
+ * Pass access to customize, or userId/role for default owner access.
+ */
+export function trackWithAccessBuilder(
+  overrides?: Partial<Track> & {
+    access?: Array<{ userId: string; role: AccessRole }>;
+    albumId?: string;
+    userId?: string;
+    role?: AccessRole;
+  },
+): TrackWithAccess | TrackWithAccessAndAlbumId {
+  const {
+    access,
+    albumId,
+    userId = "user-123",
+    role = AccessRole.owner,
+    ...trackOverrides
+  } = overrides ?? {};
+  const track = trackBuilder(trackOverrides);
+  const accessArray = access ?? [
+    trackAccessBuilder({ userId, role, trackId: track.id }),
+  ];
+  const base = {
+    ...track,
+    access: accessArray,
+  };
+  if (albumId !== undefined) {
+    return { ...base, albumId };
+  }
+  return base;
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./builders";
+export * from "./mocks";
 export * from "./nestjs";
 export * from "./web";

--- a/packages/testing/src/mocks/index.ts
+++ b/packages/testing/src/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from "./multer-file.mock";

--- a/packages/testing/src/mocks/multer-file.mock.ts
+++ b/packages/testing/src/mocks/multer-file.mock.ts
@@ -1,0 +1,29 @@
+/// <reference types="multer" />
+
+import { Readable } from "node:stream";
+
+/**
+ * Creates a mock Express.Multer.File for upload handler tests.
+ * Use this instead of defining createMockFile locally in spec files.
+ */
+export function createMockFile(
+  overrides: Partial<Express.Multer.File> = {},
+): Express.Multer.File {
+  const base: Express.Multer.File = {
+    buffer: Buffer.from("test audio content"),
+    mimetype: "audio/mpeg",
+    originalname: "test-song.mp3",
+    size: 1024,
+    fieldname: "file",
+    encoding: "7bit",
+    destination: "",
+    filename: "",
+    path: "",
+    stream: Readable.from(Buffer.from("test audio content")),
+  };
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "noEmit": false,
-    "types": ["node"],
+    "types": ["node", "multer"],
     "lib": ["ESNext", "DOM"],
     "jsx": "react-jsx"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.7


### PR DESCRIPTION
build(apps/api): configure swc for typescript decorators

Enable decorator support and metadata in SWC configuration to ensure
NestJS decorators function correctly during test execution.

chore(docs): add api testing standards cursor rule

Add a new cursor rule file to define standards for unit and integration testing, including mocking strategies, file naming conventions, and test structure guidelines.

feat(packages/testing): add multer file mock utility

Create a reusable `createMockFile` utility to standardize Express.Multer.File creation across unit tests.

feat(packages/testing): add trackWithAccess builder utility

Add a new builder to facilitate testing of tracks with associated
access permissions, supporting both standard track objects and
album-scoped tracks.

build(packages/testing): add multer types and export mocks

- Add @types/multer to devDependencies
- Include multer in tsconfig types
- Export mocks from the testing package index

build(deps): update pnpm-lock.yaml

test(apps/api): refactor audio processing tests to use shared builders

Update audio processing unit tests to utilize shared test builders and mock utilities from the @repo/testing package, improving consistency and reducing boilerplate code. Also ensure proper mock cleanup in test lifecycles.

refactor(apps/api): migrate auth unit tests to use shared test builders

Refactor various authentication feature unit tests to utilize shared test
builders and mock utilities from the `@repo/testing` package, improving
test maintainability and consistency.

test(apps/api): refactor library unit tests to use shared builders

Migrate library command and query handler tests to use shared test builders and standardized mock clearing in afterEach hooks.

test(apps/api): refactor library-albums unit tests to use shared builders

Migrate unit tests for library-albums command and query handlers to use
shared test builders and utilities, improving consistency and
maintainability of the test suite.

test(apps/api): refactor library-artists unit tests to use shared builders

Migrate unit tests for library-artists commands and queries to utilize shared test builders and standardized mocking utilities.

test(apps/api): refactor library-tracks unit tests to use shared builders

Migrate unit tests for library-tracks command and query handlers to use shared test builders and utilities, improving consistency and maintainability across the test suite.

style(packages/testing): apply consistent formatting to test utilities

test(apps/api): refactor access guard unit tests to use shared utilities

Refactor AlbumAccessGuard, ArtistAccessGuard, and TrackAccessGuard unit tests to utilize shared testing utilities and mock builders for improved consistency and maintainability.

test(apps/api): refactor repository unit tests to use shared builders

Update repository unit tests to utilize shared test builders and testing utilities, improving consistency and reducing boilerplate code across the test suite.

test(apps/api): refactor service unit tests to use shared utilities

- Standardize mock creation using `@repo/testing/nestjs`
- Add `afterEach` hooks to clear mocks consistently across service tests

test(apps/api): refactor common unit tests to use shared utilities

- Update test suites to use shared testing utilities and builders
- Standardize mock cleanup in afterEach hooks across common modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repo-wide API testing guidelines for unit vs integration tests, naming, structure, mock rules, and integration setup.

* **Tests**
  * Standardized test lifecycles with centralized mock cleanup; migrated many specs to shared builder fixtures and consistent NestJS-aligned mock helpers.

* **New Testing Utilities**
  * Added builders (including track-with-access), multipart file mock helper (createMockFile), and re-exported testing mocks for broader use.

* **Chores**
  * Updated Vitest SWC config, testing package types, and package exports/tsconfig for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->