### PR TITLE
feat: added genre option for album and it tracks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy to `.env` at the repository root (or use `.env.local` for machine-specific overrides).
+# Used by: local Nest API (`apps/api`), Prisma CLI (`pnpm prisma:migrate`), and other tools that load root env.
+
+# Host machine → Postgres bound by docker-compose.dev.yml on 127.0.0.1:5432 (defaults: playr/playr/playr).
+# Inside Docker, the API service uses `@db` as host instead; keep this line for running migrations and API on the host.
+DATABASE_URL=postgresql://playr:playr@127.0.0.1:5432/playr?schema=public
+
+# Optional: override compose defaults without editing DATABASE_URL
+# POSTGRES_USER=playr
+# POSTGRES_PASSWORD=playr
+# POSTGRES_DB=playr
+# POSTGRES_PORT=5432
+# Hostname for Prisma’s built URL when DATABASE_URL is unset (host dev: omit or 127.0.0.1; Docker: db)
+# POSTGRES_HOST=127.0.0.1

--- a/apps/api/integration/.env.test
+++ b/apps/api/integration/.env.test
@@ -1,5 +1,5 @@
 PORT=8001
-DATABASE_URL=postgresql://playr:playr@localhost:5435/playr?schema=public
+DATABASE_URL=postgresql://playr:playr@localhost:5432/playr?schema=public
 
 # JWT
 JWT_ACCESS_SECRET=test-access-secret

--- a/apps/web/src/components/library/albums/create/CreateLibraryGenreNameModal.tsx
+++ b/apps/web/src/components/library/albums/create/CreateLibraryGenreNameModal.tsx
@@ -8,27 +8,29 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { checkLibraryArtistNameAvailability } from '@/hooks/api/library-artists/requests/checkLibraryArtistNameAvailability';
+import { genreMatchKey } from '@/lib/genres/genreMatchKey';
 import { useCallback, useState } from 'react';
 
-type CreateLibraryArtistNameModalProps = {
+type CreateLibraryGenreNameModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Names of artists already staged as pending in this session (exact match vs trimmed input). */
-  pendingArtistNames: string[];
-  /** Called with trimmed name when availability passes. */
+  /** Names of genres already staged as pending in this session (exact match vs trimmed input). */
+  pendingGenreNames: string[];
+  /** Genres loaded for the library (system + custom) — used to block duplicates in the dropdown set. */
+  existingGenres: { id: string; name: string; slug: string }[];
+  /** Called with trimmed name when validation passes. */
   onConfirm: (name: string) => void;
 };
 
-export function CreateLibraryArtistNameModal({
+export function CreateLibraryGenreNameModal({
   open,
   onOpenChange,
-  pendingArtistNames,
+  pendingGenreNames,
+  existingGenres,
   onConfirm,
-}: CreateLibraryArtistNameModalProps) {
+}: CreateLibraryGenreNameModalProps) {
   const [name, setName] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [isChecking, setIsChecking] = useState(false);
 
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
@@ -36,7 +38,6 @@ export function CreateLibraryArtistNameModal({
     if (!open) {
       setName('');
       setError(null);
-      setIsChecking(false);
     }
   }
 
@@ -45,53 +46,52 @@ export function CreateLibraryArtistNameModal({
       if (!nextOpen) {
         setName('');
         setError(null);
-        setIsChecking(false);
       }
       onOpenChange(nextOpen);
     },
     [onOpenChange],
   );
 
-  const handleConfirm = useCallback(async () => {
+  const handleConfirm = useCallback(() => {
     const trimmed = name.trim();
     if (!trimmed) return;
 
     setError(null);
 
-    if (pendingArtistNames.some((n) => n === trimmed)) {
-      setError('You already added an artist with this name for this album.');
+    if (pendingGenreNames.some((n) => n === trimmed)) {
+      setError('You already added a genre with this name for this album.');
       return;
     }
 
-    setIsChecking(true);
-    try {
-      const result = await checkLibraryArtistNameAvailability(trimmed);
-      if (!result.data.available) {
-        setError('An artist with this name already exists in your library.');
-        return;
-      }
-      onConfirm(trimmed);
-      handleOpenChange(false);
-    } catch {
-      setError('Could not verify name. Try again.');
-    } finally {
-      setIsChecking(false);
+    const key = genreMatchKey(trimmed);
+    if (!key) {
+      setError('Genre name must contain at least one letter or number.');
+      return;
     }
-  }, [name, onConfirm, handleOpenChange, pendingArtistNames]);
+
+    const collides = existingGenres.some((g) => genreMatchKey(g.name) === key);
+    if (collides) {
+      setError('A genre like this already exists — pick it from the list instead.');
+      return;
+    }
+
+    onConfirm(trimmed);
+    handleOpenChange(false);
+  }, [name, onConfirm, handleOpenChange, pendingGenreNames, existingGenres]);
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>New artist</DialogTitle>
+          <DialogTitle>New genre</DialogTitle>
           <DialogDescription>
-            This artist will be saved when you create the album. You can add more details later from
-            the library.
+            Draft genres are created when you submit the album. Add several if you like, select them
+            in the list, and manage custom genres later from the library.
           </DialogDescription>
         </DialogHeader>
         <TextField
-          label="Artist name"
-          placeholder="e.g. The Band"
+          label="Genre name"
+          placeholder="e.g. Shoegaze"
           value={name}
           onChange={(v) => {
             setName(v);
@@ -104,12 +104,8 @@ export function CreateLibraryArtistNameModal({
           <Button type="button" variant="secondary" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          <Button
-            type="button"
-            onClick={() => void handleConfirm()}
-            disabled={!name.trim() || isChecking}
-          >
-            {isChecking ? 'Checking…' : 'Add artist'}
+          <Button type="button" onClick={() => void handleConfirm()} disabled={!name.trim()}>
+            Add genre
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/library/albums/create/LibraryAlbumFromFilesForm.test.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumFromFilesForm.test.tsx
@@ -6,7 +6,11 @@ import {
   extractMetadataFromAudioFile,
 } from '@/lib/audio/audio-metadata';
 import { customRender } from '@repo/testing/web';
-import { GetLibraryArtistNameAvailabilityResponseSchema } from '@repo/contracts';
+import {
+  CreateLibraryGenreResponseSchema,
+  GetLibraryArtistNameAvailabilityResponseSchema,
+  GetLibraryGenresResponseSchema,
+} from '@repo/contracts';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
@@ -58,15 +62,42 @@ vi.mock('@tanstack/react-router', () => ({
 const createAlbumMock = vi.fn();
 const bulkTracksMock = vi.fn();
 const createArtistMock = vi.fn();
+const createGenreMock = vi.fn();
 const uploadCoverMock = vi.fn();
 
-const { libraryStoreState, useLibraryArtistsMock } = vi.hoisted(() => ({
+const testGenreItem = {
+  id: 'genre-1',
+  name: 'Rock',
+  slug: 'rock',
+  description: null,
+  kind: 'system' as const,
+  libraryId: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  deletedAt: null,
+};
+
+const defaultGenresData = () =>
+  GetLibraryGenresResponseSchema.parse({
+    success: true,
+    data: {
+      items: [testGenreItem],
+      total: 1,
+      page: 1,
+      limit: 100,
+    },
+    error: null,
+    meta: { timestamp: 't', requestId: 'r', path: '/p' },
+  });
+
+const { libraryStoreState, useLibraryArtistsMock, useLibraryGenresMock } = vi.hoisted(() => ({
   libraryStoreState: {
     libraryId: 'lib-1' as string | null,
     privateArtists: [{ id: 'artist-1', name: 'Alpha' }] as { id: string; name: string }[],
     setPrivateArtists: vi.fn(),
   },
   useLibraryArtistsMock: vi.fn(() => ({ isLoading: false, data: undefined })),
+  useLibraryGenresMock: vi.fn(() => ({ isLoading: false, data: defaultGenresData() })),
 }));
 
 vi.mock('@/stores/library.store', () => ({
@@ -86,6 +117,19 @@ vi.mock('@/stores/library.store', () => ({
 
 vi.mock('@/hooks/api/library-artists/useLibraryArtists', () => ({
   useLibraryArtists: () => useLibraryArtistsMock(),
+}));
+
+vi.mock('@/hooks/api/library-genres/useLibraryGenres', () => ({
+  useLibraryGenres: () => useLibraryGenresMock(),
+}));
+
+vi.mock('@/hooks/api/library-genres/useCreateLibraryGenre', () => ({
+  useCreateLibraryGenre: () => ({
+    mutateAsync: createGenreMock,
+    get isPending() {
+      return false;
+    },
+  }),
 }));
 
 vi.mock('@/hooks/api/library-albums/useCreateLibraryAlbum', () => ({
@@ -177,7 +221,23 @@ describe('LibraryAlbumFromFilesForm', () => {
     createAlbumMock.mockResolvedValue({ data: { id: 'new-album-id' } });
     bulkTracksMock.mockResolvedValue(undefined);
     createArtistMock.mockResolvedValue({ data: { id: 'created-artist' } });
+    createGenreMock.mockResolvedValue(
+      CreateLibraryGenreResponseSchema.parse({
+        success: true,
+        data: {
+          ...testGenreItem,
+          id: 'created-genre',
+          name: 'Modal Genre',
+          slug: 'modalgenre',
+          kind: 'custom',
+          libraryId: 'lib-1',
+        },
+        error: null,
+        meta: { timestamp: 't', requestId: 'r', path: '/p' },
+      }),
+    );
     uploadCoverMock.mockResolvedValue(undefined);
+    useLibraryGenresMock.mockReturnValue({ isLoading: false, data: defaultGenresData() });
   });
 
   afterEach(() => {
@@ -191,7 +251,7 @@ describe('LibraryAlbumFromFilesForm', () => {
   it('renders cancel link and disabled submit while empty', () => {
     renderForm({ cancelTo: '/app/library/albums' });
 
-    expect(screen.getByRole('button', { name: /add audio files to continue/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^create album$/i })).toBeDisabled();
     expect(screen.getByRole('link', { name: /cancel/i })).toHaveAttribute(
       'href',
       '/app/library/albums',
@@ -370,6 +430,63 @@ describe('LibraryAlbumFromFilesForm', () => {
     await waitFor(() => {
       expect(createAlbumMock).toHaveBeenCalledWith(
         expect.objectContaining({ artistId: 'artist-1' }),
+      );
+    });
+  });
+
+  it('passes genreIds to create album when an existing genre is selected', async () => {
+    const user = userEvent.setup();
+    renderForm({ cancelTo: '/back' });
+
+    const audioInput = document.querySelector('input[accept="audio/*"]') as HTMLInputElement;
+    await user.upload(audioInput, new File(['x'], 'song.mp3', { type: 'audio/mp3' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/album title/i)).toHaveValue('From Meta');
+    });
+
+    await user.click(screen.getByRole('button', { name: /genres \(optional\)/i }));
+    await user.click(await screen.findByRole('option', { name: /^Rock$/i }));
+
+    await user.click(screen.getByRole('button', { name: /create album.*upload/i }));
+
+    await waitFor(() => {
+      expect(createGenreMock).not.toHaveBeenCalled();
+      expect(createAlbumMock).toHaveBeenCalledWith(
+        expect.objectContaining({ genreIds: ['genre-1'] }),
+      );
+    });
+  });
+
+  it('creates a genre before the album when staging a new genre from the modal', async () => {
+    const user = userEvent.setup();
+    renderForm({ cancelTo: '/back' });
+
+    const audioInput = document.querySelector('input[accept="audio/*"]') as HTMLInputElement;
+    await user.upload(audioInput, new File(['x'], 'song.mp3', { type: 'audio/mp3' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/album title/i)).toHaveValue('From Meta');
+    });
+
+    await user.click(screen.getByRole('button', { name: /genres \(optional\)/i }));
+    await user.click(await screen.findByRole('option', { name: /create new genre/i }));
+
+    expect(await screen.findByRole('heading', { name: /new genre/i })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/genre name/i), 'Modal Genre');
+    await user.click(screen.getByRole('button', { name: /add genre/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: /new genre/i })).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /create album.*upload/i }));
+
+    await waitFor(() => {
+      expect(createGenreMock).toHaveBeenCalledWith({ name: 'Modal Genre' });
+      expect(createAlbumMock).toHaveBeenCalledWith(
+        expect.objectContaining({ genreIds: ['created-genre'] }),
       );
     });
   });

--- a/apps/web/src/components/library/albums/create/LibraryAlbumFromFilesForm.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumFromFilesForm.tsx
@@ -4,15 +4,19 @@ import { useCreateLibraryAlbum } from '@/hooks/api/library-albums/useCreateLibra
 import { useUploadLibraryAlbumCover } from '@/hooks/api/library-albums/useUploadLibraryAlbumCover';
 import { useCreateLibraryArtist } from '@/hooks/api/library-artists/useCreateLibraryArtist';
 import { useLibraryArtists } from '@/hooks/api/library-artists/useLibraryArtists';
+import { useCreateLibraryGenre } from '@/hooks/api/library-genres/useCreateLibraryGenre';
+import { useLibraryGenres } from '@/hooks/api/library-genres/useLibraryGenres';
 import { useBulkCreateLibraryTracks } from '@/hooks/api/library-tracks/useBulkCreateLibraryTracks';
 import { useLibraryStore } from '@/stores/library.store';
-import { CircleNotchIcon, UploadSimpleIcon } from '@phosphor-icons/react';
+import type { ZodGenreInfer } from '@repo/contracts';
+import { CircleNotchIcon, PlusCircleIcon, UploadSimpleIcon } from '@phosphor-icons/react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { CoverSelectionBanner } from '../../tracks/bulk/CoverSelectionBanner';
 import { AlbumAudioDropCard } from './AlbumAudioDropCard';
 import { CreateLibraryArtistNameModal } from './CreateLibraryArtistNameModal';
+import { CreateLibraryGenreNameModal } from './CreateLibraryGenreNameModal';
 import { LibraryAlbumFromFilesProcessingOverlay } from './LibraryAlbumFromFilesProcessingOverlay';
 import { LibraryAlbumFromFilesTracksSection } from './LibraryAlbumFromFilesTracksSection';
 import { LibraryAlbumMetadataSection } from './LibraryAlbumMetadataSection';
@@ -21,7 +25,12 @@ import {
   isLocalPendingArtistId,
   normalizeLibraryArtistNameForMatch,
 } from './pendingLibraryArtist';
+import { isLocalPendingGenreId, makeLocalPendingGenreId } from './pendingLibraryGenre';
 import { useLibraryAlbumFromFilesForm } from './useLibraryAlbumFromFilesForm';
+import {
+  LIBRARY_ALBUM_GENRE_CREATE_VALUE,
+  LIBRARY_ALBUM_GENRE_NONE_VALUE,
+} from './libraryAlbumGenreConstants';
 
 /** Select sentinel: opens the “new artist” modal instead of setting `artistId`. */
 const CREATE_NEW_ARTIST_SELECT_VALUE = '__create_new_artist__';
@@ -39,6 +48,10 @@ export function LibraryAlbumFromFilesForm({
   const { libraryId } = useLibraryStore();
   const { isLoading: isLoadingArtists } = useLibraryArtists();
   const artists = useLibraryStore((state) => state.privateArtists);
+  const { data: genresResponse, isLoading: isLoadingGenres } = useLibraryGenres({
+    page: 1,
+    limit: 100,
+  });
 
   const { mutateAsync: createAlbum, isPending: isCreatingAlbum } = useCreateLibraryAlbum();
   const { mutateAsync: uploadCover, isPending: isUploadingCover } = useUploadLibraryAlbumCover();
@@ -46,9 +59,12 @@ export function LibraryAlbumFromFilesForm({
     useBulkCreateLibraryTracks();
   const { mutateAsync: createLibraryArtist, isPending: isCreatingArtist } =
     useCreateLibraryArtist();
+  const { mutateAsync: createLibraryGenre, isPending: isCreatingGenre } = useCreateLibraryGenre();
 
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [createArtistModalOpen, setCreateArtistModalOpen] = useState(false);
+  const [createGenreModalOpen, setCreateGenreModalOpen] = useState(false);
+  const [pendingGenres, setPendingGenres] = useState<{ id: string; name: string }[]>([]);
 
   const {
     formData,
@@ -70,10 +86,17 @@ export function LibraryAlbumFromFilesForm({
     removeTrack,
     clearTracks,
     updateFormData,
+    toggleGenreId,
+    clearGenreSelection,
+    appendGenreId,
     isFormValid,
     pendingArtists,
     setPendingArtists,
   } = useLibraryAlbumFromFilesForm({ initialArtistId });
+
+  useEffect(() => {
+    setPendingGenres((prev) => prev.filter((p) => formData.genreIds.includes(p.id)));
+  }, [formData.genreIds]);
 
   useEffect(() => {
     if (isLoadingArtists) return;
@@ -111,6 +134,11 @@ export function LibraryAlbumFromFilesForm({
   }, [selectedCoverTrackId, tracksWithCovers]);
 
   const coverPreviewUrl = manualAlbumCoverPreviewUrl ?? embeddedCoverPreviewUrl;
+
+  const genres = useMemo<ZodGenreInfer[]>(
+    () => genresResponse?.data?.items ?? [],
+    [genresResponse],
+  );
 
   const artistSelectOptions = useMemo(() => {
     const createOption = { value: CREATE_NEW_ARTIST_SELECT_VALUE, label: '+ Create new artist…' };
@@ -151,6 +179,37 @@ export function LibraryAlbumFromFilesForm({
     updateFormData('artistId', '');
   }, [formData.artistId, setPendingArtists, updateFormData]);
 
+  const handleGenreSelectionChange = useCallback(
+    (value: string) => {
+      if (value === LIBRARY_ALBUM_GENRE_CREATE_VALUE) {
+        setCreateGenreModalOpen(true);
+        return;
+      }
+      if (value === LIBRARY_ALBUM_GENRE_NONE_VALUE) {
+        clearGenreSelection();
+        return;
+      }
+      toggleGenreId(value);
+    },
+    [clearGenreSelection, toggleGenreId],
+  );
+
+  const handleConfirmNewGenreName = useCallback(
+    (name: string) => {
+      const id = makeLocalPendingGenreId();
+      setPendingGenres((prev) => [...prev, { id, name }]);
+      appendGenreId(id);
+    },
+    [appendGenreId],
+  );
+
+  const handleRemoveGenreId = useCallback(
+    (id: string) => {
+      toggleGenreId(id);
+    },
+    [toggleGenreId],
+  );
+
   const handleSelectCover = useCallback(
     (trackId: string | null) => {
       setSelectedCoverTrackId(trackId);
@@ -171,13 +230,15 @@ export function LibraryAlbumFromFilesForm({
 
   const progressStep = isCreatingArtist
     ? 'Creating artist...'
-    : isCreatingAlbum
-      ? 'Creating album...'
-      : isUploadingCover
-        ? 'Uploading cover...'
-        : isUploadingTracks
-          ? `Uploading ${tracks.length} track${tracks.length !== 1 ? 's' : ''}...`
-          : null;
+    : isCreatingGenre
+      ? 'Creating genre...'
+      : isCreatingAlbum
+        ? 'Creating album...'
+        : isUploadingCover
+          ? 'Uploading cover...'
+          : isUploadingTracks
+            ? `Uploading ${tracks.length} track${tracks.length !== 1 ? 's' : ''}...`
+            : null;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -200,12 +261,30 @@ export function LibraryAlbumFromFilesForm({
           artistId = createdArtist.data.id;
         }
 
+        const resolvedGenreIds: string[] = [];
+        for (const gid of formData.genreIds) {
+          if (isLocalPendingGenreId(gid)) {
+            const pendingGenre = pendingGenres.find((p) => p.id === gid);
+            if (!pendingGenre?.name.trim()) {
+              throw new Error('Genre name is missing');
+            }
+            const createdGenre = await createLibraryGenre({ name: pendingGenre.name.trim() });
+            if (!createdGenre.data) {
+              throw new Error('Failed to create genre');
+            }
+            resolvedGenreIds.push(createdGenre.data.id);
+          } else {
+            resolvedGenreIds.push(gid);
+          }
+        }
+
         const album = await createAlbum({
           name: formData.name,
           description: formData.description,
           type: formData.type,
           artistId,
           releaseDate: formData.releaseDate,
+          genreIds: resolvedGenreIds.length > 0 ? resolvedGenreIds : undefined,
         });
 
         if (!album.data) throw new Error('Failed to create album');
@@ -214,16 +293,21 @@ export function LibraryAlbumFromFilesForm({
           await uploadCover({ id: album.data.id, file: coverFileForUpload });
         }
 
-        await bulkCreateTracks({
-          album: album.data,
-          tracks,
-          artistIds: [artistId],
-        });
+        if (tracks.length > 0) {
+          await bulkCreateTracks({
+            album: album.data,
+            tracks,
+            artistIds: [artistId],
+          });
+        }
 
         toast.success(
-          `Successfully created album and uploaded ${tracks.length} track${tracks.length !== 1 ? 's' : ''}`,
+          tracks.length === 0
+            ? 'Successfully created album'
+            : `Successfully created album and uploaded ${tracks.length} track${tracks.length !== 1 ? 's' : ''}`,
         );
         setPendingArtists([]);
+        setPendingGenres([]);
         navigate({ to: '/app/library/albums/$id', params: { id: album.data.id } });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to create album';
@@ -239,7 +323,9 @@ export function LibraryAlbumFromFilesForm({
       tracks,
       pendingArtists,
       setPendingArtists,
+      pendingGenres,
       createLibraryArtist,
+      createLibraryGenre,
       createAlbum,
       uploadCover,
       bulkCreateTracks,
@@ -247,7 +333,8 @@ export function LibraryAlbumFromFilesForm({
     ],
   );
 
-  const isSubmitting = isCreatingArtist || isCreatingAlbum || isUploadingCover || isUploadingTracks;
+  const isSubmitting =
+    isCreatingArtist || isCreatingGenre || isCreatingAlbum || isUploadingCover || isUploadingTracks;
   const isProcessing = isScanningMetadata || isScanningCovers;
   const processingMessage =
     isScanningMetadata && isScanningCovers
@@ -258,7 +345,7 @@ export function LibraryAlbumFromFilesForm({
 
   const submitLabel =
     tracks.length === 0
-      ? 'Add audio files to continue'
+      ? 'Create album'
       : `Create album & upload ${tracks.length} track${tracks.length !== 1 ? 's' : ''}`;
 
   return (
@@ -268,6 +355,13 @@ export function LibraryAlbumFromFilesForm({
         onOpenChange={setCreateArtistModalOpen}
         pendingArtistNames={pendingArtists.map((p) => p.name)}
         onConfirm={handleConfirmNewArtistName}
+      />
+      <CreateLibraryGenreNameModal
+        open={createGenreModalOpen}
+        onOpenChange={setCreateGenreModalOpen}
+        pendingGenreNames={pendingGenres.map((p) => p.name)}
+        existingGenres={genres.map((g) => ({ id: g.id, name: g.name, slug: g.slug }))}
+        onConfirm={handleConfirmNewGenreName}
       />
       {isProcessing && <LibraryAlbumFromFilesProcessingOverlay message={processingMessage} />}
 
@@ -289,6 +383,11 @@ export function LibraryAlbumFromFilesForm({
               onClearStagedArtist={handleClearStagedArtist}
               onManualCoverFile={setManualAlbumCover}
               onRemoveCover={handleRemoveCover}
+              genres={genres}
+              pendingGenres={pendingGenres}
+              isLoadingGenres={isLoadingGenres}
+              onGenreSelectionChange={handleGenreSelectionChange}
+              onRemoveGenreId={handleRemoveGenreId}
             />
           </aside>
 
@@ -351,7 +450,7 @@ export function LibraryAlbumFromFilesForm({
           </Button>
           <Button
             type="submit"
-            disabled={!isFormValid || isSubmitting || isLoadingArtists}
+            disabled={!isFormValid || isSubmitting || isLoadingArtists || isLoadingGenres}
             className="min-w-32 sm:min-w-36"
           >
             {isSubmitting ? (
@@ -361,7 +460,11 @@ export function LibraryAlbumFromFilesForm({
               </>
             ) : (
               <>
-                <UploadSimpleIcon className="mr-2 h-4 w-4" />
+                {tracks.length === 0 ? (
+                  <PlusCircleIcon className="mr-2 h-4 w-4" />
+                ) : (
+                  <UploadSimpleIcon className="mr-2 h-4 w-4" />
+                )}
                 {submitLabel}
               </>
             )}

--- a/apps/web/src/components/library/albums/create/LibraryAlbumGenrePicker.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumGenrePicker.tsx
@@ -1,0 +1,233 @@
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import type { ZodGenreInfer } from '@repo/contracts';
+import { CaretDownIcon, CheckIcon } from '@phosphor-icons/react';
+import { useCallback, useId, useMemo, useState } from 'react';
+import {
+  LIBRARY_ALBUM_GENRE_CREATE_VALUE,
+  LIBRARY_ALBUM_GENRE_NONE_VALUE,
+} from './libraryAlbumGenreConstants';
+
+function matchesGenreSearch(query: string, name: string, slug: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return name.toLowerCase().includes(q) || slug.toLowerCase().includes(q);
+}
+
+function sortByName(a: { name: string }, b: { name: string }): number {
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+}
+
+function labelForGenreId(
+  id: string,
+  genres: ZodGenreInfer[],
+  pendingGenres: { id: string; name: string }[],
+): string | null {
+  const pending = pendingGenres.find((p) => p.id === id);
+  if (pending) return `${pending.name} (new)`;
+  const g = genres.find((x) => x.id === id);
+  return g?.name ?? null;
+}
+
+function triggerSummary(
+  selectedGenreIds: string[],
+  genres: ZodGenreInfer[],
+  pendingGenres: { id: string; name: string }[],
+  placeholder: string,
+): string {
+  if (selectedGenreIds.length === 0) return placeholder;
+  const labels = selectedGenreIds
+    .map((id) => labelForGenreId(id, genres, pendingGenres))
+    .filter((n): n is string => Boolean(n));
+  if (labels.length === 0) return placeholder;
+  if (labels.length === 1) return labels[0]!;
+  if (labels.length === 2) return `${labels[0]}, ${labels[1]}`;
+  return `${labels[0]}, ${labels[1]} +${labels.length - 2} more`;
+}
+
+export interface LibraryAlbumGenrePickerProps {
+  label?: string;
+  selectedGenreIds: string[];
+  genres: ZodGenreInfer[];
+  pendingGenres: { id: string; name: string }[];
+  isLoading: boolean;
+  disabled?: boolean;
+  /** Shown when no genres are selected. */
+  nonePlaceholder?: string;
+  /** Sentinels: `LIBRARY_ALBUM_GENRE_CREATE_VALUE` opens modal; `LIBRARY_ALBUM_GENRE_NONE_VALUE` clears all; otherwise toggles id. */
+  onSelect: (value: string) => void;
+}
+
+export function LibraryAlbumGenrePicker({
+  label = 'Genres (optional)',
+  selectedGenreIds,
+  genres,
+  pendingGenres,
+  isLoading,
+  disabled = false,
+  nonePlaceholder = 'No genres',
+  onSelect,
+}: LibraryAlbumGenrePickerProps) {
+  const id = useId();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const selectedSet = useMemo(() => new Set(selectedGenreIds), [selectedGenreIds]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) setSearch('');
+  }, []);
+
+  const filteredPending = useMemo(() => {
+    return pendingGenres.filter((p) => matchesGenreSearch(search, p.name, p.name)).sort(sortByName);
+  }, [pendingGenres, search]);
+
+  const systemGenres = useMemo(() => {
+    return genres
+      .filter((g) => g.kind === 'system')
+      .filter((g) => matchesGenreSearch(search, g.name, g.slug))
+      .sort(sortByName);
+  }, [genres, search]);
+
+  const customGenres = useMemo(() => {
+    return genres
+      .filter((g) => g.kind === 'custom')
+      .filter((g) => matchesGenreSearch(search, g.name, g.slug))
+      .sort(sortByName);
+  }, [genres, search]);
+
+  const hasLibraryRowsBelow = systemGenres.length > 0 || customGenres.length > 0;
+  const showSeparatorBeforeCustom = systemGenres.length > 0 && customGenres.length > 0;
+
+  const displayValue = triggerSummary(selectedGenreIds, genres, pendingGenres, nonePlaceholder);
+
+  const handlePick = useCallback(
+    (value: string) => {
+      if (value === LIBRARY_ALBUM_GENRE_CREATE_VALUE) {
+        onSelect(value);
+        handleOpenChange(false);
+        return;
+      }
+      onSelect(value);
+      if (value !== LIBRARY_ALBUM_GENRE_NONE_VALUE) {
+        return;
+      }
+      handleOpenChange(false);
+    },
+    [onSelect, handleOpenChange],
+  );
+
+  const sectionHeader = (title: string, opts?: { first?: boolean }) => (
+    <div
+      role="presentation"
+      className={cn(
+        'text-foreground/85 select-none px-2 pb-0.5 text-xs font-semibold tracking-tight',
+        opts?.first ? 'pt-1.5' : 'pt-2',
+      )}
+    >
+      {title}
+    </div>
+  );
+
+  const optionRow = (
+    value: string,
+    text: string,
+    selected: boolean,
+    opts?: { accent?: boolean },
+  ) => (
+    <button
+      key={value}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      className={cn(
+        'focus:bg-accent focus:text-accent-foreground flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-left text-sm outline-none select-none',
+        selected && 'bg-accent/50',
+        opts?.accent && 'font-medium text-primary',
+      )}
+      onClick={() => handlePick(value)}
+    >
+      <span className="min-w-0 flex-1 truncate">{text}</span>
+      {selected ? <CheckIcon className="text-muted-foreground size-4 shrink-0" /> : null}
+    </button>
+  );
+
+  return (
+    <Field>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <button
+            id={id}
+            type="button"
+            disabled={disabled || isLoading}
+            className={cn(
+              'border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 h-8 w-full min-w-0 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-left text-sm transition-colors select-none focus-visible:ring-[3px] flex items-center justify-between gap-1.5 outline-none disabled:cursor-not-allowed disabled:opacity-50',
+            )}
+            aria-haspopup="listbox"
+            aria-expanded={open}
+          >
+            <span className="min-w-0 flex-1 truncate text-foreground">
+              {isLoading ? 'Loading...' : displayValue}
+            </span>
+            <CaretDownIcon className="text-muted-foreground size-4 shrink-0 pointer-events-none" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[var(--radix-popover-trigger-width)] min-w-[var(--radix-popover-trigger-width)] max-w-[min(100vw-2rem,24rem)] gap-0 overflow-hidden p-0"
+        >
+          <div className="flex flex-col gap-0 border-b border-border px-2 py-2">
+            <Input
+              placeholder="Search genres…"
+              value={search}
+              onChange={(ev) => setSearch(ev.target.value)}
+              className="h-8"
+              autoComplete="off"
+              aria-label="Search genres"
+              autoFocus
+            />
+          </div>
+          <div role="listbox" aria-label="Genres" className="max-h-64 overflow-y-auto p-1">
+            {optionRow(LIBRARY_ALBUM_GENRE_CREATE_VALUE, '+ Create new genre…', false, {
+              accent: true,
+            })}
+            {optionRow(LIBRARY_ALBUM_GENRE_NONE_VALUE, 'No genres', selectedGenreIds.length === 0)}
+            {filteredPending.map((p) =>
+              optionRow(p.id, `${p.name} (new)`, selectedSet.has(p.id), { accent: true }),
+            )}
+
+            {hasLibraryRowsBelow ? <Separator className="my-1" /> : null}
+
+            {systemGenres.length > 0 ? (
+              <>
+                {sectionHeader('System genres', { first: true })}
+                {systemGenres.map((g) => optionRow(g.id, g.name, selectedSet.has(g.id)))}
+              </>
+            ) : null}
+
+            {showSeparatorBeforeCustom ? <Separator className="my-1" /> : null}
+
+            {customGenres.length > 0 ? (
+              <>
+                {sectionHeader('Custom genres', {
+                  first: systemGenres.length === 0,
+                })}
+                {customGenres.map((g) => optionRow(g.id, g.name, selectedSet.has(g.id)))}
+              </>
+            ) : null}
+
+            {!isLoading && !hasLibraryRowsBelow && search.trim() && filteredPending.length === 0 ? (
+              <p className="text-muted-foreground px-2 py-3 text-center text-xs">
+                No genres match “{search.trim()}”.
+              </p>
+            ) : null}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </Field>
+  );
+}

--- a/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.releaseDate.test.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.releaseDate.test.tsx
@@ -42,6 +42,7 @@ const baseForm: LibraryAlbumFromFilesFormData = {
   description: '',
   type: 'album',
   artistId: 'a1',
+  genreIds: [],
   /** Null so the trigger shows “Pick a date” (formatted dates change the accessible name). */
   releaseDate: null,
 };
@@ -52,11 +53,33 @@ describe('LibraryAlbumMetadataSection (release date branch)', () => {
   const onClearStagedArtist = vi.fn();
   const onManualCoverFile = vi.fn();
   const onRemoveCover = vi.fn();
+  const onGenreSelectionChange = vi.fn();
+  const onRemoveGenreId = vi.fn();
 
   const artistOptions = [
     { value: '__create_new_artist__', label: '+ Create new artist…' },
     { value: 'a1', label: 'Alpha' },
   ];
+
+  const testGenre = {
+    id: 'g1',
+    name: 'Rock',
+    slug: 'rock',
+    description: null,
+    kind: 'system' as const,
+    libraryId: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deletedAt: null,
+  };
+
+  const genrePropsFor = () => ({
+    genres: [testGenre],
+    pendingGenres: [] as { id: string; name: string }[],
+    isLoadingGenres: false,
+    onGenreSelectionChange,
+    onRemoveGenreId,
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -79,6 +102,7 @@ describe('LibraryAlbumMetadataSection (release date branch)', () => {
           onClearStagedArtist={onClearStagedArtist}
           onManualCoverFile={onManualCoverFile}
           onRemoveCover={onRemoveCover}
+          {...genrePropsFor()}
           {...overrides}
         />
       </TooltipProvider>,

--- a/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.test.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.test.tsx
@@ -36,6 +36,7 @@ const baseForm: LibraryAlbumFromFilesFormData = {
   description: '',
   type: 'album',
   artistId: 'a1',
+  genreIds: [],
   releaseDate: null,
 };
 
@@ -45,6 +46,36 @@ describe('LibraryAlbumMetadataSection', () => {
   const onClearStagedArtist = vi.fn();
   const onManualCoverFile = vi.fn();
   const onRemoveCover = vi.fn();
+
+  const onGenreSelectionChange = vi.fn();
+  const onRemoveGenreId = vi.fn();
+
+  const testGenre = {
+    id: 'g1',
+    name: 'Rock',
+    slug: 'rock',
+    description: null,
+    kind: 'system' as const,
+    libraryId: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    deletedAt: null,
+  };
+
+  const genrePropsFor = (
+    overrides?: Partial<{
+      genres: (typeof testGenre)[];
+      pendingGenres: { id: string; name: string }[];
+      isLoadingGenres: boolean;
+    }>,
+  ) => ({
+    genres: [testGenre],
+    pendingGenres: [] as { id: string; name: string }[],
+    isLoadingGenres: false,
+    onGenreSelectionChange,
+    onRemoveGenreId,
+    ...overrides,
+  });
 
   const artistOptions = [
     { value: '__create_new_artist__', label: '+ Create new artist…' },
@@ -69,6 +100,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -93,11 +125,76 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
     expect(screen.getByLabelText(/album title/i)).toHaveValue('Test album');
     expect(screen.getByText(/album details/i)).toBeInTheDocument();
+  });
+
+  it('opens genre picker, filters by search, and selects a genre', async () => {
+    const user = userEvent.setup();
+    const customGenre = {
+      id: 'g2',
+      name: 'Ambient',
+      slug: 'ambient',
+      description: null,
+      kind: 'custom' as const,
+      libraryId: 'lib-1',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    renderWithTooltip(
+      <LibraryAlbumMetadataSection
+        formData={baseForm}
+        artists={[{ id: 'a1', name: 'Alpha' }]}
+        artistSelectOptions={artistOptions}
+        isLoadingArtists={false}
+        isStagedNewArtistSelected={false}
+        coverPreviewUrl={null}
+        onUpdate={onUpdate}
+        onArtistIdChange={onArtistIdChange}
+        onClearStagedArtist={onClearStagedArtist}
+        onManualCoverFile={onManualCoverFile}
+        onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
+        genres={[testGenre, customGenre]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /genres \(optional\)/i }));
+    expect(await screen.findByRole('option', { name: /create new genre/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^no genres$/i })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/search genres/i), 'ambi');
+    expect(screen.queryByRole('option', { name: /^rock$/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('option', { name: /^ambient$/i }));
+    expect(onGenreSelectionChange).toHaveBeenCalledWith('g2');
+  });
+
+  it('removes a selected genre via chip', async () => {
+    const user = userEvent.setup();
+    renderWithTooltip(
+      <LibraryAlbumMetadataSection
+        formData={{ ...baseForm, genreIds: ['g1'] }}
+        artists={[{ id: 'a1', name: 'Alpha' }]}
+        artistSelectOptions={artistOptions}
+        isLoadingArtists={false}
+        isStagedNewArtistSelected={false}
+        coverPreviewUrl={null}
+        onUpdate={onUpdate}
+        onArtistIdChange={onArtistIdChange}
+        onClearStagedArtist={onClearStagedArtist}
+        onManualCoverFile={onManualCoverFile}
+        onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/remove rock/i));
+    expect(onRemoveGenreId).toHaveBeenCalledWith('g1');
   });
 
   it('shows staged-artist readonly row with clear action', async () => {
@@ -115,6 +212,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -138,6 +236,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -159,6 +258,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -188,6 +288,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -218,6 +319,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -249,6 +351,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -272,6 +375,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -304,6 +408,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -327,6 +432,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -356,6 +462,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -376,6 +483,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -397,6 +505,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -417,6 +526,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -437,6 +547,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -460,6 +571,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -481,6 +593,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -502,6 +615,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -527,6 +641,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -551,6 +666,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -574,6 +690,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -599,6 +716,7 @@ describe('LibraryAlbumMetadataSection', () => {
           onClearStagedArtist={onClearStagedArtist}
           onManualCoverFile={onManualCoverFile}
           onRemoveCover={onRemoveCover}
+          {...genrePropsFor()}
         />
       </TooltipProvider>,
     );
@@ -630,6 +748,7 @@ describe('LibraryAlbumMetadataSection', () => {
           onClearStagedArtist={onClearStagedArtist}
           onManualCoverFile={onManualCoverFile}
           onRemoveCover={onRemoveCover}
+          {...genrePropsFor()}
         />
       </TooltipProvider>,
     );
@@ -651,6 +770,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -683,6 +803,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -707,6 +828,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 
@@ -728,6 +850,7 @@ describe('LibraryAlbumMetadataSection', () => {
         onClearStagedArtist={onClearStagedArtist}
         onManualCoverFile={onManualCoverFile}
         onRemoveCover={onRemoveCover}
+        {...genrePropsFor()}
       />,
     );
 

--- a/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.tsx
+++ b/apps/web/src/components/library/albums/create/LibraryAlbumMetadataSection.tsx
@@ -20,10 +20,13 @@ import {
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import type { ZodGenreInfer } from '@repo/contracts';
 import { AlbumType } from '@repo/db';
 import { Link } from '@tanstack/react-router';
 import { CameraIcon, MusicNotesIcon, TrashIcon, XIcon } from '@phosphor-icons/react';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { LibraryAlbumGenrePicker } from './LibraryAlbumGenrePicker';
+import { isLocalPendingGenreId } from './pendingLibraryGenre';
 import type { LibraryAlbumFromFilesFormData } from './useLibraryAlbumFromFilesForm';
 
 const albumTypeOptions = Object.entries(AlbumType).map(([key, value]) => ({
@@ -53,6 +56,12 @@ interface LibraryAlbumMetadataSectionProps {
   onManualCoverFile: (file: File | null) => void;
   /** Clears manual file if set, otherwise clears embedded cover selection */
   onRemoveCover: () => void;
+  /** Genres from the library (system + custom), for empty-state copy and picker. */
+  genres: ZodGenreInfer[];
+  pendingGenres: { id: string; name: string }[];
+  isLoadingGenres: boolean;
+  onGenreSelectionChange: (value: string) => void;
+  onRemoveGenreId: (genreId: string) => void;
 }
 
 export function LibraryAlbumMetadataSection({
@@ -67,6 +76,11 @@ export function LibraryAlbumMetadataSection({
   onClearStagedArtist,
   onManualCoverFile,
   onRemoveCover,
+  genres,
+  pendingGenres,
+  isLoadingGenres,
+  onGenreSelectionChange,
+  onRemoveGenreId,
 }: LibraryAlbumMetadataSectionProps) {
   const artistFieldId = useId();
   const coverInputRef = useRef<HTMLInputElement>(null);
@@ -127,6 +141,17 @@ export function LibraryAlbumMetadataSection({
     e.preventDefault();
     e.stopPropagation();
   }, []);
+
+  const genreIdsForChips = useMemo(
+    () =>
+      [...formData.genreIds].sort((a, b) => {
+        const aNew = isLocalPendingGenreId(a);
+        const bNew = isLocalPendingGenreId(b);
+        if (aNew === bNew) return 0;
+        return aNew ? -1 : 1;
+      }),
+    [formData.genreIds],
+  );
 
   return (
     <div className="flex flex-col gap-6 overflow-visible lg:max-h-full lg:min-h-0 lg:flex-1">
@@ -358,6 +383,46 @@ export function LibraryAlbumMetadataSection({
               .
             </p>
           )}
+        </div>
+
+        <div className="space-y-2">
+          <LibraryAlbumGenrePicker
+            selectedGenreIds={formData.genreIds}
+            genres={genres}
+            pendingGenres={pendingGenres}
+            isLoading={isLoadingGenres}
+            disabled={isLoadingGenres}
+            nonePlaceholder={genres.length === 0 ? 'No genres or create new' : 'No genres'}
+            onSelect={onGenreSelectionChange}
+          />
+          {formData.genreIds.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {genreIdsForChips.map((gid) => {
+                const pending = pendingGenres.find((p) => p.id === gid);
+                const g = genres.find((x) => x.id === gid);
+                const label = pending ? `${pending.name} (new)` : (g?.name ?? gid);
+                const isNewGenre = isLocalPendingGenreId(gid);
+                return (
+                  <Button
+                    key={gid}
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    className={cn(
+                      'h-7 gap-1 pr-1 pl-2 text-xs font-normal',
+                      isNewGenre &&
+                        'border border-emerald-600/45 bg-emerald-500/15 text-emerald-950 hover:bg-emerald-500/25 dark:border-emerald-500/40 dark:bg-emerald-950/55 dark:text-emerald-100 dark:hover:bg-emerald-900/45',
+                    )}
+                    onClick={() => onRemoveGenreId(gid)}
+                    aria-label={`Remove ${label}`}
+                  >
+                    <span className="max-w-[10rem] truncate">{label}</span>
+                    <XIcon className="size-3.5 shrink-0 opacity-70" />
+                  </Button>
+                );
+              })}
+            </div>
+          ) : null}
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/src/components/library/albums/create/libraryAlbumGenreConstants.ts
+++ b/apps/web/src/components/library/albums/create/libraryAlbumGenreConstants.ts
@@ -1,0 +1,5 @@
+/** Clears genre selection (optional field). */
+export const LIBRARY_ALBUM_GENRE_NONE_VALUE = '__no_genre__';
+
+/** Opens “create genre” modal; not a stored id. */
+export const LIBRARY_ALBUM_GENRE_CREATE_VALUE = '__create_new_genre__';

--- a/apps/web/src/components/library/albums/create/pendingLibraryGenre.ts
+++ b/apps/web/src/components/library/albums/create/pendingLibraryGenre.ts
@@ -1,0 +1,7 @@
+export function makeLocalPendingGenreId(): string {
+  return `local:pending:${crypto.randomUUID()}`;
+}
+
+export function isLocalPendingGenreId(id: string): boolean {
+  return id.startsWith('local:pending:');
+}

--- a/apps/web/src/components/library/albums/create/useLibraryAlbumFromFilesForm.test.ts
+++ b/apps/web/src/components/library/albums/create/useLibraryAlbumFromFilesForm.test.ts
@@ -49,6 +49,7 @@ describe('useLibraryAlbumFromFilesForm', () => {
         description: '',
         type: 'album',
         artistId: '',
+        genreIds: [],
         releaseDate: null,
       });
       expect(result.current.suggestedArtistName).toBeNull();
@@ -434,6 +435,11 @@ describe('useLibraryAlbumFromFilesForm', () => {
       act(() => {
         result.current.updateFormData('name', 'My Album');
         result.current.updateFormData('artistId', 'artist-123');
+      });
+
+      expect(result.current.isFormValid).toBe(true);
+
+      act(() => {
         result.current.addFiles(createFileList([createAudioFile('song.mp3')]));
       });
 

--- a/apps/web/src/components/library/albums/create/useLibraryAlbumFromFilesForm.ts
+++ b/apps/web/src/components/library/albums/create/useLibraryAlbumFromFilesForm.ts
@@ -15,6 +15,8 @@ export type LibraryAlbumFromFilesFormData = Pick<
   'name' | 'description' | 'type' | 'releaseDate'
 > & {
   artistId: string;
+  /** Selected genre ids (library genres and/or `local:pending:…` drafts). */
+  genreIds: string[];
 };
 
 const initialFormData: LibraryAlbumFromFilesFormData = {
@@ -22,6 +24,7 @@ const initialFormData: LibraryAlbumFromFilesFormData = {
   description: '',
   type: 'album',
   artistId: '',
+  genreIds: [],
   releaseDate: null,
 };
 
@@ -311,6 +314,7 @@ export function useLibraryAlbumFromFilesForm(options?: UseLibraryAlbumFromFilesF
     setFormData({
       ...initialFormData,
       artistId: options?.initialArtistId ?? '',
+      genreIds: [],
     });
     setManualAlbumCover(null);
   }, [clearTracks, options?.initialArtistId, setManualAlbumCover]);
@@ -324,6 +328,26 @@ export function useLibraryAlbumFromFilesForm(options?: UseLibraryAlbumFromFilesF
     },
     [],
   );
+
+  const toggleGenreId = useCallback((genreId: string) => {
+    setFormData((prev) => {
+      const cur = prev.genreIds;
+      if (cur.includes(genreId)) {
+        return { ...prev, genreIds: cur.filter((x) => x !== genreId) };
+      }
+      return { ...prev, genreIds: [...cur, genreId] };
+    });
+  }, []);
+
+  const clearGenreSelection = useCallback(() => {
+    setFormData((prev) => ({ ...prev, genreIds: [] }));
+  }, []);
+
+  const appendGenreId = useCallback((genreId: string) => {
+    setFormData((prev) =>
+      prev.genreIds.includes(genreId) ? prev : { ...prev, genreIds: [...prev.genreIds, genreId] },
+    );
+  }, []);
 
   const selectedCoverFile = useMemo(
     () =>
@@ -343,10 +367,7 @@ export function useLibraryAlbumFromFilesForm(options?: UseLibraryAlbumFromFilesF
   );
 
   const isFormValid =
-    formData.name.trim().length > 0 &&
-    formData.artistId.length > 0 &&
-    !hasInvalidTracks &&
-    tracks.length > 0;
+    formData.name.trim().length > 0 && formData.artistId.length > 0 && !hasInvalidTracks;
 
   return {
     formData,
@@ -370,6 +391,9 @@ export function useLibraryAlbumFromFilesForm(options?: UseLibraryAlbumFromFilesF
     clearTracks,
     clearAll,
     updateFormData,
+    toggleGenreId,
+    clearGenreSelection,
+    appendGenreId,
     isFormValid,
     pendingArtists,
     setPendingArtists,

--- a/apps/web/src/components/library/tracks/create/useCreateTrackForm.test.ts
+++ b/apps/web/src/components/library/tracks/create/useCreateTrackForm.test.ts
@@ -3,12 +3,14 @@ import {
   extractCoverFromAudioFile,
   extractMetadataFromAudioFile,
 } from '@/lib/audio/audio-metadata';
-import { albumBuilder, artistBuilder } from '@repo/testing/builders';
+import { albumBuilder, artistBuilder, imageBuilder } from '@repo/testing/builders';
 import { customRenderHook } from '@repo/testing/web';
 import { act, waitFor } from '@testing-library/react';
-import { ZodError } from 'zod';
+import { ZodError, z } from 'zod';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCreateTrackForm, validateWithZod } from './useCreateTrackForm';
+
+type SchemaType = z.infer<typeof CreateLibraryTrackRequestSchema>;
 
 vi.mock('@/lib/audio/audio-metadata', () => ({
   extractMetadataFromAudioFile: vi.fn().mockResolvedValue(null),
@@ -80,7 +82,9 @@ describe('useCreateTrackForm', () => {
     it('handles root-level validation errors (empty path)', () => {
       vi.mocked(CreateLibraryTrackRequestSchema.safeParse).mockReturnValueOnce({
         success: false,
-        error: new ZodError([{ path: [], message: 'Root error', code: 'custom' }]),
+        error: new ZodError([
+          { path: [], message: 'Root error', code: 'custom' },
+        ]) as ZodError<SchemaType>,
       });
 
       const errors = validateWithZod({
@@ -102,7 +106,7 @@ describe('useCreateTrackForm', () => {
         error: new ZodError([
           { path: ['title'], message: 'First error', code: 'custom' },
           { path: ['title'], message: 'Second error', code: 'custom' },
-        ]),
+        ]) as ZodError<SchemaType>,
       });
 
       const errors = validateWithZod({
@@ -663,7 +667,7 @@ describe('useCreateTrackForm', () => {
       vi.mocked(extractCoverFromAudioFile).mockResolvedValue(coverFile);
 
       // Case 1: Album already has a cover -> should NOT auto-use track cover
-      const albumWithCover = { ...mockAlbum, cover: { url: 'existing-url' } };
+      const albumWithCover = { ...mockAlbum, cover: imageBuilder({ url: 'existing-url' }) };
       const { result: result1 } = customRenderHook(() =>
         useCreateTrackForm({ album: albumWithCover, onSubmit: mockOnSubmit }),
       );
@@ -707,7 +711,7 @@ describe('useCreateTrackForm', () => {
       unmount();
 
       // The microtask will run but 'cancelled' will be true
-      await new Promise((resolve) => queueMicrotask(resolve));
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
 
       // No assertion needed other than it doesn't crash or update unmounted state (which Vitest would catch)
     });

--- a/apps/web/src/hooks/api/library-genres/requests/createLibraryGenre.ts
+++ b/apps/web/src/hooks/api/library-genres/requests/createLibraryGenre.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/lib/api-client';
+import type { CreateLibraryGenreRequest, CreateLibraryGenreResponse } from '@repo/contracts';
+import { CreateLibraryGenreResponseSchema } from '@repo/contracts';
+
+export const createLibraryGenre = (data: CreateLibraryGenreRequest) => {
+  return apiClient<CreateLibraryGenreResponse>('library/genres', {
+    method: 'POST',
+    body: data,
+    zodSchema: CreateLibraryGenreResponseSchema,
+  });
+};

--- a/apps/web/src/hooks/api/library-genres/requests/getLibraryGenres.ts
+++ b/apps/web/src/hooks/api/library-genres/requests/getLibraryGenres.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/lib/api-client';
+import type { GetLibraryGenresRequest, GetLibraryGenresResponse } from '@repo/contracts';
+import { GetLibraryGenresResponseSchema } from '@repo/contracts';
+
+export const getLibraryGenres = (params: GetLibraryGenresRequest) => {
+  const search = new URLSearchParams();
+  search.set('page', String(params.page ?? 1));
+  search.set('limit', String(params.limit ?? 20));
+  if (params.query != null && params.query !== '') {
+    search.set('query', params.query);
+  }
+  if (params.kind != null) {
+    search.set('kind', params.kind);
+  }
+  return apiClient<GetLibraryGenresResponse>(`library/genres?${search.toString()}`, {
+    method: 'GET',
+    zodSchema: GetLibraryGenresResponseSchema,
+  });
+};

--- a/apps/web/src/hooks/api/library-genres/useCreateLibraryGenre.ts
+++ b/apps/web/src/hooks/api/library-genres/useCreateLibraryGenre.ts
@@ -1,0 +1,19 @@
+import { ApiError } from '@/lib/api-error';
+import type { CreateLibraryGenreResponse } from '@repo/contracts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createLibraryGenre } from './requests/createLibraryGenre';
+
+export const useCreateLibraryGenre = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    CreateLibraryGenreResponse,
+    ApiError,
+    Parameters<typeof createLibraryGenre>[0]
+  >({
+    mutationFn: createLibraryGenre,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'genres'] });
+    },
+  });
+};

--- a/apps/web/src/hooks/api/library-genres/useLibraryGenres.ts
+++ b/apps/web/src/hooks/api/library-genres/useLibraryGenres.ts
@@ -1,0 +1,12 @@
+import type { GetLibraryGenresRequest, GetLibraryGenresResponse } from '@repo/contracts';
+import { useQuery } from '@tanstack/react-query';
+import { getLibraryGenres } from './requests/getLibraryGenres';
+
+export const useLibraryGenres = (params: GetLibraryGenresRequest) => {
+  const { page = 1, limit = 20, query, kind } = params;
+
+  return useQuery<GetLibraryGenresResponse, Error>({
+    queryKey: ['library', 'genres', page, limit, query ?? '', kind ?? ''],
+    queryFn: () => getLibraryGenres({ page, limit, query, kind }),
+  });
+};

--- a/apps/web/src/lib/genres/genreMatchKey.ts
+++ b/apps/web/src/lib/genres/genreMatchKey.ts
@@ -1,0 +1,13 @@
+/**
+ * Client-side match key for genre labels. Keep aligned with
+ * `apps/api/src/shared/genres/genre-normalization.service.ts` (`normalizeToMatchKey`).
+ */
+export function genreMatchKey(raw: string): string {
+  const collapsed = raw
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '')
+    .slice(0, 64);
+  return collapsed;
+}

--- a/apps/web/src/lib/library/albumDetailMeta.test.ts
+++ b/apps/web/src/lib/library/albumDetailMeta.test.ts
@@ -1,0 +1,80 @@
+import { AlbumType } from '@repo/db';
+import { describe, expect, it } from 'vitest';
+import {
+  albumTypeDisplayName,
+  buildGenreMiddleSegment,
+  formatAlbumReleaseDateSegment,
+  genreNamesFromAlbumGenres,
+} from './albumDetailMeta';
+
+describe('genreNamesFromAlbumGenres', () => {
+  it('returns empty for undefined or empty', () => {
+    expect(genreNamesFromAlbumGenres(undefined)).toEqual([]);
+    expect(genreNamesFromAlbumGenres([])).toEqual([]);
+  });
+
+  it('collects trimmed names in API order', () => {
+    expect(
+      genreNamesFromAlbumGenres([
+        { genre: { name: '  Rock  ' } },
+        { genre: null },
+        { genre: { name: 'Jazz' } },
+      ]),
+    ).toEqual(['Rock', 'Jazz']);
+  });
+});
+
+describe('buildGenreMiddleSegment', () => {
+  it('uses No Genre when empty', () => {
+    expect(buildGenreMiddleSegment([])).toEqual({
+      text: 'No Genre',
+      showTooltip: false,
+      tooltipLines: [],
+    });
+  });
+
+  it('uses single name when one genre', () => {
+    expect(buildGenreMiddleSegment(['Ambient'])).toEqual({
+      text: 'Ambient',
+      showTooltip: false,
+      tooltipLines: ['Ambient'],
+    });
+  });
+
+  it('summarizes two genres with singular more genre', () => {
+    expect(buildGenreMiddleSegment(['Rock', 'Jazz'])).toEqual({
+      text: 'Rock and 1 more genre',
+      showTooltip: true,
+      tooltipLines: ['Rock', 'Jazz'],
+    });
+  });
+
+  it('summarizes three+ genres with plural more genres', () => {
+    expect(buildGenreMiddleSegment(['Rock', 'Jazz', 'Blues'])).toEqual({
+      text: 'Rock and 2 more genres',
+      showTooltip: true,
+      tooltipLines: ['Rock', 'Jazz', 'Blues'],
+    });
+  });
+});
+
+describe('albumTypeDisplayName', () => {
+  it('capitalizes enum key like edit form', () => {
+    expect(albumTypeDisplayName(AlbumType.album)).toBe('Album');
+    expect(albumTypeDisplayName(AlbumType.ep)).toBe('Ep');
+    expect(albumTypeDisplayName(AlbumType.compilation)).toBe('Compilation');
+  });
+});
+
+describe('formatAlbumReleaseDateSegment', () => {
+  it('returns null for missing or invalid', () => {
+    expect(formatAlbumReleaseDateSegment(null)).toBeNull();
+    expect(formatAlbumReleaseDateSegment(undefined)).toBeNull();
+    expect(formatAlbumReleaseDateSegment('not-a-date')).toBeNull();
+  });
+
+  it('formats ISO strings', () => {
+    expect(formatAlbumReleaseDateSegment('2024-06-15T12:00:00.000Z')).toMatch(/Jun/);
+    expect(formatAlbumReleaseDateSegment('2024-06-15T12:00:00.000Z')).toMatch(/2024/);
+  });
+});

--- a/apps/web/src/lib/library/albumDetailMeta.ts
+++ b/apps/web/src/lib/library/albumDetailMeta.ts
@@ -1,0 +1,48 @@
+import { AlbumType } from '@repo/db';
+import { format, isValid } from 'date-fns';
+
+/** Album–genre join rows as returned on `Album.genres`. */
+export type AlbumGenreRow = {
+  genre?: { name?: string | null } | null;
+} | null;
+
+export function genreNamesFromAlbumGenres(genres: AlbumGenreRow[] | undefined): string[] {
+  if (!genres?.length) return [];
+  return genres.map((ag) => ag?.genre?.name?.trim()).filter((n): n is string => Boolean(n));
+}
+
+export function buildGenreMiddleSegment(names: string[]): {
+  text: string;
+  showTooltip: boolean;
+  tooltipLines: string[];
+} {
+  if (names.length === 0) {
+    return { text: 'No Genre', showTooltip: false, tooltipLines: [] };
+  }
+  if (names.length === 1) {
+    return { text: names[0]!, showTooltip: false, tooltipLines: names };
+  }
+  const more = names.length - 1;
+  const genreWord = more === 1 ? 'genre' : 'genres';
+  return {
+    text: `${names[0]} and ${more} more ${genreWord}`,
+    showTooltip: true,
+    tooltipLines: names,
+  };
+}
+
+/** Same label shape as album type options in `EditAlbumMetadata`. */
+export function albumTypeDisplayName(type: AlbumType): string {
+  const entry = Object.entries(AlbumType).find(([, v]) => v === type);
+  const key = entry?.[0] ?? 'album';
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+export function formatAlbumReleaseDateSegment(
+  releaseDate: Date | string | null | undefined,
+): string | null {
+  if (releaseDate == null) return null;
+  const d = releaseDate instanceof Date ? releaseDate : new Date(releaseDate);
+  if (!isValid(d)) return null;
+  return format(d, 'MMM d, yyyy');
+}

--- a/apps/web/src/routes/app/library/albums/$id/index.tsx
+++ b/apps/web/src/routes/app/library/albums/$id/index.tsx
@@ -17,10 +17,17 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { Spinner } from '@/components/ui/spinner';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useDeleteLibraryAlbum } from '@/hooks/api/library-albums/useDeleteLibraryAlbum';
 import { useLibraryAlbum } from '@/hooks/api/library-albums/useLibraryAlbum';
 import { useDeleteLibraryTrack } from '@/hooks/api/library-tracks/useDeleteLibraryTrack';
 import { zodTrackToPlaybackTrack } from '@/lib/playback/playback-mappers';
+import {
+  albumTypeDisplayName,
+  buildGenreMiddleSegment,
+  formatAlbumReleaseDateSegment,
+  genreNamesFromAlbumGenres,
+} from '@/lib/library/albumDetailMeta';
 import { usePlayerStore } from '@/stores/player-store/player.store';
 import {
   DiscIcon,
@@ -95,7 +102,32 @@ function RouteComponent() {
     );
   }
 
-  const releaseYear = album.releaseDate ? new Date(album.releaseDate).getFullYear() : null;
+  const genreNames = genreNamesFromAlbumGenres(album.genres);
+  const genreMiddle = buildGenreMiddleSegment(genreNames);
+  const dateSegment = formatAlbumReleaseDateSegment(album.releaseDate ?? undefined);
+  const typeLabel = albumTypeDisplayName(album.type);
+
+  const genreMiddleEl = genreMiddle.showTooltip ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="cursor-default underline decoration-dotted underline-offset-2"
+          aria-label={`Genres: ${genreMiddle.tooltipLines.join(', ')}`}
+        >
+          {genreMiddle.text}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs">
+        <div className="flex flex-col gap-1 text-left text-sm">
+          {genreMiddle.tooltipLines.map((line, i) => (
+            <span key={`${i}-${line}`}>{line}</span>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  ) : (
+    <span>{genreMiddle.text}</span>
+  );
 
   return (
     <div className="flex flex-col w-full min-h-full pb-8">
@@ -123,16 +155,20 @@ function RouteComponent() {
 
           {/* Quick Info */}
           <div className="flex-1 pb-2">
-            <div className="flex items-center gap-2 mb-1">
-              <p className="text-xs font-bold uppercase tracking-widest text-primary">
-                {album.type || 'Album'}
-              </p>
-              {releaseYear && (
+            <div className="mb-1 flex flex-wrap items-center gap-x-2 text-xs font-semibold">
+              <span className="text-primary tracking-widest uppercase">{typeLabel}</span>
+              <span className="text-stone-500" aria-hidden="true">
+                -
+              </span>
+              <span className="text-muted-foreground">{genreMiddleEl}</span>
+              {dateSegment ? (
                 <>
-                  <span className="text-stone-600 font-bold">•</span>
-                  <p className="text-xs font-bold text-muted-foreground uppercase">{releaseYear}</p>
+                  <span className="text-stone-500" aria-hidden="true">
+                    -
+                  </span>
+                  <span className="text-muted-foreground">{dateSegment}</span>
                 </>
-              )}
+              ) : null}
             </div>
             <h2 className="text-3xl font-bold text-white opacity-90 truncate max-w-2xl mb-1">
               {album.name}

--- a/apps/web/src/routes/app/library/albums/create.tsx
+++ b/apps/web/src/routes/app/library/albums/create.tsx
@@ -24,10 +24,11 @@ function RouteComponent() {
       <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-[1920px] flex-col gap-6 overflow-visible lg:flex-1 lg:min-h-0">
         <div className="flex shrink-0 flex-col gap-2">
           <Alert className="border-primary/20 bg-primary/5">
-            <AlertTitle className="text-primary">Create album with tracks</AlertTitle>
+            <AlertTitle className="text-primary">Create album</AlertTitle>
             <AlertDescription className="text-muted-foreground">
-              Fill in album details, then add audio files. Metadata and embedded artwork are read
-              automatically; you can edit everything before publishing.
+              Fill in album details and create whenever you are ready, or add audio files to import
+              tracks first. Metadata and embedded artwork are read automatically from files you add;
+              you can edit everything before publishing.
             </AlertDescription>
           </Alert>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
     environment:
       PORT: 8000
       DATABASE_URL: postgresql://${POSTGRES_USER:-playr}:${POSTGRES_PASSWORD:-playr}@db:5432/${POSTGRES_DB:-playr}?schema=public
+      # Used by packages/db prisma.config fallback URL if DATABASE_URL were unset; matches service name `db`.
+      POSTGRES_HOST: db
       S3_ENDPOINT: http://minio:${S3_PORT:-9000}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-minioadmin}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-minioadmin}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "turbo run test:coverage",
     "prisma:generate": "turbo run prisma:generate",
     "prisma:migrate": "turbo run prisma:migrate",
+    "prisma:reset": "turbo run prisma:reset",
     "prisma:push": "turbo run prisma:push",
     "prisma:studio": "turbo run prisma:studio"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "check-types": "tsc --noEmit",
     "prisma:generate": "prisma generate && pnpm build",
     "prisma:migrate": "prisma migrate dev",
+    "prisma:reset": "prisma migrate reset --force",
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio"
   },

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -13,8 +13,16 @@ const databaseUrlFromProcessEnv = process.env.DATABASE_URL;
 function loadEnvFiles(): void {
   const opts = { quiet: true } as const;
   dotenv.config({ path: join(repoRoot, ".env"), ...opts });
-  dotenv.config({ path: join(repoRoot, ".env.local"), override: true, ...opts });
-  dotenv.config({ path: join(repoRoot, "apps", "api", ".env"), override: true, ...opts });
+  dotenv.config({
+    path: join(repoRoot, ".env.local"),
+    override: true,
+    ...opts,
+  });
+  dotenv.config({
+    path: join(repoRoot, "apps", "api", ".env"),
+    override: true,
+    ...opts,
+  });
 }
 
 /**

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,6 +1,48 @@
 import dotenv from "dotenv";
-dotenv.config({ path: ".env" });
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "prisma/config";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+/** Monorepo root (`packages/db` → `packages` → repo root). */
+const repoRoot = join(__dirname, "..", "..");
+
+/** Present before this module runs when Docker Compose / CI / shell exports `DATABASE_URL`. */
+const databaseUrlFromProcessEnv = process.env.DATABASE_URL;
+
+function loadEnvFiles(): void {
+  const opts = { quiet: true } as const;
+  dotenv.config({ path: join(repoRoot, ".env"), ...opts });
+  dotenv.config({ path: join(repoRoot, ".env.local"), override: true, ...opts });
+  dotenv.config({ path: join(repoRoot, "apps", "api", ".env"), override: true, ...opts });
+}
+
+/**
+ * Default URL when `DATABASE_URL` is still unset after loading env files.
+ * - Host dev: `POSTGRES_HOST` defaults to `127.0.0.1` (maps to compose-published port).
+ * - In Docker: set `POSTGRES_HOST=db` (or inject a full `DATABASE_URL` with `@db`, which we preserve).
+ */
+function defaultDevDatabaseUrlFromEnv(): string {
+  const user = process.env.POSTGRES_USER ?? "playr";
+  const password = process.env.POSTGRES_PASSWORD ?? "playr";
+  const database = process.env.POSTGRES_DB ?? "playr";
+  const port = process.env.POSTGRES_PORT ?? "5432";
+  const host = process.env.POSTGRES_HOST ?? "127.0.0.1";
+  const u = encodeURIComponent(user);
+  const p = encodeURIComponent(password);
+  return `postgresql://${u}:${p}@${host}:${port}/${database}?schema=public`;
+}
+
+loadEnvFiles();
+
+// Do not let repo `.env` files replace DB URL that was already set (e.g. `...@db:5432` in Docker).
+if (databaseUrlFromProcessEnv) {
+  process.env.DATABASE_URL = databaseUrlFromProcessEnv;
+}
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = defaultDevDatabaseUrlFromEnv();
+}
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/turbo.json
+++ b/turbo.json
@@ -73,6 +73,9 @@
     "prisma:migrate": {
       "cache": false
     },
+    "prisma:reset": {
+      "cache": false
+    },
     "prisma:push": {
       "cache": false
     },


### PR DESCRIPTION
feat(packages/db): add example environment configuration and update database settings

- Introduced a new `.env.example` file to provide a template for environment variables used in the project.
- Updated `docker-compose.yml` to include a fallback `POSTGRES_HOST` for database connections.
- Added `prisma:reset` command to `package.json` for easier database management.
- Enhanced `prisma.config.ts` to load environment variables from multiple sources and set a default database URL if not provided.
- Adjusted test environment database URL to match the new configuration.

refactor(packages/db): improve environment variable loading in prisma.config.ts

- Enhanced the loadEnvFiles function for better readability by formatting dotenv.config calls with consistent indentation and structure.
- Maintained functionality for loading environment variables from multiple sources while improving code clarity.

feat(apps/web): add genre management functionality for albums

- Introduced constants for genre selection in `libraryAlbumGenreConstants.ts`.
- Implemented local pending genre ID generation in `pendingLibraryGenre.ts`.
- Added hooks for creating and fetching library genres in `useCreateLibraryGenre.ts` and `useLibraryGenres.ts`.
- Created request functions for API interactions in `createLibraryGenre.ts` and `getLibraryGenres.ts`.
- Developed a utility for genre matching in `genreMatchKey.ts`.
- Enhanced album detail metadata handling in `albumDetailMeta.ts` to support genre display and formatting.

feat(apps/web): implement genre selection and management in album creation

- Added `CreateLibraryGenreNameModal` for creating new genres.
- Integrated genre selection into `LibraryAlbumFromFilesForm` and `LibraryAlbumMetadataSection`.
- Introduced `LibraryAlbumGenrePicker` for selecting genres with search functionality.
- Updated state management to handle genre IDs, including local pending genres.
- Enhanced album detail display to include genre information in the album view.

feat(apps/web): integrate genre management into album creation tests

- Updated `LibraryAlbumFromFilesForm.test.tsx` to include genre selection and creation scenarios.
- Enhanced `LibraryAlbumMetadataSection.test.tsx` with genre selection and removal tests.
- Modified `useLibraryAlbumFromFilesForm.test.ts` to validate genre IDs in form data.
- Added new tests for genre-related functionalities in `albumDetailMeta.test.ts` to ensure proper genre handling and display.
- Improved overall test coverage for album creation and genre management features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-genre support in album creation: pick multiple genres, search, and create new genres inline.
  * Richer album detail metadata: improved genre display (with tooltip) and refined release date formatting.

* **Bug Fixes**
  * Modal state now reliably resets when closing (artist name modal).

* **Chores**
  * Added environment template and local DB defaults; introduced DB reset utilities and related scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hagrid862/playr/pull/135)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->