### PR TITLE
refactor(packages/db): remove durationMs field from ListenHistory model

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,14 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
+  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
     name: Install Dependencies
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,20 +55,24 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client
+      - name: Build @repo/db (Prisma generate + tsup)
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: pnpm run prisma:generate
+        run: pnpm exec turbo run build --filter=@repo/db
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: install
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,7 +96,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -133,7 +142,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -168,7 +179,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -203,7 +216,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -238,7 +253,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -273,7 +290,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -308,7 +327,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -343,7 +364,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -382,7 +405,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -424,7 +449,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -464,7 +491,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -509,7 +538,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -638,7 +669,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -757,7 +790,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
-  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
@@ -55,7 +54,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -96,7 +95,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -142,7 +141,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -179,7 +178,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -216,7 +215,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -253,7 +252,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -290,7 +289,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -327,7 +326,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -364,7 +363,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -405,7 +404,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -449,7 +448,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -491,7 +490,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -538,7 +537,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -669,7 +668,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -790,7 +789,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -13,7 +13,6 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
-  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
@@ -57,7 +56,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -98,7 +97,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -144,7 +143,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -181,7 +180,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -218,7 +217,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -255,7 +254,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -297,7 +296,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -380,7 +379,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -13,11 +13,14 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
+  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
     name: Install Dependencies
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,20 +57,24 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client
+      - name: Build @repo/db (Prisma generate + tsup)
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: pnpm run prisma:generate
+        run: pnpm exec turbo run build --filter=@repo/db
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: install
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +98,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +144,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +181,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +218,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +255,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +297,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -361,7 +380,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -13,7 +13,6 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
-  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
@@ -57,7 +56,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -98,7 +97,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -144,7 +143,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -181,7 +180,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -218,7 +217,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -255,7 +254,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
@@ -297,7 +296,7 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
           restore-keys: |
             node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 

--- a/.github/workflows/push-light.yml
+++ b/.github/workflows/push-light.yml
@@ -13,11 +13,14 @@ concurrency:
 env:
   NODE_VERSION: "24"
   PNPM_VERSION: "10.32.1"
+  NODE_MODULES_CACHE_KEY: ${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'packages/db/prisma/schema.prisma', 'packages/db/prisma/migrations/**', 'packages/db/prisma.config.ts') }}
 
 jobs:
   install:
     name: Install Dependencies
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,20 +57,24 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client
+      - name: Build @repo/db (Prisma generate + tsup)
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: pnpm run prisma:generate
+        run: pnpm exec turbo run build --filter=@repo/db
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: install
+    env:
+      DATABASE_URL: "postgresql://playr:playr@localhost:5432/playr?schema=public"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +98,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -135,7 +144,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -170,7 +181,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -205,7 +218,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -240,7 +255,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile
@@ -280,7 +297,9 @@ jobs:
             packages/*/node_modules
             packages/db/src/generated
             packages/db/dist
-          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-${{ env.NODE_MODULES_CACHE_KEY }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-node${{ env.NODE_VERSION }}-pnpm${{ env.PNPM_VERSION }}-
 
       - name: Install dependencies (cache miss fallback)
         run: pnpm install --frozen-lockfile

--- a/packages/contracts/src/schemas/listen-history.schema.ts
+++ b/packages/contracts/src/schemas/listen-history.schema.ts
@@ -5,7 +5,6 @@ import { zodDateTime } from "../utils/zod-datetime";
 export const ListenHistorySchema = z.object({
   id: z.string(),
   listenedAt: zodDateTime(),
-  durationMs: z.number().int(),
   completed: z.boolean(),
   userId: z.string(),
   trackId: z.string(),

--- a/packages/contracts/src/schemas/listen-history.schema.ts
+++ b/packages/contracts/src/schemas/listen-history.schema.ts
@@ -5,7 +5,6 @@ import { zodDateTime } from "../utils/zod-datetime";
 export const ListenHistorySchema = z.object({
   id: z.string(),
   listenedAt: zodDateTime(),
-  completed: z.boolean(),
   userId: z.string(),
   trackId: z.string(),
   createdAt: zodDateTime(),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,9 +13,9 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "prisma generate && tsup",
     "check-types": "tsc --noEmit",
-    "prisma:generate": "prisma generate && pnpm build",
+    "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio"

--- a/packages/db/prisma/migrations/20260323114018/migration.sql
+++ b/packages/db/prisma/migrations/20260323114018/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `durationMs` on the `listen_history` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "listen_history" DROP COLUMN "durationMs";

--- a/packages/db/prisma/migrations/20260323160925/migration.sql
+++ b/packages/db/prisma/migrations/20260323160925/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `completed` on the `listen_history` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "listen_history" DROP COLUMN "completed";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -539,7 +539,6 @@ model ArtistFollow {
 model ListenHistory {
   id         String   @id @default(cuid())
   listenedAt DateTime @default(now())
-  durationMs Int      @default(0)
   completed  Boolean  @default(false)
 
   userId String

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -539,7 +539,6 @@ model ArtistFollow {
 model ListenHistory {
   id         String   @id @default(cuid())
   listenedAt DateTime @default(now())
-  completed  Boolean  @default(false)
 
   userId String
   user   User   @relation("UserListenHistory", fields: [userId], references: [id], onDelete: Cascade)

--- a/turbo.json
+++ b/turbo.json
@@ -67,7 +67,8 @@
       "persistent": true
     },
     "prisma:generate": {
-      "cache": true
+      "cache": true,
+      "outputs": ["src/generated/**"]
     },
     "prisma:migrate": {
       "cache": false


### PR DESCRIPTION
refactor(packages/db): remove durationMs field from ListenHistory model

refactor(packages/db): remove durationMs column from listen_history table

refactor(packages/contracts): remove durationMs field from listen history schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed duration tracking from listen history — playback durations will no longer be recorded or shown.
  * Removed completion status from listen history — listens will no longer indicate a "completed" flag.
  * Applied database migrations that drop the stored duration and completion columns — any existing values for those fields will be deleted; other listen history details remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->