### PR TITLE
ci: update Node.js and pnpm versions in GitHub workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -89,7 +89,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -133,7 +133,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -168,7 +168,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -203,7 +203,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -238,7 +238,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -273,7 +273,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -308,7 +308,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -343,7 +343,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -382,7 +382,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -424,7 +424,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -464,7 +464,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -509,7 +509,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -638,7 +638,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -757,7 +757,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -89,7 +89,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -133,7 +133,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -168,7 +168,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -203,7 +203,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -238,7 +238,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -273,7 +273,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -308,7 +308,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -343,7 +343,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -382,7 +382,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -424,7 +424,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -464,7 +464,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -509,7 +509,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -638,7 +638,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -757,7 +757,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "9.15.4"
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.32.1"
 
 jobs:
   install:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -89,7 +89,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -133,7 +133,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -168,7 +168,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -203,7 +203,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -238,7 +238,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -273,7 +273,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -308,7 +308,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -343,7 +343,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -382,7 +382,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -424,7 +424,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -464,7 +464,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -509,7 +509,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -638,7 +638,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -757,7 +757,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -361,7 +361,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -361,7 +361,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "9.15.4"
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.32.1"
 
 jobs:
   install:

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -361,7 +361,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -54,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +135,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +205,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +240,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +280,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-v3-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "9.15.4"
+  NODE_VERSION: "24"
+  PNPM_VERSION: "10.32.1"
 
 jobs:
   install:

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 FROM base AS builder
 RUN apk add --no-cache libc6-compat openssl

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -44,6 +44,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.18",
+    "eslint": "catalog:",
     "jsdom": "^27.4.0",
     "prettier": "catalog:",
     "typescript": "catalog:",

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 FROM base AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/apps/artist/Dockerfile
+++ b/apps/artist/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 FROM base AS builder
 RUN apk add --no-cache libc6-compat openssl

--- a/apps/artist/package.json
+++ b/apps/artist/package.json
@@ -44,6 +44,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.18",
+    "eslint": "catalog:",
     "jsdom": "^27.4.0",
     "prettier": "catalog:",
     "typescript": "catalog:",

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 FROM base AS builder
 RUN apk add --no-cache libc6-compat openssl

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.18",
+    "eslint": "catalog:",
     "jsdom": "^27.4.0",
     "prettier": "catalog:",
     "typescript": "catalog:",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - playr-network
 
   api:
-    image: node:22-alpine
+    image: node:24-alpine
     working_dir: /app
     volumes:
       - .:/app
@@ -122,7 +122,7 @@ services:
       - playr-network
 
   web:
-    image: node:22-alpine
+    image: node:24-alpine
     working_dir: /app
     volumes:
       - .:/app
@@ -138,7 +138,7 @@ services:
       - playr-network
 
   admin:
-    image: node:22-alpine
+    image: node:24-alpine
     working_dir: /app
     volumes:
       - .:/app
@@ -154,7 +154,7 @@ services:
       - playr-network
 
   artist:
-    image: node:22-alpine
+    image: node:24-alpine
     working_dir: /app
     volumes:
       - .:/app

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "license-checker": "^25.0.1",
     "madge": "^8.0.0",
     "prettier": "catalog:",
+    "prettier-plugin-packagejson": "^3.0.0",
     "turbo": "^2.7.6",
     "typescript": "catalog:"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "packageManager": "pnpm@10.32.1",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "turbo": "^2.7.6",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.32.1",
   "engines": {
     "node": ">=22"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -56,6 +56,7 @@
     "@nestjs/common": "^11.0.1",
     "@types/multer": "^2.0.0",
     "@repo/configs": "workspace:*",
+    "eslint": "catalog:",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-router": "^1.157.16",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,89 +1454,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2587,66 +2603,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2953,24 +2982,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -3043,24 +3076,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -5145,48 +5182,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      prettier-plugin-packagejson:
+        specifier: ^3.0.0
+        version: 3.0.0(prettier@3.8.1)
       turbo:
         specifier: ^2.7.6
         version: 2.7.6
@@ -141,6 +144,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.7)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@2.0.1)
@@ -425,6 +431,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.7)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@2.0.1)
@@ -603,6 +612,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.7)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(@noble/hashes@2.0.1)
@@ -768,6 +780,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.6.1)
       react:
         specifier: 'catalog:'
         version: 19.2.4


### PR DESCRIPTION
ci: update Node.js and pnpm versions in GitHub workflows

chore: update pnpm to 10.32.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime from v22 to v24 and pnpm from v9.15.4 to v10.32.1 across CI, container images, and project config.
  * Bumped package manager and Node engine declarations to match the new versions.
  * Revised node_modules cache key to include Node/pnpm versions for more granular caching.
  * Added ESLint and a package.json formatting plugin to dev tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->