### PR TITLE
feat: add media session integration for local playback control

### DIFF
--- a/apps/web/src/components/app/player/use-player-audio.ts
+++ b/apps/web/src/components/app/player/use-player-audio.ts
@@ -1,4 +1,9 @@
+import {
+  isControllingLocalAudio,
+  isNoActivePlaybackDevice,
+} from '@/lib/playback/playback-active-device';
 import { getOrderedNextQueue } from '@/lib/playback/queue/playback-queue';
+import { usePlaybackMediaSession } from '@/lib/playback/media-session/usePlaybackMediaSession';
 import {
   emitCurrentTimeSync,
   firePlaybackCommand,
@@ -11,15 +16,12 @@ import { useEffect, useRef, useState } from 'react';
 
 const PLAYBACK_TIME_SYNC_INTERVAL_MS = 1500;
 
-const isNoActiveDevice = (value: string | null | undefined): boolean => {
-  return value == null || value === '';
-};
-
 /**
  * Hook to manage audio element synchronization with player store
  */
 export function usePlayerAudio() {
   const audioRef = useRef<HTMLAudioElement>(null);
+  usePlaybackMediaSession(audioRef);
   const timeToRestoreRef = useRef<number | null>(null);
   const lastTimeSyncAtRef = useRef<number>(0);
   const lastSyncedSecondRef = useRef<number | null>(null);
@@ -108,10 +110,11 @@ export function usePlayerAudio() {
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
-    const shouldOutputAudio =
-      !isPlaybackSyncConnected() ||
-      isNoActiveDevice(activeDeviceId) ||
-      activeDeviceId === localPlaybackDeviceId;
+    const shouldOutputAudio = isControllingLocalAudio({
+      isPlaybackSyncConnected: isPlaybackSyncConnected(),
+      activeDeviceId,
+      localPlaybackDeviceId,
+    });
 
     if (!isPlaying || !shouldOutputAudio) {
       audio.pause();
@@ -166,10 +169,11 @@ export function usePlayerAudio() {
 
   const handleTimeUpdate = () => {
     const audio = audioRef.current;
-    const shouldOutputAudio =
-      !isPlaybackSyncConnected() ||
-      isNoActiveDevice(activeDeviceId) ||
-      activeDeviceId === localPlaybackDeviceId;
+    const shouldOutputAudio = isControllingLocalAudio({
+      isPlaybackSyncConnected: isPlaybackSyncConnected(),
+      activeDeviceId,
+      localPlaybackDeviceId,
+    });
     if (!audio || !shouldOutputAudio) {
       return;
     }
@@ -181,7 +185,7 @@ export function usePlayerAudio() {
       !isPlaybackSyncConnected() ||
       !isPlaying ||
       !currentTrack ||
-      isNoActiveDevice(activeDeviceId) ||
+      isNoActivePlaybackDevice(activeDeviceId) ||
       activeDeviceId !== localPlaybackDeviceId ||
       playbackVersion === 0
     ) {

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
@@ -582,7 +582,7 @@ describe('usePlaybackMediaSession', () => {
     );
   });
 
-  it('uses playbackRate 0 when paused in position state', () => {
+  it('uses playbackRate 1 when paused in position state', () => {
     const audio = document.createElement('audio');
     Object.defineProperty(audio, 'duration', { value: 50, configurable: true });
     audio.currentTime = 10;
@@ -591,7 +591,7 @@ describe('usePlaybackMediaSession', () => {
     setPositionState!.mockClear();
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
     expect(setPositionState).toHaveBeenCalledWith(
-      expect.objectContaining({ playbackRate: 0, duration: 50, position: 10 }),
+      expect.objectContaining({ playbackRate: 1, duration: 50, position: 10 }),
     );
   });
 

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
@@ -1,8 +1,5 @@
 import { UNKNOWN_ARTIST_LABEL } from '@/lib/display-constants';
-import {
-  firePlaybackCommand,
-  isPlaybackSyncConnected,
-} from '@/lib/playback/sync/playback-sync';
+import { firePlaybackCommand, isPlaybackSyncConnected } from '@/lib/playback/sync/playback-sync';
 import type { PlayerState } from '@/stores/player-store/player.store';
 import { usePlayerStore } from '@/stores/player-store/player.store';
 import type { PlaybackTrack } from '@repo/contracts';
@@ -112,7 +109,10 @@ function installNavigatorMediaSession(opts?: {
       ...(opts?.omitSetPositionState ? {} : { setPositionState }),
     },
   });
-  return { setActionHandler, setPositionState: opts?.omitSetPositionState ? null : setPositionState };
+  return {
+    setActionHandler,
+    setPositionState: opts?.omitSetPositionState ? null : setPositionState,
+  };
 }
 
 function handlerFor(setActionHandler: ReturnType<typeof vi.fn>, action: string) {
@@ -205,9 +205,7 @@ describe('usePlaybackMediaSession', () => {
     const audioRef = { current: document.createElement('audio') };
     customRenderHook(() => usePlaybackMediaSession(audioRef));
 
-    const md = navigator.mediaSession.metadata as InstanceType<
-      typeof MediaMetadata
-    > | null;
+    const md = navigator.mediaSession.metadata as InstanceType<typeof MediaMetadata> | null;
     expect(md?.title).toBe('Song');
     expect(md?.artist).toBe('Artist A');
     expect(md?.album).toBe('Album');
@@ -283,10 +281,7 @@ describe('usePlaybackMediaSession', () => {
     getState.mockImplementation(() => state);
     customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
 
-    expect(errSpy).toHaveBeenCalledWith(
-      '[MediaSession] failed to set metadata',
-      expect.any(Error),
-    );
+    expect(errSpy).toHaveBeenCalledWith('[MediaSession] failed to set metadata', expect.any(Error));
     errSpy.mockRestore();
   });
 
@@ -338,7 +333,9 @@ describe('usePlaybackMediaSession', () => {
     act(() =>
       handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 5 } as MediaSessionActionDetails),
     );
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 12 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 12 } as MediaSessionActionDetails),
+    );
 
     expect(state.resume).not.toHaveBeenCalled();
     expect(state.pause).not.toHaveBeenCalled();
@@ -357,7 +354,10 @@ describe('usePlaybackMediaSession', () => {
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
 
     act(() =>
-      handlerFor(setActionHandler, 'seekbackward')?.({ seekOffset: 20 } as MediaSessionActionDetails),
+      handlerFor(
+        setActionHandler,
+        'seekbackward',
+      )?.({ seekOffset: 20 } as MediaSessionActionDetails),
     );
     expect(state.setCurrentTime).toHaveBeenCalledWith(30);
     expect(firePlaybackCommand).toHaveBeenCalled();
@@ -366,7 +366,10 @@ describe('usePlaybackMediaSession', () => {
     vi.mocked(state.setCurrentTime).mockClear();
 
     act(() =>
-      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 15 } as MediaSessionActionDetails),
+      handlerFor(
+        setActionHandler,
+        'seekforward',
+      )?.({ seekOffset: 15 } as MediaSessionActionDetails),
     );
     expect(state.setCurrentTime).toHaveBeenCalledWith(45);
     expect(firePlaybackCommand).toHaveBeenCalled();
@@ -393,7 +396,10 @@ describe('usePlaybackMediaSession', () => {
     getState.mockImplementation(() => state);
     customRenderHook(() => usePlaybackMediaSession({ current: null }));
     act(() =>
-      handlerFor(setActionHandler, 'seekbackward')?.({ seekOffset: 10 } as MediaSessionActionDetails),
+      handlerFor(
+        setActionHandler,
+        'seekbackward',
+      )?.({ seekOffset: 10 } as MediaSessionActionDetails),
     );
     expect(state.setCurrentTime).toHaveBeenCalledWith(30);
   });
@@ -428,7 +434,10 @@ describe('usePlaybackMediaSession', () => {
     vi.mocked(state.setCurrentTime).mockClear();
     act(() => handlerFor(setActionHandler, 'seekto')?.({} as MediaSessionActionDetails));
     act(() =>
-      handlerFor(setActionHandler, 'seekto')?.({ seekTime: Number.NaN } as MediaSessionActionDetails),
+      handlerFor(
+        setActionHandler,
+        'seekto',
+      )?.({ seekTime: Number.NaN } as MediaSessionActionDetails),
     );
     expect(state.setCurrentTime).not.toHaveBeenCalled();
   });
@@ -440,7 +449,9 @@ describe('usePlaybackMediaSession', () => {
     Object.defineProperty(audio, 'duration', { value: 200, configurable: true });
 
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(42);
     expect(audio.currentTime).toBe(42);
   });
@@ -456,7 +467,9 @@ describe('usePlaybackMediaSession', () => {
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
     vi.mocked(firePlaybackCommand).mockClear();
 
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 100 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 100 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(80);
     expect(firePlaybackCommand).not.toHaveBeenCalled();
   });
@@ -468,7 +481,9 @@ describe('usePlaybackMediaSession', () => {
     Object.defineProperty(audio, 'duration', { value: 55, configurable: true });
 
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(55);
   });
 
@@ -479,7 +494,9 @@ describe('usePlaybackMediaSession', () => {
     Object.defineProperty(audio, 'duration', { value: 60, configurable: true });
 
     customRenderHook(() => usePlaybackMediaSession({ current: audio }));
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(60);
   });
 
@@ -493,7 +510,9 @@ describe('usePlaybackMediaSession', () => {
     vi.mocked(isPlaybackSyncConnected).mockReturnValue(true);
 
     customRenderHook(() => usePlaybackMediaSession({ current: null }));
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(42);
   });
 
@@ -502,7 +521,9 @@ describe('usePlaybackMediaSession', () => {
     getState.mockImplementation(() => state);
     customRenderHook(() => usePlaybackMediaSession({ current: null }));
 
-    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 40 } as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: 40 } as MediaSessionActionDetails),
+    );
     expect(state.setCurrentTime).toHaveBeenCalledWith(40);
   });
 
@@ -635,7 +656,9 @@ describe('usePlaybackMediaSession', () => {
     const state = minimalPlayerState({ duration: 100, currentTime: 50 });
     getState.mockImplementation(() => state);
     const { mediaSession } = navigator;
-    const ms = mediaSession as MediaSession & { setPositionState?: typeof mediaSession.setPositionState };
+    const ms = mediaSession as MediaSession & {
+      setPositionState?: typeof mediaSession.setPositionState;
+    };
     const saved = ms.setPositionState;
     // @ts-expect-error remove for flushPositionState inner guard
     delete ms.setPositionState;

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.test.ts
@@ -1,0 +1,737 @@
+import { UNKNOWN_ARTIST_LABEL } from '@/lib/display-constants';
+import {
+  firePlaybackCommand,
+  isPlaybackSyncConnected,
+} from '@/lib/playback/sync/playback-sync';
+import type { PlayerState } from '@/stores/player-store/player.store';
+import { usePlayerStore } from '@/stores/player-store/player.store';
+import type { PlaybackTrack } from '@repo/contracts';
+import { customRenderHook } from '@repo/testing/web';
+import { act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolvePlaybackArtworkUrl, usePlaybackMediaSession } from './usePlaybackMediaSession';
+
+const { getState } = vi.hoisted(() => ({
+  getState: vi.fn(),
+}));
+
+vi.mock('@/stores/player-store/player.store', () => ({
+  usePlayerStore: Object.assign(vi.fn(), {
+    getState,
+    subscribe: vi.fn(() => vi.fn()),
+  }),
+}));
+
+vi.mock('@/lib/playback/sync/playback-sync', () => ({
+  emitCurrentTimeSync: vi.fn((t: number) => ({ kind: 'emitCurrentTimeSync', t })),
+  firePlaybackCommand: vi.fn(),
+  isPlaybackSyncConnected: vi.fn(),
+}));
+
+function playbackTrack(overrides: Partial<PlaybackTrack> = {}): PlaybackTrack {
+  return {
+    id: 'p1',
+    title: 'Song',
+    trackId: 't1',
+    artists: ['Artist A'],
+    albumName: 'Album',
+    albumId: 'al1',
+    albumArt: 'https://cdn.example/cover.jpg',
+    duration: 180,
+    explicit: false,
+    ...overrides,
+  };
+}
+
+function minimalPlayerState(overrides: Partial<PlayerState> = {}): PlayerState {
+  const track = playbackTrack();
+  return {
+    currentTrack: track,
+    isPlaying: true,
+    volume: 1,
+    currentTime: 0,
+    duration: track.duration,
+    quality: 'auto',
+    availableQualities: ['auto'],
+    queue: [],
+    originalQueue: [],
+    history: [],
+    repeatMode: 'off',
+    isShuffled: false,
+    playbackVersion: 1,
+    playbackFavorited: 'not-set',
+    playbackInLibrary: false,
+    activeDeviceId: 'device-local',
+    localPlaybackDeviceId: 'device-local',
+    playbackDevices: [],
+    applyPlaybackStateFromServer: vi.fn(),
+    clearSessionPlayback: vi.fn(),
+    resetForLogout: vi.fn(),
+    setLocalPlaybackDeviceId: vi.fn(),
+    setPlaybackDevices: vi.fn(),
+    playTrack: vi.fn(),
+    playQueueItem: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    togglePlay: vi.fn(),
+    setVolume: vi.fn(),
+    setCurrentTime: vi.fn(),
+    setDuration: vi.fn(),
+    setQuality: vi.fn(),
+    setAvailableQualities: vi.fn(),
+    setQueue: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
+    toggleRepeatMode: vi.fn(),
+    toggleShuffle: vi.fn(),
+    addToQueue: vi.fn(),
+    playNext: vi.fn(),
+    removeFromQueue: vi.fn(),
+    reorderQueue: vi.fn(),
+    addToHistory: vi.fn(),
+    isQueueOpen: false,
+    sidebarView: 'queue',
+    toggleQueue: vi.fn(),
+    setQueueOpen: vi.fn(),
+    setSidebarView: vi.fn(),
+    ...overrides,
+  } as PlayerState;
+}
+
+function installNavigatorMediaSession(opts?: {
+  omitSetPositionState?: boolean;
+  setActionHandlerImpl?: typeof navigator.mediaSession.setActionHandler;
+}) {
+  const setActionHandler = vi.fn(opts?.setActionHandlerImpl ?? (() => {}));
+  const setPositionState = vi.fn();
+  Object.assign(navigator, {
+    mediaSession: {
+      metadata: null as MediaMetadata | null,
+      playbackState: 'none' as MediaSessionPlaybackState,
+      setActionHandler,
+      ...(opts?.omitSetPositionState ? {} : { setPositionState }),
+    },
+  });
+  return { setActionHandler, setPositionState: opts?.omitSetPositionState ? null : setPositionState };
+}
+
+function handlerFor(setActionHandler: ReturnType<typeof vi.fn>, action: string) {
+  return setActionHandler.mock.calls.find((c: unknown[]) => c[0] === action)?.[1] as
+    | ((details?: MediaSessionActionDetails) => void)
+    | undefined;
+}
+
+describe('resolvePlaybackArtworkUrl', () => {
+  it('returns null for empty input', () => {
+    expect(resolvePlaybackArtworkUrl(null)).toBe(null);
+    expect(resolvePlaybackArtworkUrl('')).toBe(null);
+    expect(resolvePlaybackArtworkUrl('   ')).toBe(null);
+  });
+
+  it('returns absolute http(s) URLs unchanged', () => {
+    expect(resolvePlaybackArtworkUrl('https://x/c.jpg')).toBe('https://x/c.jpg');
+    expect(resolvePlaybackArtworkUrl('http://x/c.jpg')).toBe('http://x/c.jpg');
+  });
+
+  it('resolves relative paths against window.location.origin', () => {
+    expect(resolvePlaybackArtworkUrl('/covers/a.png')).toBe(
+      `${window.location.origin}/covers/a.png`,
+    );
+  });
+
+  it('returns null when URL resolution throws', () => {
+    const OriginalURL = globalThis.URL;
+    vi.spyOn(globalThis, 'URL').mockImplementationOnce(function MockUrl(
+      input: string | URL,
+      base?: string | URL,
+    ) {
+      if (input === 'relative/art.png') throw new TypeError('bad');
+      return new OriginalURL(input, base);
+    });
+    expect(resolvePlaybackArtworkUrl('relative/art.png')).toBe(null);
+    vi.mocked(URL).mockRestore();
+  });
+
+  it('returns null when window is undefined', () => {
+    const w = globalThis.window;
+    vi.stubGlobal('window', undefined);
+    expect(resolvePlaybackArtworkUrl('/x')).toBe(null);
+    vi.stubGlobal('window', w);
+  });
+});
+
+describe('usePlaybackMediaSession', () => {
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let setPositionState: ReturnType<typeof vi.fn> | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'MediaMetadata',
+      class {
+        title = '';
+        artist = '';
+        album = '';
+        artwork: MediaImage[] = [];
+        constructor(init: MediaMetadataInit) {
+          this.title = init.title ?? '';
+          this.artist = init.artist ?? '';
+          this.album = init.album ?? '';
+          this.artwork = init.artwork ?? [];
+        }
+      },
+    );
+
+    const nav = installNavigatorMediaSession();
+    setActionHandler = nav.setActionHandler;
+    setPositionState = nav.setPositionState;
+
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    vi.mocked(usePlayerStore).mockImplementation((selector: (s: PlayerState) => unknown) =>
+      selector(getState() as PlayerState),
+    );
+    vi.mocked(isPlaybackSyncConnected).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets metadata and action handlers when this device controls playback', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+
+    const audioRef = { current: document.createElement('audio') };
+    customRenderHook(() => usePlaybackMediaSession(audioRef));
+
+    const md = navigator.mediaSession.metadata as InstanceType<
+      typeof MediaMetadata
+    > | null;
+    expect(md?.title).toBe('Song');
+    expect(md?.artist).toBe('Artist A');
+    expect(md?.album).toBe('Album');
+    expect(md?.artwork?.[0]?.src).toBe('https://cdn.example/cover.jpg');
+
+    expect(setActionHandler).toHaveBeenCalledWith('play', expect.any(Function));
+    expect(setActionHandler).toHaveBeenCalledWith('pause', expect.any(Function));
+    expect(setActionHandler).toHaveBeenCalledWith('nexttrack', expect.any(Function));
+    expect(setPositionState).toHaveBeenCalled();
+  });
+
+  it('uses unknown artist label when artists array is empty and omits artwork when albumArt is null', () => {
+    const state = minimalPlayerState({
+      currentTrack: playbackTrack({ artists: [], albumArt: null }),
+    });
+    getState.mockImplementation(() => state);
+
+    const audioRef = { current: document.createElement('audio') };
+    customRenderHook(() => usePlaybackMediaSession(audioRef));
+
+    const md = navigator.mediaSession.metadata as { artist: string; artwork: MediaImage[] } | null;
+    expect(md?.artist).toBe(UNKNOWN_ARTIST_LABEL);
+    expect(md?.artwork).toEqual([]);
+  });
+
+  it('clears presentation when another device is active', () => {
+    const state = minimalPlayerState({
+      activeDeviceId: 'remote-device',
+      localPlaybackDeviceId: 'local-device',
+    });
+    getState.mockImplementation(() => state);
+
+    const audioRef = { current: document.createElement('audio') };
+    const { rerender } = customRenderHook(() => usePlaybackMediaSession(audioRef));
+
+    expect(navigator.mediaSession.metadata).toBe(null);
+    expect(navigator.mediaSession.playbackState).toBe('none');
+
+    act(() => {
+      state.activeDeviceId = 'local-device';
+      state.localPlaybackDeviceId = 'local-device';
+      rerender();
+    });
+
+    expect(navigator.mediaSession.metadata).not.toBe(null);
+  });
+
+  it('invokes resume when play action fires while controlling', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+
+    const audioRef = { current: document.createElement('audio') };
+    customRenderHook(() => usePlaybackMediaSession(audioRef));
+
+    const playHandler = handlerFor(setActionHandler, 'play');
+    expect(playHandler).toBeTypeOf('function');
+    act(() => playHandler?.());
+    expect(state.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs when setting metadata throws', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal(
+      'MediaMetadata',
+      class {
+        constructor() {
+          throw new Error('metadata fail');
+        }
+      },
+    );
+
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      '[MediaSession] failed to set metadata',
+      expect.any(Error),
+    );
+    errSpy.mockRestore();
+  });
+
+  it('invokes pause, stop, previousTrack, and nextTrack handlers when controlling', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    act(() => handlerFor(setActionHandler, 'pause')?.());
+    act(() => handlerFor(setActionHandler, 'stop')?.());
+    act(() => handlerFor(setActionHandler, 'previoustrack')?.());
+    act(() => handlerFor(setActionHandler, 'nexttrack')?.());
+
+    expect(state.pause).toHaveBeenCalledTimes(2);
+    expect(state.previousTrack).toHaveBeenCalledTimes(1);
+    expect(state.nextTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops action handlers when no longer controlling', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    act(() => {
+      state.activeDeviceId = 'remote';
+      state.localPlaybackDeviceId = 'local';
+    });
+
+    act(() => handlerFor(setActionHandler, 'pause')?.());
+    expect(state.pause).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits every media action handler when not controlling', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    act(() => {
+      state.activeDeviceId = 'remote';
+      state.localPlaybackDeviceId = 'local';
+    });
+
+    act(() => handlerFor(setActionHandler, 'play')?.());
+    act(() => handlerFor(setActionHandler, 'pause')?.());
+    act(() => handlerFor(setActionHandler, 'stop')?.());
+    act(() => handlerFor(setActionHandler, 'previoustrack')?.());
+    act(() => handlerFor(setActionHandler, 'nexttrack')?.());
+    act(() => handlerFor(setActionHandler, 'seekbackward')?.());
+    act(() =>
+      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 5 } as MediaSessionActionDetails),
+    );
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 12 } as MediaSessionActionDetails));
+
+    expect(state.resume).not.toHaveBeenCalled();
+    expect(state.pause).not.toHaveBeenCalled();
+    expect(state.previousTrack).not.toHaveBeenCalled();
+    expect(state.nextTrack).not.toHaveBeenCalled();
+    expect(state.setCurrentTime).not.toHaveBeenCalled();
+  });
+
+  it('seekbackward and seekforward use seekOffset and commit seek with sync', async () => {
+    const state = minimalPlayerState({ currentTime: 50, duration: 100 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 100, configurable: true });
+    audio.currentTime = 50;
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+
+    act(() =>
+      handlerFor(setActionHandler, 'seekbackward')?.({ seekOffset: 20 } as MediaSessionActionDetails),
+    );
+    expect(state.setCurrentTime).toHaveBeenCalledWith(30);
+    expect(firePlaybackCommand).toHaveBeenCalled();
+
+    vi.mocked(firePlaybackCommand).mockClear();
+    vi.mocked(state.setCurrentTime).mockClear();
+
+    act(() =>
+      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 15 } as MediaSessionActionDetails),
+    );
+    expect(state.setCurrentTime).toHaveBeenCalledWith(45);
+    expect(firePlaybackCommand).toHaveBeenCalled();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it('seekbackward uses default offset when seekOffset is missing', () => {
+    const state = minimalPlayerState({ currentTime: 25, duration: 100 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 100, configurable: true });
+    audio.currentTime = 25;
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    act(() => handlerFor(setActionHandler, 'seekbackward')?.());
+    expect(state.setCurrentTime).toHaveBeenCalledWith(15);
+  });
+
+  it('seekbackward uses store currentTime when audio element is absent', () => {
+    const state = minimalPlayerState({ currentTime: 40, duration: 100 });
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: null }));
+    act(() =>
+      handlerFor(setActionHandler, 'seekbackward')?.({ seekOffset: 10 } as MediaSessionActionDetails),
+    );
+    expect(state.setCurrentTime).toHaveBeenCalledWith(30);
+  });
+
+  it('seekforward uses store currentTime when audio ref is null', () => {
+    const state = minimalPlayerState({ currentTime: 15, duration: 100 });
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: null }));
+    act(() =>
+      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 5 } as MediaSessionActionDetails),
+    );
+    expect(state.setCurrentTime).toHaveBeenCalledWith(20);
+  });
+
+  it('seekforward uses default seek offset when details omit seekOffset', () => {
+    const state = minimalPlayerState({ currentTime: 20, duration: 100 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 100, configurable: true });
+    audio.currentTime = 20;
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    act(() => handlerFor(setActionHandler, 'seekforward')?.());
+    expect(state.setCurrentTime).toHaveBeenCalledWith(30);
+  });
+
+  it('seekto no-ops when seekTime is null or not finite', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    vi.mocked(state.setCurrentTime).mockClear();
+    act(() => handlerFor(setActionHandler, 'seekto')?.({} as MediaSessionActionDetails));
+    act(() =>
+      handlerFor(setActionHandler, 'seekto')?.({ seekTime: Number.NaN } as MediaSessionActionDetails),
+    );
+    expect(state.setCurrentTime).not.toHaveBeenCalled();
+  });
+
+  it('seekto commits when seekTime is valid', () => {
+    const state = minimalPlayerState({ duration: 200 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 200, configurable: true });
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(42);
+    expect(audio.currentTime).toBe(42);
+  });
+
+  it('commitSeek uses store duration first and skips firePlaybackCommand when playbackVersion is 0', () => {
+    vi.mocked(isPlaybackSyncConnected).mockReturnValue(true);
+    const state = minimalPlayerState({ playbackVersion: 0, duration: 80, currentTime: 0 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 999, configurable: true });
+    audio.currentTime = 0;
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    vi.mocked(firePlaybackCommand).mockClear();
+
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 100 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(80);
+    expect(firePlaybackCommand).not.toHaveBeenCalled();
+  });
+
+  it('commitSeek uses audio duration when store duration is NaN', () => {
+    const state = minimalPlayerState({ duration: Number.NaN, currentTime: 0 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 55, configurable: true });
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(55);
+  });
+
+  it('commitSeek uses audio duration when store duration is zero', () => {
+    const state = minimalPlayerState({ duration: 0, currentTime: 0 });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 60, configurable: true });
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 99 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(60);
+  });
+
+  it('commitSeek keeps seek time as max when store and audio duration are unusable', () => {
+    const state = minimalPlayerState({
+      duration: Number.NaN,
+      currentTime: 0,
+      playbackVersion: 0,
+    });
+    getState.mockImplementation(() => state);
+    vi.mocked(isPlaybackSyncConnected).mockReturnValue(true);
+
+    customRenderHook(() => usePlaybackMediaSession({ current: null }));
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 42 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(42);
+  });
+
+  it('commitSeek works without an audio element', () => {
+    const state = minimalPlayerState({ duration: 50, currentTime: 10 });
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: null }));
+
+    act(() => handlerFor(setActionHandler, 'seekto')?.({ seekTime: 40 } as MediaSessionActionDetails));
+    expect(state.setCurrentTime).toHaveBeenCalledWith(40);
+  });
+
+  it('does not fire sync when disconnected', () => {
+    vi.mocked(isPlaybackSyncConnected).mockReturnValue(false);
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+
+    vi.mocked(firePlaybackCommand).mockClear();
+    act(() =>
+      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 5 } as MediaSessionActionDetails),
+    );
+    expect(firePlaybackCommand).not.toHaveBeenCalled();
+  });
+
+  it('sets playbackState to paused when not playing', () => {
+    const state = minimalPlayerState({ isPlaying: false });
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+    expect(navigator.mediaSession.playbackState).toBe('paused');
+  });
+
+  it('swallows setActionHandler errors for unsupported actions', () => {
+    setActionHandler.mockImplementation(() => {
+      throw new DOMException('not supported');
+    });
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    expect(() =>
+      customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') })),
+    ).not.toThrow();
+  });
+
+  it('clears position state when flush sees invalid duration', () => {
+    const state = minimalPlayerState({ duration: 0, isPlaying: true });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: NaN, configurable: true });
+
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    expect(setPositionState).toHaveBeenCalledWith(null);
+  });
+
+  it('uses audio duration for position state when store duration is zero', () => {
+    const state = minimalPlayerState({ duration: 0, currentTime: 0, isPlaying: true });
+    getState.mockImplementation(() => state);
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 100, configurable: true });
+    audio.currentTime = 33;
+
+    setPositionState!.mockClear();
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 100, position: 33, playbackRate: 1 }),
+    );
+  });
+
+  it('uses playbackRate 0 when paused in position state', () => {
+    const audio = document.createElement('audio');
+    Object.defineProperty(audio, 'duration', { value: 50, configurable: true });
+    audio.currentTime = 10;
+    const state = minimalPlayerState({ isPlaying: false, duration: 50, currentTime: 10 });
+    getState.mockImplementation(() => state);
+    setPositionState!.mockClear();
+    customRenderHook(() => usePlaybackMediaSession({ current: audio }));
+    expect(setPositionState).toHaveBeenCalledWith(
+      expect.objectContaining({ playbackRate: 0, duration: 50, position: 10 }),
+    );
+  });
+
+  it('swallows setPositionState errors when updating position', () => {
+    setPositionState!.mockImplementation(() => {
+      throw new Error('invalid');
+    });
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    expect(() =>
+      customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') })),
+    ).not.toThrow();
+  });
+
+  it('returns early when mediaSession is missing', () => {
+    const orig = navigator.mediaSession;
+    // @ts-expect-error test stub
+    delete navigator.mediaSession;
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+    Object.assign(navigator, { mediaSession: orig });
+  });
+
+  it('clearMediaSessionPresentation returns when navigator has no mediaSession', () => {
+    const origNav = globalThis.navigator;
+    vi.stubGlobal('navigator', { userAgent: 'vitest' } as Navigator);
+    const state = minimalPlayerState({ currentTrack: null });
+    getState.mockImplementation(() => state);
+    customRenderHook(() => usePlaybackMediaSession({ current: null }));
+    vi.stubGlobal('navigator', origNav);
+  });
+
+  it('clearMediaSessionPresentation returns when mediaSession is removed before viewer unmount', () => {
+    const state = minimalPlayerState({
+      activeDeviceId: 'remote',
+      localPlaybackDeviceId: 'local',
+    });
+    getState.mockImplementation(() => state);
+    const { unmount } = customRenderHook(() =>
+      usePlaybackMediaSession({ current: document.createElement('audio') }),
+    );
+    // @ts-expect-error test teardown path
+    delete navigator.mediaSession;
+    unmount();
+  });
+
+  it('clearMediaSessionPresentation returns when navigator is undefined on unmount', () => {
+    const state = minimalPlayerState({ currentTrack: null });
+    getState.mockImplementation(() => state);
+    const { unmount } = customRenderHook(() => usePlaybackMediaSession({ current: null }));
+    const orig = globalThis.navigator;
+    vi.stubGlobal('navigator', undefined);
+    try {
+      unmount();
+    } finally {
+      vi.stubGlobal('navigator', orig);
+    }
+  });
+
+  it('flushPositionState returns when setPositionState is missing (post-seek microtask)', async () => {
+    const state = minimalPlayerState({ duration: 100, currentTime: 50 });
+    getState.mockImplementation(() => state);
+    const { mediaSession } = navigator;
+    const ms = mediaSession as MediaSession & { setPositionState?: typeof mediaSession.setPositionState };
+    const saved = ms.setPositionState;
+    // @ts-expect-error remove for flushPositionState inner guard
+    delete ms.setPositionState;
+
+    customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') }));
+    act(() =>
+      handlerFor(setActionHandler, 'seekforward')?.({ seekOffset: 1 } as MediaSessionActionDetails),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    ms.setPositionState = saved;
+  });
+
+  it('returns early when setPositionState is not available', () => {
+    installNavigatorMediaSession({ omitSetPositionState: true });
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    expect(() =>
+      customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') })),
+    ).not.toThrow();
+  });
+
+  it('advances position interval while controlling and clears on unmount', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    const audioRef = { current: document.createElement('audio') };
+    const { unmount } = customRenderHook(() => usePlaybackMediaSession(audioRef));
+    const afterMount = setPositionState!.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(setPositionState!.mock.calls.length).toBeGreaterThan(afterMount);
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it('handles navigator undefined during position effect cleanup', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    const { unmount } = customRenderHook(() =>
+      usePlaybackMediaSession({ current: document.createElement('audio') }),
+    );
+    const orig = globalThis.navigator;
+    vi.stubGlobal('navigator', undefined);
+    try {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      unmount();
+    } finally {
+      vi.stubGlobal('navigator', orig);
+    }
+    vi.useRealTimers();
+  });
+
+  it('swallows clearPositionState when setPositionState throws on null', () => {
+    setPositionState!.mockImplementation(() => {
+      throw new DOMException('bad');
+    });
+    const state = minimalPlayerState({
+      activeDeviceId: 'remote',
+      localPlaybackDeviceId: 'local',
+    });
+    getState.mockImplementation(() => state);
+    expect(() =>
+      customRenderHook(() => usePlaybackMediaSession({ current: document.createElement('audio') })),
+    ).not.toThrow();
+  });
+
+  it('unmount clears action handlers with null', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    const { unmount } = customRenderHook(() =>
+      usePlaybackMediaSession({ current: document.createElement('audio') }),
+    );
+    setActionHandler.mockClear();
+    unmount();
+    expect(setActionHandler).toHaveBeenCalledWith('play', null);
+  });
+
+  it('metadata effect cleanup skips action handler clear when navigator is undefined', () => {
+    const state = minimalPlayerState();
+    getState.mockImplementation(() => state);
+    const { unmount } = customRenderHook(() =>
+      usePlaybackMediaSession({ current: document.createElement('audio') }),
+    );
+    const orig = globalThis.navigator;
+    vi.stubGlobal('navigator', undefined);
+    try {
+      unmount();
+    } finally {
+      vi.stubGlobal('navigator', orig);
+    }
+  });
+});

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
@@ -65,8 +65,7 @@ export function resolvePlaybackArtworkUrl(albumArt: string | null | undefined): 
 }
 
 function buildMediaMetadata(track: PlaybackTrack): MediaMetadata {
-  const artist =
-    track.artists.length > 0 ? track.artists.join(', ') : UNKNOWN_ARTIST_LABEL;
+  const artist = track.artists.length > 0 ? track.artists.join(', ') : UNKNOWN_ARTIST_LABEL;
   const artworkUrl = resolvePlaybackArtworkUrl(track.albumArt);
   const artwork: MediaImage[] = artworkUrl ? [{ src: artworkUrl }] : [];
   return new MediaMetadata({

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
@@ -148,7 +148,7 @@ function flushPositionState(audioRef: RefObject<HTMLAudioElement | null>): void 
     navigator.mediaSession.setPositionState({
       duration: dur,
       position: clamped,
-      playbackRate: s.isPlaying ? 1 : 0,
+      playbackRate: 1,
     });
   } catch {
     /* Chromium throws if duration/position invalid */

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
@@ -213,14 +213,16 @@ export function usePlaybackMediaSession(audioRef: RefObject<HTMLAudioElement | n
     trySetActionHandler('seekbackward', (details) => {
       if (!controllingNow()) return;
       const audio = audioRef.current;
-      const base = audio?.currentTime ?? usePlayerStore.getState().currentTime;
+      const fromAudio = audio?.currentTime;
+      const base = fromAudio ?? usePlayerStore.getState().currentTime;
       const offset = details?.seekOffset ?? DEFAULT_SEEK_SKIP_SEC;
       commitSeek(base - offset, audio, audioRef);
     });
     trySetActionHandler('seekforward', (details) => {
       if (!controllingNow()) return;
       const audio = audioRef.current;
-      const base = audio?.currentTime ?? usePlayerStore.getState().currentTime;
+      const fromAudio = audio?.currentTime;
+      const base = fromAudio ?? usePlayerStore.getState().currentTime;
       const offset = details?.seekOffset ?? DEFAULT_SEEK_SKIP_SEC;
       commitSeek(base + offset, audio, audioRef);
     });
@@ -263,7 +265,9 @@ export function usePlaybackMediaSession(audioRef: RefObject<HTMLAudioElement | n
     const id = window.setInterval(() => flushPositionState(audioRef), POSITION_STATE_INTERVAL_MS);
     return () => {
       window.clearInterval(id);
-      clearPositionState(navigator.mediaSession);
+      if (typeof navigator !== 'undefined' && 'mediaSession' in navigator) {
+        clearPositionState(navigator.mediaSession);
+      }
     };
   }, [audioRef, currentTrack, isControlling, isPlaying, duration]);
 }

--- a/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
+++ b/apps/web/src/lib/playback/media-session/usePlaybackMediaSession.ts
@@ -1,0 +1,269 @@
+import { UNKNOWN_ARTIST_LABEL } from '@/lib/display-constants';
+import { isControllingLocalAudio } from '@/lib/playback/playback-active-device';
+import {
+  emitCurrentTimeSync,
+  firePlaybackCommand,
+  isPlaybackSyncConnected,
+} from '@/lib/playback/sync/playback-sync';
+import { usePlayerStore } from '@/stores/player-store/player.store';
+import type { PlaybackTrack } from '@repo/contracts';
+import { useEffect, type RefObject } from 'react';
+
+const POSITION_STATE_INTERVAL_MS = 1000;
+const DEFAULT_SEEK_SKIP_SEC = 10;
+
+const MEDIA_SESSION_ACTIONS: MediaSessionAction[] = [
+  'play',
+  'pause',
+  'previoustrack',
+  'nexttrack',
+  'seekbackward',
+  'seekforward',
+  'seekto',
+  'stop',
+];
+
+function clearAllMediaSessionActionHandlers(): void {
+  if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+  for (const action of MEDIA_SESSION_ACTIONS) {
+    try {
+      navigator.mediaSession.setActionHandler(action, null);
+    } catch {
+      /* action unsupported */
+    }
+  }
+}
+
+function clearPositionState(ms: MediaSession): void {
+  try {
+    (ms.setPositionState as (state: MediaPositionState | null) => void)(null);
+  } catch {
+    /* noop */
+  }
+}
+
+function clearMediaSessionPresentation(): void {
+  if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+  const ms = navigator.mediaSession;
+  ms.metadata = null;
+  ms.playbackState = 'none';
+  clearPositionState(ms);
+  clearAllMediaSessionActionHandlers();
+}
+
+/** Returns an absolute URL suitable for MediaMetadata artwork, or null. */
+export function resolvePlaybackArtworkUrl(albumArt: string | null | undefined): string | null {
+  if (typeof window === 'undefined') return null;
+  const trimmed = albumArt?.trim();
+  if (!trimmed) return null;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  try {
+    return new URL(trimmed, window.location.origin).href;
+  } catch {
+    return null;
+  }
+}
+
+function buildMediaMetadata(track: PlaybackTrack): MediaMetadata {
+  const artist =
+    track.artists.length > 0 ? track.artists.join(', ') : UNKNOWN_ARTIST_LABEL;
+  const artworkUrl = resolvePlaybackArtworkUrl(track.albumArt);
+  const artwork: MediaImage[] = artworkUrl ? [{ src: artworkUrl }] : [];
+  return new MediaMetadata({
+    title: track.title,
+    artist,
+    album: track.albumName,
+    artwork,
+  });
+}
+
+function controllingNow(): boolean {
+  const s = usePlayerStore.getState();
+  return isControllingLocalAudio({
+    isPlaybackSyncConnected: isPlaybackSyncConnected(),
+    activeDeviceId: s.activeDeviceId,
+    localPlaybackDeviceId: s.localPlaybackDeviceId,
+  });
+}
+
+function commitSeek(
+  time: number,
+  audio: HTMLAudioElement | null,
+  positionStateAudioRef: RefObject<HTMLAudioElement | null>,
+): void {
+  const { duration, setCurrentTime, currentTrack, playbackVersion } = usePlayerStore.getState();
+  let max = time;
+  if (Number.isFinite(duration) && duration > 0) {
+    max = duration;
+  } else if (audio && Number.isFinite(audio.duration) && audio.duration > 0) {
+    max = audio.duration;
+  }
+  const clamped = Math.max(0, Math.min(time, max));
+  if (audio) {
+    audio.currentTime = clamped;
+  }
+  setCurrentTime(clamped);
+  if (isPlaybackSyncConnected() && currentTrack && playbackVersion !== 0) {
+    firePlaybackCommand(emitCurrentTimeSync(clamped), 'emitCurrentTimeSync');
+  }
+  queueMicrotask(() => flushPositionState(positionStateAudioRef));
+}
+
+function trySetActionHandler(
+  action: MediaSessionAction,
+  handler: MediaSessionActionHandler | null,
+): void {
+  try {
+    navigator.mediaSession.setActionHandler(action, handler);
+  } catch {
+    /* unsupported */
+  }
+}
+
+function flushPositionState(audioRef: RefObject<HTMLAudioElement | null>): void {
+  if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+  if (!('setPositionState' in navigator.mediaSession)) return;
+
+  if (!controllingNow()) {
+    clearPositionState(navigator.mediaSession);
+    return;
+  }
+
+  const s = usePlayerStore.getState();
+  const audio = audioRef.current;
+  const pos = audio ? audio.currentTime : s.currentTime;
+  const dur =
+    Number.isFinite(s.duration) && s.duration > 0
+      ? s.duration
+      : audio && Number.isFinite(audio.duration) && audio.duration > 0
+        ? audio.duration
+        : 0;
+
+  if (!Number.isFinite(dur) || dur <= 0) {
+    clearPositionState(navigator.mediaSession);
+    return;
+  }
+
+  const clamped = Math.max(0, Math.min(pos, dur));
+  try {
+    navigator.mediaSession.setPositionState({
+      duration: dur,
+      position: clamped,
+      playbackRate: s.isPlaying ? 1 : 0,
+    });
+  } catch {
+    /* Chromium throws if duration/position invalid */
+  }
+}
+
+/**
+ * Syncs OS / browser media session with the local player when this tab is the active output device.
+ */
+export function usePlaybackMediaSession(audioRef: RefObject<HTMLAudioElement | null>): void {
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const duration = usePlayerStore((s) => s.duration);
+  const activeDeviceId = usePlayerStore((s) => s.activeDeviceId);
+  const localPlaybackDeviceId = usePlayerStore((s) => s.localPlaybackDeviceId);
+
+  const isControlling = isControllingLocalAudio({
+    isPlaybackSyncConnected: isPlaybackSyncConnected(),
+    activeDeviceId,
+    localPlaybackDeviceId,
+  });
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) {
+      return;
+    }
+
+    if (!currentTrack || !isControlling) {
+      clearMediaSessionPresentation();
+      return () => {
+        clearMediaSessionPresentation();
+      };
+    }
+
+    try {
+      navigator.mediaSession.metadata = buildMediaMetadata(currentTrack);
+    } catch (err) {
+      console.error('[MediaSession] failed to set metadata', err);
+    }
+
+    trySetActionHandler('play', () => {
+      if (!controllingNow()) return;
+      usePlayerStore.getState().resume();
+    });
+    trySetActionHandler('pause', () => {
+      if (!controllingNow()) return;
+      usePlayerStore.getState().pause();
+    });
+    trySetActionHandler('stop', () => {
+      if (!controllingNow()) return;
+      usePlayerStore.getState().pause();
+    });
+    trySetActionHandler('previoustrack', () => {
+      if (!controllingNow()) return;
+      usePlayerStore.getState().previousTrack();
+    });
+    trySetActionHandler('nexttrack', () => {
+      if (!controllingNow()) return;
+      usePlayerStore.getState().nextTrack();
+    });
+    trySetActionHandler('seekbackward', (details) => {
+      if (!controllingNow()) return;
+      const audio = audioRef.current;
+      const base = audio?.currentTime ?? usePlayerStore.getState().currentTime;
+      const offset = details?.seekOffset ?? DEFAULT_SEEK_SKIP_SEC;
+      commitSeek(base - offset, audio, audioRef);
+    });
+    trySetActionHandler('seekforward', (details) => {
+      if (!controllingNow()) return;
+      const audio = audioRef.current;
+      const base = audio?.currentTime ?? usePlayerStore.getState().currentTime;
+      const offset = details?.seekOffset ?? DEFAULT_SEEK_SKIP_SEC;
+      commitSeek(base + offset, audio, audioRef);
+    });
+    trySetActionHandler('seekto', (details) => {
+      if (!controllingNow()) return;
+      if (details.seekTime == null || !Number.isFinite(details.seekTime)) return;
+      commitSeek(details.seekTime, audioRef.current, audioRef);
+    });
+
+    return () => {
+      clearAllMediaSessionActionHandlers();
+    };
+  }, [audioRef, currentTrack, isControlling]);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) {
+      return;
+    }
+    if (!currentTrack || !isControlling) {
+      navigator.mediaSession.playbackState = 'none';
+      return;
+    }
+    navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
+  }, [currentTrack, isControlling, isPlaying]);
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) {
+      return;
+    }
+    if (!('setPositionState' in navigator.mediaSession)) {
+      return;
+    }
+
+    if (!currentTrack || !isControlling) {
+      flushPositionState(audioRef);
+      return;
+    }
+
+    flushPositionState(audioRef);
+    const id = window.setInterval(() => flushPositionState(audioRef), POSITION_STATE_INTERVAL_MS);
+    return () => {
+      window.clearInterval(id);
+      clearPositionState(navigator.mediaSession);
+    };
+  }, [audioRef, currentTrack, isControlling, isPlaying, duration]);
+}

--- a/apps/web/src/lib/playback/playback-active-device.test.ts
+++ b/apps/web/src/lib/playback/playback-active-device.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isControllingLocalAudio, isNoActivePlaybackDevice } from './playback-active-device';
+
+describe('isNoActivePlaybackDevice', () => {
+  it('returns true for null, undefined, or empty string', () => {
+    expect(isNoActivePlaybackDevice(null)).toBe(true);
+    expect(isNoActivePlaybackDevice(undefined)).toBe(true);
+    expect(isNoActivePlaybackDevice('')).toBe(true);
+  });
+
+  it('returns false when an id is set', () => {
+    expect(isNoActivePlaybackDevice('device-1')).toBe(false);
+  });
+});
+
+describe('isControllingLocalAudio', () => {
+  it('returns true when playback sync is not connected', () => {
+    expect(
+      isControllingLocalAudio({
+        isPlaybackSyncConnected: false,
+        activeDeviceId: 'other',
+        localPlaybackDeviceId: 'me',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when no active device is assigned', () => {
+    expect(
+      isControllingLocalAudio({
+        isPlaybackSyncConnected: true,
+        activeDeviceId: null,
+        localPlaybackDeviceId: 'me',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when this device is the active device', () => {
+    expect(
+      isControllingLocalAudio({
+        isPlaybackSyncConnected: true,
+        activeDeviceId: 'me',
+        localPlaybackDeviceId: 'me',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when another device is active', () => {
+    expect(
+      isControllingLocalAudio({
+        isPlaybackSyncConnected: true,
+        activeDeviceId: 'other',
+        localPlaybackDeviceId: 'me',
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/playback/playback-active-device.ts
+++ b/apps/web/src/lib/playback/playback-active-device.ts
@@ -1,0 +1,21 @@
+/** True when the server has not assigned an active playback device yet. */
+export function isNoActivePlaybackDevice(value: string | null | undefined): boolean {
+  return value == null || value === '';
+}
+
+/**
+ * True when this browser tab should drive local `<audio>` output and OS media session
+ * (sync off, no active device yet, or this tab is the active device).
+ */
+export function isControllingLocalAudio(params: {
+  isPlaybackSyncConnected: boolean;
+  activeDeviceId: string | null;
+  localPlaybackDeviceId: string;
+}): boolean {
+  const { isPlaybackSyncConnected, activeDeviceId, localPlaybackDeviceId } = params;
+  return (
+    !isPlaybackSyncConnected ||
+    isNoActivePlaybackDevice(activeDeviceId) ||
+    activeDeviceId === localPlaybackDeviceId
+  );
+}


### PR DESCRIPTION
feat(apps/web): enhance audio playback management with media session integration

- Introduced new utility functions for determining active playback devices and controlling local audio output.
- Implemented the `usePlaybackMediaSession` hook to synchronize the browser's media session with the local audio player.
- Refactored the `usePlayerAudio` hook to utilize the new utilities for improved audio output management based on playback state and device control.

feat(apps/web): add unit tests for playback device management and media session hook

- Introduced unit tests for `isNoActivePlaybackDevice` and `isControllingLocalAudio` functions to validate their behavior with various input scenarios.
- Added comprehensive tests for the `usePlaybackMediaSession` hook, ensuring proper integration with the media session API and correct handling of playback state and metadata.
- Enhanced test coverage for resolving playback artwork URLs and managing media session actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System media controls are now fully integrated with playback, enabling complete control from your device's lock screen and native media buttons
  * Enhanced coordination for multi-device playback scenarios with improved detection of which device should actively control audio output

* **Tests**
  * Added comprehensive test coverage for media session integration and device management capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hagrid862/playr/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->