### PR TITLE
tests(apps/api): add tests for search suggestions

### DIFF
--- a/apps/api/integration/search.int-spec.ts
+++ b/apps/api/integration/search.int-spec.ts
@@ -1,0 +1,348 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaServiceMock } from '@repo/testing/nestjs';
+import request from 'supertest';
+import './setup-env';
+import { setupJwtAuthPrismaMocks } from './jwt-auth-prisma-setup';
+import { createIntegrationApp } from './test-utils';
+
+describe('SearchController (Integration)', () => {
+  let app: INestApplication;
+  let prismaMock: PrismaServiceMock;
+  let jwtService: JwtService;
+  let config: ConfigService;
+
+  beforeAll(async () => {
+    const setup = await createIntegrationApp();
+    app = setup.app;
+    prismaMock = setup.prismaMock;
+    jwtService = app.get(JwtService);
+    config = app.get(ConfigService);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Add extended property to mock for search service
+    (prismaMock as any).extended = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
+    };
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const getAuthHeader = async (userId: string = 'user-123') => {
+    const token = await jwtService.signAsync(
+      { sub: userId, username: 'testuser', sessionId: 'session-123' },
+      {
+        secret: config.getOrThrow<string>('JWT_ACCESS_SECRET'),
+        expiresIn: '15m',
+      },
+    );
+    return `Bearer ${token}`;
+  };
+
+  describe('GET /search/suggestions', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .query({ query: 'test' })
+        .expect(401);
+    });
+
+    it('should return 400 when query is too short', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'ab' })
+        .expect(400);
+    });
+
+    it('should return 400 when query is empty', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: '' })
+        .expect(400);
+    });
+
+    it('should return 400 when query parameter is missing', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .expect(400);
+    });
+
+    it('should return search results for valid query with authenticated user', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      // Mock the extended prisma client for search
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Test Artist',
+          type: 'artist',
+          visibility: 'public',
+          albumType: null,
+          score: 0.8,
+        },
+      ];
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce(mockResults);
+
+      const response = await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test' })
+        .expect(200);
+
+      expect(response.body.data).toBeDefined();
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should return empty array when no results found', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      const response = await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'nonexistent' })
+        .expect(200);
+
+      expect(response.body.data).toEqual([]);
+    });
+
+    it('should handle query with special characters', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test-query' })
+        .expect(200);
+    });
+
+    it('should handle query with leading/trailing whitespace', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: '  test  ' })
+        .expect(200);
+    });
+  });
+
+  describe('GET /search/library-suggestions', () => {
+    it('should return 401 when no token is provided', async () => {
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .query({ query: 'test' })
+        .expect(401);
+    });
+
+    it('should return 400 when query is too short', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'ab' })
+        .expect(400);
+    });
+
+    it('should return 400 when query is empty', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: '' })
+        .expect(400);
+    });
+
+    it('should return 400 when query parameter is missing', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .expect(400);
+    });
+
+    it('should return library search results for valid query with authenticated user', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Library Artist',
+          type: 'artist',
+          visibility: 'private',
+          albumType: null,
+          score: 0.9,
+        },
+      ];
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce(mockResults);
+
+      const response = await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test' })
+        .expect(200);
+
+      expect(response.body.data).toBeDefined();
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should return empty array when no results found', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      const response = await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'nonexistent' })
+        .expect(200);
+
+      expect(response.body.data).toEqual([]);
+    });
+
+    it('should filter by single category', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test', categories: 'artist' })
+        .expect(200);
+    });
+
+    it('should filter by multiple categories', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test', categories: ['artist', 'album', 'track'] })
+        .expect(200);
+    });
+
+    it('should handle all category types', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test', categories: ['artist', 'album', 'track', 'playlist', 'genre'] })
+        .expect(200);
+    });
+
+    it('should handle query with special characters', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'test-query' })
+        .expect(200);
+    });
+
+    it('should handle query with leading/trailing whitespace', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: '  test  ' })
+        .expect(200);
+    });
+
+    it('should return results with albumType when present', async () => {
+      const authHeader = await getAuthHeader();
+
+      setupJwtAuthPrismaMocks(prismaMock);
+
+      const mockResults = [
+        {
+          id: 'album-1',
+          name: 'Test Album',
+          type: 'album',
+          visibility: 'private',
+          albumType: 'album',
+          score: 0.7,
+        },
+      ];
+
+      (prismaMock as any).extended.$queryRaw.mockResolvedValueOnce(mockResults);
+
+      const response = await request(app.getHttpServer())
+        .get('/search/library-suggestions')
+        .set('Authorization', authHeader)
+        .query({ query: 'album' })
+        .expect(200);
+
+      expect(response.body.data).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.spec.ts
+++ b/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.spec.ts
@@ -1,4 +1,4 @@
-import { SearchService } from '@/features/search/services/search.service';
+import { SearchSuggestionsService } from '@/features/search/services/search-suggestions.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   LibrarySearchSuggestionsResults,
@@ -12,7 +12,7 @@ import { LibrarySearchSuggestionsHandler } from './library-search-suggestions.ha
 
 describe('LibrarySearchSuggestionsHandler', () => {
   let handler: LibrarySearchSuggestionsHandler;
-  let searchService: DeepMocked<SearchService>;
+  let suggestionsService: DeepMocked<SearchSuggestionsService>;
 
   const userId = 'user-123';
   const query = 'test query';
@@ -31,12 +31,12 @@ describe('LibrarySearchSuggestionsHandler', () => {
   ];
 
   beforeEach(async () => {
-    searchService = createMock<SearchService>();
+    suggestionsService = createMock<SearchSuggestionsService>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LibrarySearchSuggestionsHandler,
-        { provide: SearchService, useValue: searchService },
+        { provide: SearchSuggestionsService, useValue: suggestionsService },
       ],
     }).compile();
 
@@ -47,26 +47,26 @@ describe('LibrarySearchSuggestionsHandler', () => {
     vi.clearAllMocks();
   });
 
-  it('should call searchService.librarySearchSuggestions with userId, query, and categories', async () => {
-    searchService.librarySearchSuggestions.mockResolvedValue(mockResults);
+  it('should call suggestionsService.librarySearchSuggestions with userId, query, and categories', async () => {
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(mockResults);
 
     const result = await handler.execute(searchQuery);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, categories);
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, categories);
     expect(result).toEqual(mockResults);
   });
 
-  it('should call searchService.librarySearchSuggestions with undefined categories when not provided', async () => {
+  it('should call suggestionsService.librarySearchSuggestions with undefined categories when not provided', async () => {
     const queryWithoutCategories = new LibrarySearchSuggestionsQuery(userId, query);
-    searchService.librarySearchSuggestions.mockResolvedValue(mockResults);
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(mockResults);
 
     await handler.execute(queryWithoutCategories);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, undefined);
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, undefined);
   });
 
-  it('should return empty array when searchService returns empty array', async () => {
-    searchService.librarySearchSuggestions.mockResolvedValue([]);
+  it('should return empty array when suggestionsService returns empty array', async () => {
+    suggestionsService.librarySearchSuggestions.mockResolvedValue([]);
 
     const result = await handler.execute(searchQuery);
 
@@ -78,11 +78,11 @@ describe('LibrarySearchSuggestionsHandler', () => {
     const trackResults: LibrarySearchSuggestionsResults = [
       { id: 'track-1', name: 'Test Track', type: SearchResultType.Track, visibility: 'private' },
     ];
-    searchService.librarySearchSuggestions.mockResolvedValue(trackResults);
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(trackResults);
 
     const result = await handler.execute(singleCategoryQuery);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['track']);
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['track']);
     expect(result).toEqual(trackResults);
   });
 
@@ -113,11 +113,11 @@ describe('LibrarySearchSuggestionsHandler', () => {
       },
       { id: 'genre-1', name: 'Genre', type: SearchResultType.Genre, visibility: 'public' },
     ];
-    searchService.librarySearchSuggestions.mockResolvedValue(allResults);
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(allResults);
 
     const result = await handler.execute(allCategoriesQuery);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(
       userId,
       query,
       allCategories,
@@ -135,11 +135,11 @@ describe('LibrarySearchSuggestionsHandler', () => {
         visibility: 'private',
       },
     ];
-    searchService.librarySearchSuggestions.mockResolvedValue(playlistResults);
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(playlistResults);
 
     const result = await handler.execute(playlistQuery);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, [
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, [
       'playlist',
     ]);
     expect(result).toEqual(playlistResults);
@@ -150,11 +150,11 @@ describe('LibrarySearchSuggestionsHandler', () => {
     const genreResults: LibrarySearchSuggestionsResults = [
       { id: 'genre-1', name: 'Rock', type: SearchResultType.Genre, visibility: 'public' },
     ];
-    searchService.librarySearchSuggestions.mockResolvedValue(genreResults);
+    suggestionsService.librarySearchSuggestions.mockResolvedValue(genreResults);
 
     const result = await handler.execute(genreQuery);
 
-    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['genre']);
+    expect(suggestionsService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['genre']);
     expect(result).toEqual(genreResults);
   });
 });

--- a/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.spec.ts
+++ b/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.spec.ts
@@ -1,0 +1,160 @@
+import { SearchService } from '@/features/search/services/search.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  LibrarySearchSuggestionsResults,
+  SearchSuggestionsCategories,
+  SearchResultType,
+} from '@repo/contracts';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LibrarySearchSuggestionsQuery } from '../impl/library-search-suggestions.query';
+import { LibrarySearchSuggestionsHandler } from './library-search-suggestions.handler';
+
+describe('LibrarySearchSuggestionsHandler', () => {
+  let handler: LibrarySearchSuggestionsHandler;
+  let searchService: DeepMocked<SearchService>;
+
+  const userId = 'user-123';
+  const query = 'test query';
+  const categories: SearchSuggestionsCategories[] = ['artist', 'album'];
+  const searchQuery = new LibrarySearchSuggestionsQuery(userId, query, categories);
+
+  const mockResults: LibrarySearchSuggestionsResults = [
+    { id: 'artist-1', name: 'Test Artist', type: SearchResultType.Artist, visibility: 'private' },
+    {
+      id: 'album-1',
+      name: 'Test Album',
+      type: SearchResultType.Album,
+      visibility: 'private',
+      albumType: 'album',
+    },
+  ];
+
+  beforeEach(async () => {
+    searchService = createMock<SearchService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibrarySearchSuggestionsHandler,
+        { provide: SearchService, useValue: searchService },
+      ],
+    }).compile();
+
+    handler = module.get<LibrarySearchSuggestionsHandler>(LibrarySearchSuggestionsHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call searchService.librarySearchSuggestions with userId, query, and categories', async () => {
+    searchService.librarySearchSuggestions.mockResolvedValue(mockResults);
+
+    const result = await handler.execute(searchQuery);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, categories);
+    expect(result).toEqual(mockResults);
+  });
+
+  it('should call searchService.librarySearchSuggestions with undefined categories when not provided', async () => {
+    const queryWithoutCategories = new LibrarySearchSuggestionsQuery(userId, query);
+    searchService.librarySearchSuggestions.mockResolvedValue(mockResults);
+
+    await handler.execute(queryWithoutCategories);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, undefined);
+  });
+
+  it('should return empty array when searchService returns empty array', async () => {
+    searchService.librarySearchSuggestions.mockResolvedValue([]);
+
+    const result = await handler.execute(searchQuery);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle single category filter', async () => {
+    const singleCategoryQuery = new LibrarySearchSuggestionsQuery(userId, query, ['track']);
+    const trackResults: LibrarySearchSuggestionsResults = [
+      { id: 'track-1', name: 'Test Track', type: SearchResultType.Track, visibility: 'private' },
+    ];
+    searchService.librarySearchSuggestions.mockResolvedValue(trackResults);
+
+    const result = await handler.execute(singleCategoryQuery);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['track']);
+    expect(result).toEqual(trackResults);
+  });
+
+  it('should handle all category types', async () => {
+    const allCategories: SearchSuggestionsCategories[] = [
+      'artist',
+      'album',
+      'track',
+      'playlist',
+      'genre',
+    ];
+    const allCategoriesQuery = new LibrarySearchSuggestionsQuery(userId, query, allCategories);
+    const allResults: LibrarySearchSuggestionsResults = [
+      { id: 'artist-1', name: 'Artist', type: SearchResultType.Artist, visibility: 'private' },
+      {
+        id: 'album-1',
+        name: 'Album',
+        type: SearchResultType.Album,
+        visibility: 'private',
+        albumType: 'album',
+      },
+      { id: 'track-1', name: 'Track', type: SearchResultType.Track, visibility: 'private' },
+      {
+        id: 'playlist-1',
+        name: 'Playlist',
+        type: SearchResultType.Playlist,
+        visibility: 'private',
+      },
+      { id: 'genre-1', name: 'Genre', type: SearchResultType.Genre, visibility: 'public' },
+    ];
+    searchService.librarySearchSuggestions.mockResolvedValue(allResults);
+
+    const result = await handler.execute(allCategoriesQuery);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(
+      userId,
+      query,
+      allCategories,
+    );
+    expect(result).toEqual(allResults);
+  });
+
+  it('should handle playlist category', async () => {
+    const playlistQuery = new LibrarySearchSuggestionsQuery(userId, query, ['playlist']);
+    const playlistResults: LibrarySearchSuggestionsResults = [
+      {
+        id: 'playlist-1',
+        name: 'My Playlist',
+        type: SearchResultType.Playlist,
+        visibility: 'private',
+      },
+    ];
+    searchService.librarySearchSuggestions.mockResolvedValue(playlistResults);
+
+    const result = await handler.execute(playlistQuery);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, [
+      'playlist',
+    ]);
+    expect(result).toEqual(playlistResults);
+  });
+
+  it('should handle genre category', async () => {
+    const genreQuery = new LibrarySearchSuggestionsQuery(userId, query, ['genre']);
+    const genreResults: LibrarySearchSuggestionsResults = [
+      { id: 'genre-1', name: 'Rock', type: SearchResultType.Genre, visibility: 'public' },
+    ];
+    searchService.librarySearchSuggestions.mockResolvedValue(genreResults);
+
+    const result = await handler.execute(genreQuery);
+
+    expect(searchService.librarySearchSuggestions).toHaveBeenCalledWith(userId, query, ['genre']);
+    expect(result).toEqual(genreResults);
+  });
+});

--- a/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.ts
+++ b/apps/api/src/features/search/queries/handlers/library-search-suggestions.handler.ts
@@ -1,13 +1,13 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { LibrarySearchSuggestionsQuery } from '../impl/library-search-suggestions.query';
-import { SearchService } from '../../services/search.service';
+import { SearchSuggestionsService } from '../../services/search-suggestions.service';
 import { LibrarySearchSuggestionsResults } from '@repo/contracts';
 
 @QueryHandler(LibrarySearchSuggestionsQuery)
 export class LibrarySearchSuggestionsHandler implements IQueryHandler<LibrarySearchSuggestionsQuery> {
-  constructor(private readonly searchService: SearchService) {}
+  constructor(private readonly searchSuggestionsService: SearchSuggestionsService) {}
 
   async execute(query: LibrarySearchSuggestionsQuery): Promise<LibrarySearchSuggestionsResults> {
-    return this.searchService.librarySearchSuggestions(query.userId, query.query, query.categories);
+    return this.searchSuggestionsService.librarySearchSuggestions(query.userId, query.query, query.categories);
   }
 }

--- a/apps/api/src/features/search/queries/handlers/search-suggestions.handler.spec.ts
+++ b/apps/api/src/features/search/queries/handlers/search-suggestions.handler.spec.ts
@@ -1,4 +1,4 @@
-import { SearchService } from '@/features/search/services/search.service';
+import { SearchSuggestionsService } from '@/features/search/services/search-suggestions.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SearchSuggestionsResults, SearchResultType } from '@repo/contracts';
 import { createMock, DeepMocked } from '@repo/testing/nestjs';
@@ -8,7 +8,7 @@ import { SearchSuggestionsHandler } from './search-suggestions.handler';
 
 describe('SearchSuggestionsHandler', () => {
   let handler: SearchSuggestionsHandler;
-  let searchService: DeepMocked<SearchService>;
+  let suggestionsService: DeepMocked<SearchSuggestionsService>;
 
   const query = 'test query';
   const userId = 'user-123';
@@ -26,10 +26,13 @@ describe('SearchSuggestionsHandler', () => {
   ];
 
   beforeEach(async () => {
-    searchService = createMock<SearchService>();
+    suggestionsService = createMock<SearchSuggestionsService>();
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SearchSuggestionsHandler, { provide: SearchService, useValue: searchService }],
+      providers: [
+        SearchSuggestionsHandler,
+        { provide: SearchSuggestionsService, useValue: suggestionsService },
+      ],
     }).compile();
 
     handler = module.get<SearchSuggestionsHandler>(SearchSuggestionsHandler);
@@ -39,33 +42,33 @@ describe('SearchSuggestionsHandler', () => {
     vi.clearAllMocks();
   });
 
-  it('should call searchService.searchSuggestions with query and userId', async () => {
-    searchService.searchSuggestions.mockResolvedValue(mockResults);
+  it('should call suggestionsService.searchSuggestions with query and userId', async () => {
+    suggestionsService.searchSuggestions.mockResolvedValue(mockResults);
 
     const result = await handler.execute(searchQuery);
 
-    expect(searchService.searchSuggestions).toHaveBeenCalledWith(query, userId);
+    expect(suggestionsService.searchSuggestions).toHaveBeenCalledWith(query, userId);
     expect(result).toEqual(mockResults);
   });
 
-  it('should call searchService.searchSuggestions with undefined userId when not provided', async () => {
+  it('should call suggestionsService.searchSuggestions with undefined userId when not provided', async () => {
     const queryWithoutUser = new SearchSuggestionsQuery(query);
-    searchService.searchSuggestions.mockResolvedValue(mockResults);
+    suggestionsService.searchSuggestions.mockResolvedValue(mockResults);
 
     await handler.execute(queryWithoutUser);
 
-    expect(searchService.searchSuggestions).toHaveBeenCalledWith(query, undefined);
+    expect(suggestionsService.searchSuggestions).toHaveBeenCalledWith(query, undefined);
   });
 
-  it('should return empty array when searchService returns empty array', async () => {
-    searchService.searchSuggestions.mockResolvedValue([]);
+  it('should return empty array when suggestionsService returns empty array', async () => {
+    suggestionsService.searchSuggestions.mockResolvedValue([]);
 
     const result = await handler.execute(searchQuery);
 
     expect(result).toEqual([]);
   });
 
-  it('should return all result types from searchService', async () => {
+  it('should return all result types from suggestionsService', async () => {
     const mixedResults: SearchSuggestionsResults = [
       { id: 'artist-1', name: 'Artist', type: SearchResultType.Artist, visibility: 'public' },
       {
@@ -78,7 +81,7 @@ describe('SearchSuggestionsHandler', () => {
       { id: 'track-1', name: 'Track', type: SearchResultType.Track, visibility: 'public' },
       { id: 'playlist-1', name: 'Playlist', type: SearchResultType.Playlist, visibility: 'public' },
     ];
-    searchService.searchSuggestions.mockResolvedValue(mixedResults);
+    suggestionsService.searchSuggestions.mockResolvedValue(mixedResults);
 
     const result = await handler.execute(searchQuery);
 

--- a/apps/api/src/features/search/queries/handlers/search-suggestions.handler.spec.ts
+++ b/apps/api/src/features/search/queries/handlers/search-suggestions.handler.spec.ts
@@ -1,0 +1,88 @@
+import { SearchService } from '@/features/search/services/search.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchSuggestionsResults, SearchResultType } from '@repo/contracts';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SearchSuggestionsQuery } from '../impl/search-suggestions.query';
+import { SearchSuggestionsHandler } from './search-suggestions.handler';
+
+describe('SearchSuggestionsHandler', () => {
+  let handler: SearchSuggestionsHandler;
+  let searchService: DeepMocked<SearchService>;
+
+  const query = 'test query';
+  const userId = 'user-123';
+  const searchQuery = new SearchSuggestionsQuery(query, userId);
+
+  const mockResults: SearchSuggestionsResults = [
+    { id: 'artist-1', name: 'Test Artist', type: SearchResultType.Artist, visibility: 'public' },
+    {
+      id: 'album-1',
+      name: 'Test Album',
+      type: SearchResultType.Album,
+      visibility: 'public',
+      albumType: 'album',
+    },
+  ];
+
+  beforeEach(async () => {
+    searchService = createMock<SearchService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SearchSuggestionsHandler, { provide: SearchService, useValue: searchService }],
+    }).compile();
+
+    handler = module.get<SearchSuggestionsHandler>(SearchSuggestionsHandler);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call searchService.searchSuggestions with query and userId', async () => {
+    searchService.searchSuggestions.mockResolvedValue(mockResults);
+
+    const result = await handler.execute(searchQuery);
+
+    expect(searchService.searchSuggestions).toHaveBeenCalledWith(query, userId);
+    expect(result).toEqual(mockResults);
+  });
+
+  it('should call searchService.searchSuggestions with undefined userId when not provided', async () => {
+    const queryWithoutUser = new SearchSuggestionsQuery(query);
+    searchService.searchSuggestions.mockResolvedValue(mockResults);
+
+    await handler.execute(queryWithoutUser);
+
+    expect(searchService.searchSuggestions).toHaveBeenCalledWith(query, undefined);
+  });
+
+  it('should return empty array when searchService returns empty array', async () => {
+    searchService.searchSuggestions.mockResolvedValue([]);
+
+    const result = await handler.execute(searchQuery);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return all result types from searchService', async () => {
+    const mixedResults: SearchSuggestionsResults = [
+      { id: 'artist-1', name: 'Artist', type: SearchResultType.Artist, visibility: 'public' },
+      {
+        id: 'album-1',
+        name: 'Album',
+        type: SearchResultType.Album,
+        visibility: 'public',
+        albumType: 'album',
+      },
+      { id: 'track-1', name: 'Track', type: SearchResultType.Track, visibility: 'public' },
+      { id: 'playlist-1', name: 'Playlist', type: SearchResultType.Playlist, visibility: 'public' },
+    ];
+    searchService.searchSuggestions.mockResolvedValue(mixedResults);
+
+    const result = await handler.execute(searchQuery);
+
+    expect(result).toHaveLength(4);
+    expect(result).toEqual(mixedResults);
+  });
+});

--- a/apps/api/src/features/search/queries/handlers/search-suggestions.handler.ts
+++ b/apps/api/src/features/search/queries/handlers/search-suggestions.handler.ts
@@ -1,13 +1,13 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { SearchSuggestionsQuery } from '../impl/search-suggestions.query';
-import { SearchService } from '../../services/search.service';
+import { SearchSuggestionsService } from '../../services/search-suggestions.service';
 import { SearchSuggestionsResults } from '@repo/contracts';
 
 @QueryHandler(SearchSuggestionsQuery)
 export class SearchSuggestionsHandler implements IQueryHandler<SearchSuggestionsQuery> {
-  constructor(private readonly searchService: SearchService) {}
+  constructor(private readonly searchSuggestionsService: SearchSuggestionsService) {}
 
   async execute(query: SearchSuggestionsQuery): Promise<SearchSuggestionsResults> {
-    return this.searchService.searchSuggestions(query.query, query.userId);
+    return this.searchSuggestionsService.searchSuggestions(query.query, query.userId);
   }
 }

--- a/apps/api/src/features/search/search.controller.spec.ts
+++ b/apps/api/src/features/search/search.controller.spec.ts
@@ -1,0 +1,158 @@
+import { createMock, DeepMocked } from '@golevelup/ts-vitest';
+import { QueryBus } from '@nestjs/cqrs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SearchSuggestionsQueryRequestDto } from './dto/search-suggestions-query.request.dto';
+import { LibrarySearchSuggestionsQueryRequestDto } from './dto/library-search-suggestions-query.request.dto';
+import { SearchSuggestionsQuery } from './queries/impl/search-suggestions.query';
+import { LibrarySearchSuggestionsQuery } from './queries/impl/library-search-suggestions.query';
+import { SearchController } from './search.controller';
+import type { User } from '@repo/db';
+
+describe('SearchController', () => {
+  let controller: SearchController;
+  let queryBus: DeepMocked<QueryBus>;
+
+  beforeEach(async () => {
+    queryBus = createMock<QueryBus>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SearchController],
+      providers: [{ provide: QueryBus, useValue: queryBus }],
+    }).compile();
+
+    controller = module.get<SearchController>(SearchController);
+  });
+
+  describe('searchSuggestions', () => {
+    it('should execute SearchSuggestionsQuery with query and user id when user is authenticated', async () => {
+      const queryDto = createMock<SearchSuggestionsQueryRequestDto>({
+        query: 'test',
+      });
+      const user: User = { id: 'user-123' } as User;
+      const expectedResult = [
+        { id: 'artist-1', name: 'Test Artist', type: 'artist', visibility: 'public' },
+      ];
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.searchSuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(new SearchSuggestionsQuery('test', 'user-123'));
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should execute SearchSuggestionsQuery with undefined userId when user is null', async () => {
+      const queryDto = createMock<SearchSuggestionsQueryRequestDto>({
+        query: 'pop',
+      });
+      const expectedResult = [
+        { id: 'artist-1', name: 'Pop Artist', type: 'artist', visibility: 'public' },
+      ];
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.searchSuggestions(queryDto, null);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(new SearchSuggestionsQuery('pop', undefined));
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should pass through the exact query string from DTO to query', async () => {
+      const queryDto = createMock<SearchSuggestionsQueryRequestDto>({
+        query: 'rock band',
+      });
+      const user: User = { id: 'user-456' } as User;
+      queryBus.execute.mockResolvedValue([]);
+
+      await controller.searchSuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new SearchSuggestionsQuery('rock band', 'user-456'),
+      );
+    });
+  });
+
+  describe('searchLibrarySuggestions', () => {
+    it('should execute LibrarySearchSuggestionsQuery with userId, query, and categories', async () => {
+      const queryDto = createMock<LibrarySearchSuggestionsQueryRequestDto>({
+        query: 'jazz',
+        categories: ['artist', 'album'],
+      });
+      const user: User = { id: 'user-789' } as User;
+      const expectedResult = [
+        { id: 'artist-1', name: 'Jazz Artist', type: 'artist', visibility: 'private' },
+      ];
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.searchLibrarySuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new LibrarySearchSuggestionsQuery('user-789', 'jazz', ['artist', 'album']),
+      );
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should execute LibrarySearchSuggestionsQuery with undefined categories when not provided', async () => {
+      const queryDto = createMock<LibrarySearchSuggestionsQueryRequestDto>({
+        query: 'classical',
+        categories: undefined,
+      });
+      const user: User = { id: 'user-101' } as User;
+      queryBus.execute.mockResolvedValue([]);
+
+      await controller.searchLibrarySuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new LibrarySearchSuggestionsQuery('user-101', 'classical', undefined),
+      );
+    });
+
+    it('should execute LibrarySearchSuggestionsQuery with single category as array', async () => {
+      const queryDto = createMock<LibrarySearchSuggestionsQueryRequestDto>({
+        query: 'pop',
+        categories: ['track'],
+      });
+      const user: User = { id: 'user-202' } as User;
+      queryBus.execute.mockResolvedValue([]);
+
+      await controller.searchLibrarySuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new LibrarySearchSuggestionsQuery('user-202', 'pop', ['track']),
+      );
+    });
+
+    it('should execute LibrarySearchSuggestionsQuery with all category types', async () => {
+      const queryDto = createMock<LibrarySearchSuggestionsQueryRequestDto>({
+        query: 'music',
+        categories: ['artist', 'album', 'track', 'playlist', 'genre'],
+      });
+      const user: User = { id: 'user-303' } as User;
+      queryBus.execute.mockResolvedValue([]);
+
+      await controller.searchLibrarySuggestions(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new LibrarySearchSuggestionsQuery('user-303', 'music', [
+          'artist',
+          'album',
+          'track',
+          'playlist',
+          'genre',
+        ]),
+      );
+    });
+
+    it('should return empty array when no results found', async () => {
+      const queryDto = createMock<LibrarySearchSuggestionsQueryRequestDto>({
+        query: 'nonexistent',
+        categories: ['artist'],
+      });
+      const user: User = { id: 'user-404' } as User;
+      queryBus.execute.mockResolvedValue([]);
+
+      const result = await controller.searchLibrarySuggestions(queryDto, user);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/features/search/search.controller.spec.ts
+++ b/apps/api/src/features/search/search.controller.spec.ts
@@ -4,8 +4,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SearchSuggestionsQueryRequestDto } from './dto/search-suggestions-query.request.dto';
 import { LibrarySearchSuggestionsQueryRequestDto } from './dto/library-search-suggestions-query.request.dto';
+import { SearchQueryRequestDto } from './dto/search-query.request.dto';
 import { SearchSuggestionsQuery } from './queries/impl/search-suggestions.query';
 import { LibrarySearchSuggestionsQuery } from './queries/impl/library-search-suggestions.query';
+import { SearchQueryImpl } from './queries/impl/search.query';
 import { SearchController } from './search.controller';
 import type { User } from '@repo/db';
 
@@ -153,6 +155,115 @@ describe('SearchController', () => {
       const result = await controller.searchLibrarySuggestions(queryDto, user);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('search', () => {
+    it('should execute SearchQueryImpl with userId and full query DTO when user is authenticated', async () => {
+      const queryDto = createMock<SearchQueryRequestDto>({
+        query: 'beatles',
+        page: 1,
+        pageSize: 20,
+      });
+      const user: User = { id: 'user-123' } as User;
+      const expectedResult = {
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 20,
+        filters: null,
+        orderBy: null,
+      };
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.search(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new SearchQueryImpl('user-123', expect.objectContaining({ query: 'beatles' })),
+      );
+      expect(result).toBe(expectedResult);
+    });
+
+    it('should pass null userId when user is not authenticated', async () => {
+      const queryDto = createMock<SearchQueryRequestDto>({
+        query: 'rock',
+        page: 1,
+        pageSize: 20,
+      });
+      const expectedResult = {
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 20,
+        filters: null,
+        orderBy: null,
+      };
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      await controller.search(queryDto, null);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new SearchQueryImpl(null, expect.objectContaining({ query: 'rock' })),
+      );
+    });
+
+    it('should pass through filters and orderBy from DTO', async () => {
+      const queryDto = createMock<SearchQueryRequestDto>({
+        query: 'jazz',
+        filters: {
+          types: ['artist'],
+          visibility: 'public',
+        },
+        orderBy: {
+          field: 'name',
+          direction: 'desc',
+        },
+        page: 2,
+        pageSize: 10,
+      });
+      const user: User = { id: 'user-456' } as User;
+      queryBus.execute.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 2,
+        pageSize: 10,
+        filters: null,
+        orderBy: null,
+      });
+
+      await controller.search(queryDto, user);
+
+      expect(queryBus.execute).toHaveBeenCalledWith(
+        new SearchQueryImpl('user-456', expect.objectContaining({
+          query: 'jazz',
+          filters: expect.objectContaining({ types: ['artist'] }),
+          orderBy: expect.objectContaining({ field: 'name', direction: 'desc' }),
+          page: 2,
+          pageSize: 10,
+        })),
+      );
+    });
+
+    it('should return the result from queryBus.execute', async () => {
+      const queryDto = createMock<SearchQueryRequestDto>({
+        query: 'electronic',
+      });
+      const user: User = { id: 'user-789' } as User;
+      const expectedResult = {
+        data: [
+          { id: 'artist-1', name: 'Daft Punk', type: 'artist', visibility: 'public', score: 0.9 },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+        filters: null,
+        orderBy: null,
+      };
+      queryBus.execute.mockResolvedValue(expectedResult);
+
+      const result = await controller.search(queryDto, user);
+
+      expect(result).toBe(expectedResult);
     });
   });
 });

--- a/apps/api/src/features/search/search.controller.ts
+++ b/apps/api/src/features/search/search.controller.ts
@@ -34,6 +34,7 @@ export class SearchController {
   @ApiResponse({
     status: 401,
     description:
+      // TODO: Remove this when public and community visibilities are implemented
       'User token is required. Public and community visibilities are not implemented yet',
     type: ApiErrorResponseDto,
   })

--- a/apps/api/src/features/search/services/search-suggestions.service.spec.ts
+++ b/apps/api/src/features/search/services/search-suggestions.service.spec.ts
@@ -1,0 +1,217 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrismaService } from '@/shared/services/prisma.service';
+import { SearchSuggestionsService } from './search-suggestions.service';
+
+describe('SearchSuggestionsService', () => {
+  let service: SearchSuggestionsService;
+  let prismaService: DeepMocked<PrismaService>;
+
+  const mockQueryRaw = vi.fn().mockResolvedValue([]);
+  const mockExtendedClient = {
+    $queryRaw: mockQueryRaw,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExtendedClient.$queryRaw.mockReset();
+
+    prismaService = createMock<PrismaService>();
+    Object.defineProperty(prismaService, 'extended', {
+      get: () => mockExtendedClient,
+      configurable: true,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchSuggestionsService,
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile();
+
+    service = module.get<SearchSuggestionsService>(SearchSuggestionsService);
+  });
+
+  describe('searchSuggestions', () => {
+    it('should throw UnauthorizedException when userId is not provided', async () => {
+      await expect(service.searchSuggestions('test')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw BadRequestException when query is too short', async () => {
+      await expect(
+        service.searchSuggestions('ab', 'user-123'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when query is empty', async () => {
+      await expect(service.searchSuggestions('', 'user-123')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should return search results when query is valid', async () => {
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Test Artist',
+          type: 'artist',
+          visibility: 'public',
+          albumType: null,
+          score: 0.8,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.searchSuggestions('test', 'user-123');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('artist-1');
+      expect(result[0].name).toBe('Test Artist');
+      expect(result[0].type).toBe('artist');
+    });
+
+    it('should include albumType when present in results', async () => {
+      const mockResults = [
+        {
+          id: 'album-1',
+          name: 'Test Album',
+          type: 'album',
+          visibility: 'public',
+          albumType: 'album',
+          score: 0.7,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.searchSuggestions('album', 'user-123');
+
+      expect(result[0]).toHaveProperty('albumType', 'album');
+    });
+
+    it('should trim query before processing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      await service.searchSuggestions('  test  ', 'user-123');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+  });
+
+  describe('librarySearchSuggestions', () => {
+    it('should throw BadRequestException when query is too short', async () => {
+      await expect(
+        service.librarySearchSuggestions('user-123', 'ab'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when query is empty', async () => {
+      await expect(
+        service.librarySearchSuggestions('user-123', ''),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should return search results when query is valid', async () => {
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Library Artist',
+          type: 'artist',
+          visibility: 'private',
+          albumType: null,
+          score: 0.9,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.librarySearchSuggestions('user-123', 'artist');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('artist-1');
+      expect(result[0].name).toBe('Library Artist');
+      expect(result[0].type).toBe('artist');
+    });
+
+    it('should filter by artist category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['artist']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by album category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['album']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by track category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'track-1', name: 'Track', type: 'track', visibility: 'private', albumType: null, score: 0.6 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['track']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by playlist category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'playlist-1', name: 'Playlist', type: 'playlist', visibility: 'private', albumType: null, score: 0.5 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['playlist']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by genre category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'genre-1', name: 'Rock', type: 'genre', visibility: 'public', albumType: null, score: 0.4 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['genre']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should search all categories when no categories specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
+        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should return empty array when no results found', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      const result = await service.librarySearchSuggestions('user-123', 'nonexistent');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should trim query before processing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      await service.librarySearchSuggestions('user-123', '  test  ');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/features/search/services/search-suggestions.service.ts
+++ b/apps/api/src/features/search/services/search-suggestions.service.ts
@@ -1,0 +1,262 @@
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Prisma } from '@repo/db';
+import { PrismaService } from '@/shared/services/prisma.service';
+import type { LibrarySearchSuggestionsResults, SearchSuggestionsResults } from '@repo/contracts';
+import { AlbumType, Visibility } from '@repo/db';
+
+interface RawSearchResult {
+  id: string;
+  name: string;
+  type: 'artist' | 'album' | 'track' | 'playlist' | 'genre';
+  visibility: Visibility;
+  albumType: AlbumType | null;
+  score: number;
+  coverUrl: string | null;
+  avatarUrl: string | null;
+}
+
+@Injectable()
+export class SearchSuggestionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async searchSuggestions(query: string, userId?: string): Promise<SearchSuggestionsResults> {
+    if (!userId) {
+      throw new UnauthorizedException(
+        'User token is required. Public and community visibilities are not implemented yet',
+      );
+    }
+
+    if (!query || query.trim().length < 3) {
+      throw new BadRequestException('Query is too short or invalid');
+    }
+
+    const trimmedQuery = query.trim();
+    const searchPattern = `%${trimmedQuery}%`;
+
+    const results = await this.prisma.extended.$queryRaw<RawSearchResult[]>`
+      WITH unified_search AS (
+        SELECT a.id, a.name, 'artist' as type, a.visibility, NULL as "albumType", similarity(a.name, ${trimmedQuery}) as score,
+          NULL::text as "coverUrl",
+          avatar.url as "avatarUrl"
+        FROM "artists" a
+        LEFT JOIN "images" avatar ON a."avatarId" = avatar.id
+        WHERE (similarity(a.name, ${trimmedQuery}) > 0.15 OR a.name ILIKE ${searchPattern})
+        AND a."deletedAt" IS NULL
+        AND (
+          a.visibility = 'public'
+          OR (${userId}::text IS NOT NULL AND (
+            a.visibility = 'community'
+            OR EXISTS (SELECT 1 FROM "artist_access" aa WHERE aa."artistId" = a.id AND aa."userId" = ${userId})
+          ))
+        )
+
+        UNION ALL
+
+        SELECT al.id, al.name, 'album' as type, al.visibility, al.type as "albumType", similarity(al.name, ${trimmedQuery}) as score,
+          cover.url as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "albums" al
+        LEFT JOIN "images" cover ON al."coverId" = cover.id
+        WHERE (similarity(al.name, ${trimmedQuery}) > 0.15 OR al.name ILIKE ${searchPattern})
+        AND al."deletedAt" IS NULL
+        AND (
+          al.visibility = 'public'
+          OR (${userId}::text IS NOT NULL AND (
+            al.visibility = 'community'
+            OR EXISTS (SELECT 1 FROM "album_access" ala WHERE ala."albumId" = al.id AND ala."userId" = ${userId})
+          ))
+        )
+
+        UNION ALL
+
+        SELECT t.id, t.title as name, 'track' as type, t.visibility, NULL as "albumType", similarity(t.title, ${trimmedQuery}) as score,
+          cover.url as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "tracks" t
+        LEFT JOIN "albums" al ON t."albumId" = al.id
+        LEFT JOIN "images" cover ON al."coverId" = cover.id
+        WHERE (similarity(t.title, ${trimmedQuery}) > 0.15 OR t.title ILIKE ${searchPattern})
+        AND t."deletedAt" IS NULL
+        AND (
+          t.visibility = 'public'
+          OR (${userId}::text IS NOT NULL AND (
+            t.visibility = 'community'
+            OR EXISTS (SELECT 1 FROM "track_access" ta WHERE ta."trackId" = t.id AND ta."userId" = ${userId})
+          ))
+        )
+
+        UNION ALL
+
+         SELECT p.id, p.name, 'playlist' as type,
+           CASE WHEN p."isPublic" = true THEN 'public'::"Visibility" ELSE 'private'::"Visibility" END as visibility,
+           NULL as "albumType", similarity(p.name, ${trimmedQuery}) as score,
+           cover.url as "coverUrl",
+           NULL::text as "avatarUrl"
+        FROM "playlists" p
+        LEFT JOIN "images" cover ON p."coverId" = cover.id
+        WHERE (p.name % ${trimmedQuery} OR p.name ILIKE ${searchPattern})
+        AND p."deletedAt" IS NULL
+        AND (
+          p."isPublic" = true
+          OR (${userId}::text IS NOT NULL AND EXISTS (
+            SELECT 1 FROM "libraries" l WHERE l.id = p."libraryId" AND l."userId" = ${userId}
+          ))
+        )
+
+        UNION ALL
+
+        SELECT g.id, g.name, 'genre' as type, 'public'::"Visibility" as visibility, NULL as "albumType", similarity(g.name, ${trimmedQuery}) as score,
+          NULL::text as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "genres" g
+        WHERE (similarity(g.name, ${trimmedQuery}) > 0.15 OR g.name ILIKE ${searchPattern})
+        AND g."deletedAt" IS NULL
+      )
+      SELECT id, name, type, visibility, "albumType", score, "coverUrl", "avatarUrl"
+      FROM unified_search
+      ORDER BY score DESC
+      LIMIT 8
+    `;
+
+    return results.map((r: RawSearchResult) => ({
+      id: r.id,
+      name: r.name,
+      type: r.type,
+      coverURL: r.coverUrl,
+      avatarURL: r.avatarUrl,
+      visibility: r.visibility,
+      ...(r.albumType ? { albumType: r.albumType } : {}),
+    }));
+  }
+
+  async librarySearchSuggestions(
+    userId: string,
+    query: string,
+    types?: ('artist' | 'album' | 'track' | 'playlist' | 'genre')[],
+  ): Promise<LibrarySearchSuggestionsResults> {
+    if (!query || query.trim().length < 3) {
+      throw new BadRequestException('Query is too short or invalid');
+    }
+
+    const trimmedQuery = query.trim();
+    const searchPattern = `%${trimmedQuery}%`;
+    const targetTypes = types ?? ['artist', 'album', 'track', 'playlist', 'genre'];
+
+    const queryParts: Prisma.Sql[] = [];
+    let needsUnionAll = false;
+
+    if (targetTypes.includes('artist')) {
+      queryParts.push(Prisma.sql`
+        SELECT la."artistId" as id, a.name, 'artist' as type, 'private'::"Visibility" as visibility, NULL as "albumType", similarity(a.name, ${trimmedQuery}) as score,
+          NULL::text as "coverUrl",
+          avatar.url as "avatarUrl"
+        FROM "library_artists" la
+        JOIN "artists" a ON la."artistId" = a.id
+        LEFT JOIN "images" avatar ON a."avatarId" = avatar.id
+        WHERE la."libraryId" = (SELECT id FROM user_library)
+        AND (similarity(a.name, ${trimmedQuery}) > 0.15 OR a.name ILIKE ${searchPattern})
+        AND a."deletedAt" IS NULL
+      `);
+      needsUnionAll = true;
+    }
+
+    if (targetTypes.includes('album')) {
+      if (needsUnionAll) {
+        queryParts.push(Prisma.sql` UNION ALL `);
+      }
+      queryParts.push(Prisma.sql`
+        SELECT lb."albumId" as id, al.name, 'album' as type, 'private'::"Visibility" as visibility, al.type as "albumType", similarity(al.name, ${trimmedQuery}) as score,
+          cover.url as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "library_albums" lb
+        JOIN "albums" al ON lb."albumId" = al.id
+        LEFT JOIN "images" cover ON al."coverId" = cover.id
+        WHERE lb."libraryId" = (SELECT id FROM user_library)
+        AND (similarity(al.name, ${trimmedQuery}) > 0.15 OR al.name ILIKE ${searchPattern})
+        AND al."deletedAt" IS NULL
+      `);
+      needsUnionAll = true;
+    }
+
+    if (targetTypes.includes('track')) {
+      if (needsUnionAll) {
+        queryParts.push(Prisma.sql` UNION ALL `);
+      }
+      queryParts.push(Prisma.sql`
+        SELECT lt."trackId" as id, t.title as name, 'track' as type, 'private'::"Visibility" as visibility, NULL as "albumType", similarity(t.title, ${trimmedQuery}) as score,
+          cover.url as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "library_tracks" lt
+        JOIN "tracks" t ON lt."trackId" = t.id
+        LEFT JOIN "albums" al ON t."albumId" = al.id
+        LEFT JOIN "images" cover ON al."coverId" = cover.id
+        WHERE lt."libraryId" = (SELECT id FROM user_library)
+        AND (similarity(t.title, ${trimmedQuery}) > 0.15 OR t.title ILIKE ${searchPattern})
+        AND t."deletedAt" IS NULL
+      `);
+      needsUnionAll = true;
+    }
+
+    if (targetTypes.includes('playlist')) {
+      if (needsUnionAll) {
+        queryParts.push(Prisma.sql` UNION ALL `);
+      }
+      queryParts.push(Prisma.sql`
+        SELECT p.id, p.name, 'playlist' as type, 'private'::"Visibility" as visibility, NULL as "albumType", similarity(p.name, ${trimmedQuery}) as score,
+          cover.url as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "playlists" p
+        LEFT JOIN "images" cover ON p."coverId" = cover.id
+        WHERE p."libraryId" = (SELECT id FROM user_library)
+        AND (similarity(p.name, ${trimmedQuery}) > 0.15 OR p.name ILIKE ${searchPattern})
+        AND p."deletedAt" IS NULL
+      `);
+      needsUnionAll = true;
+    }
+
+    if (targetTypes.includes('genre')) {
+      if (needsUnionAll) {
+        queryParts.push(Prisma.sql` UNION ALL `);
+      }
+      queryParts.push(Prisma.sql`
+        SELECT g.id, g.name, 'genre' as type, 'private'::"Visibility" as visibility, NULL as "albumType", similarity(g.name, ${trimmedQuery}) as score,
+          NULL::text as "coverUrl",
+          NULL::text as "avatarUrl"
+        FROM "genres" g
+        WHERE (g."libraryId" = (SELECT id FROM user_library) OR g."libraryId" IS NULL)
+        AND (similarity(g.name, ${trimmedQuery}) > 0.15 OR g.name ILIKE ${searchPattern})
+        AND g."deletedAt" IS NULL
+      `);
+      needsUnionAll = true;
+    }
+
+    if (queryParts.length === 0) {
+      return [];
+    }
+
+    const combinedQuery = Prisma.join(queryParts, '');
+
+    const results = await this.prisma.extended.$queryRaw<RawSearchResult[]>`
+      WITH user_library AS (
+        SELECT id FROM "libraries" WHERE "userId" = ${userId}
+      ),
+      library_items AS (
+        ${combinedQuery}
+      )
+      SELECT id, name, type, visibility, "albumType", score, "coverUrl", "avatarUrl"
+      FROM library_items
+      ORDER BY score DESC
+      LIMIT 20
+    `;
+
+    return results.map((r: RawSearchResult) => ({
+      id: r.id,
+      name: r.name,
+      type: r.type,
+      coverURL: r.coverUrl,
+      avatarURL: r.avatarUrl,
+      visibility: r.visibility,
+      ...(r.albumType ? { albumType: r.albumType } : {}),
+    }));
+  }
+}

--- a/apps/api/src/features/search/services/search.service.spec.ts
+++ b/apps/api/src/features/search/services/search.service.spec.ts
@@ -1,0 +1,215 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock, DeepMocked } from '@repo/testing/nestjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrismaService } from '@/shared/services/prisma.service';
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let prismaService: DeepMocked<PrismaService>;
+
+  const mockQueryRaw = vi.fn().mockResolvedValue([]);
+  const mockExtendedClient = {
+    $queryRaw: mockQueryRaw,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExtendedClient.$queryRaw.mockReset();
+
+    prismaService = createMock<PrismaService>();
+    Object.defineProperty(prismaService, 'extended', {
+      get: () => mockExtendedClient,
+      configurable: true,
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile();
+
+    service = module.get<SearchService>(SearchService);
+  });
+
+  describe('searchSuggestions', () => {
+    it('should throw UnauthorizedException when userId is not provided', async () => {
+      await expect(service.searchSuggestions('test')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw BadRequestException when query is too short', async () => {
+      await expect(
+        service.searchSuggestions('ab', 'user-123'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when query is empty', async () => {
+      await expect(service.searchSuggestions('', 'user-123')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should return search results when query is valid', async () => {
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Test Artist',
+          type: 'artist',
+          visibility: 'public',
+          albumType: null,
+          score: 0.8,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.searchSuggestions('test', 'user-123');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('artist-1');
+      expect(result[0].name).toBe('Test Artist');
+      expect(result[0].type).toBe('artist');
+    });
+
+    it('should include albumType when present in results', async () => {
+      const mockResults = [
+        {
+          id: 'album-1',
+          name: 'Test Album',
+          type: 'album',
+          visibility: 'public',
+          albumType: 'album',
+          score: 0.7,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.searchSuggestions('album', 'user-123');
+
+      expect(result[0]).toHaveProperty('albumType', 'album');
+    });
+
+    it('should trim query before processing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      await service.searchSuggestions('  test  ', 'user-123');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+  });
+
+  describe('librarySearchSuggestions', () => {
+    it('should throw BadRequestException when query is too short', async () => {
+      await expect(
+        service.librarySearchSuggestions('user-123', 'ab'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when query is empty', async () => {
+      await expect(
+        service.librarySearchSuggestions('user-123', ''),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should return search results when query is valid', async () => {
+      const mockResults = [
+        {
+          id: 'artist-1',
+          name: 'Library Artist',
+          type: 'artist',
+          visibility: 'private',
+          albumType: null,
+          score: 0.9,
+        },
+      ];
+      mockQueryRaw.mockResolvedValueOnce(mockResults);
+
+      const result = await service.librarySearchSuggestions('user-123', 'artist');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('artist-1');
+      expect(result[0].name).toBe('Library Artist');
+      expect(result[0].type).toBe('artist');
+    });
+
+    it('should filter by artist category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['artist']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by album category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['album']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by track category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'track-1', name: 'Track', type: 'track', visibility: 'private', albumType: null, score: 0.6 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['track']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by playlist category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'playlist-1', name: 'Playlist', type: 'playlist', visibility: 'private', albumType: null, score: 0.5 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['playlist']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should filter by genre category when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'genre-1', name: 'Rock', type: 'genre', visibility: 'public', albumType: null, score: 0.4 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test', ['genre']);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should search all categories when no categories specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([
+        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
+        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
+      ]);
+
+      await service.librarySearchSuggestions('user-123', 'test');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should return empty array when no results found', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      const result = await service.librarySearchSuggestions('user-123', 'nonexistent');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should trim query before processing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+
+      await service.librarySearchSuggestions('user-123', '  test  ');
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/features/search/services/search.service.spec.ts
+++ b/apps/api/src/features/search/services/search.service.spec.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrismaService } from '@/shared/services/prisma.service';
 import { SearchService } from './search.service';
+import type { SearchQuery } from '@repo/contracts';
 
 describe('SearchService', () => {
   let service: SearchService;
@@ -34,24 +35,24 @@ describe('SearchService', () => {
     service = module.get<SearchService>(SearchService);
   });
 
-  describe('searchSuggestions', () => {
-    it('should throw UnauthorizedException when userId is not provided', async () => {
-      await expect(service.searchSuggestions('test')).rejects.toThrow(UnauthorizedException);
-    });
-
+  describe('search', () => {
     it('should throw BadRequestException when query is too short', async () => {
-      await expect(
-        service.searchSuggestions('ab', 'user-123'),
-      ).rejects.toThrow(BadRequestException);
-    });
+      const searchQuery: SearchQuery = { query: 'a', page: 1, pageSize: 20 };
 
-    it('should throw BadRequestException when query is empty', async () => {
-      await expect(service.searchSuggestions('', 'user-123')).rejects.toThrow(
+      await expect(service.search('user-123', searchQuery)).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('should return search results when query is valid', async () => {
+    it('should throw BadRequestException when query is empty', async () => {
+      const searchQuery: SearchQuery = { query: '', page: 1, pageSize: 20 };
+
+      await expect(service.search('user-123', searchQuery)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should return results with pagination metadata for authenticated user', async () => {
       const mockResults = [
         {
           id: 'artist-1',
@@ -59,155 +60,236 @@ describe('SearchService', () => {
           type: 'artist',
           visibility: 'public',
           albumType: null,
-          score: 0.8,
+          score: 0.9,
         },
-      ];
-      mockQueryRaw.mockResolvedValueOnce(mockResults);
-
-      const result = await service.searchSuggestions('test', 'user-123');
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('artist-1');
-      expect(result[0].name).toBe('Test Artist');
-      expect(result[0].type).toBe('artist');
-    });
-
-    it('should include albumType when present in results', async () => {
-      const mockResults = [
         {
           id: 'album-1',
           name: 'Test Album',
           type: 'album',
           visibility: 'public',
           albumType: 'album',
-          score: 0.7,
+          score: 0.8,
         },
       ];
-      mockQueryRaw.mockResolvedValueOnce(mockResults);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(2) }]); // count query
+      mockQueryRaw.mockResolvedValueOnce(mockResults);              // results query
 
-      const result = await service.searchSuggestions('album', 'user-123');
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        page: 1,
+        pageSize: 20,
+      };
+      const result = await service.search('user-123', searchQuery);
 
-      expect(result[0]).toHaveProperty('albumType', 'album');
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+      expect(result.pageSize).toBe(20);
+      expect(result.data[0].id).toBe('artist-1');
+      expect(result.data[1].id).toBe('album-1');
     });
 
-    it('should trim query before processing', async () => {
-      mockQueryRaw.mockResolvedValueOnce([]);
-
-      await service.searchSuggestions('  test  ', 'user-123');
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-  });
-
-  describe('librarySearchSuggestions', () => {
-    it('should throw BadRequestException when query is too short', async () => {
-      await expect(
-        service.librarySearchSuggestions('user-123', 'ab'),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('should throw BadRequestException when query is empty', async () => {
-      await expect(
-        service.librarySearchSuggestions('user-123', ''),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('should return search results when query is valid', async () => {
+    it('should return only public results when userId is null (unauthenticated)', async () => {
       const mockResults = [
         {
           id: 'artist-1',
-          name: 'Library Artist',
+          name: 'Public Artist',
           type: 'artist',
-          visibility: 'private',
+          visibility: 'public',
           albumType: null,
           score: 0.9,
         },
       ];
-      mockQueryRaw.mockResolvedValueOnce(mockResults);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(1) }]); // count query
+      mockQueryRaw.mockResolvedValueOnce(mockResults);              // results query
 
-      const result = await service.librarySearchSuggestions('user-123', 'artist');
+      const searchQuery: SearchQuery = {
+        query: 'public',
+        page: 1,
+        pageSize: 20,
+      };
+      const result = await service.search(null, searchQuery);
 
-      expect(mockQueryRaw).toHaveBeenCalled();
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('artist-1');
-      expect(result[0].name).toBe('Library Artist');
-      expect(result[0].type).toBe('artist');
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
     });
 
-    it('should filter by artist category when specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test', ['artist']);
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should filter by album category when specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test', ['album']);
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should filter by track category when specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'track-1', name: 'Track', type: 'track', visibility: 'private', albumType: null, score: 0.6 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test', ['track']);
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should filter by playlist category when specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'playlist-1', name: 'Playlist', type: 'playlist', visibility: 'private', albumType: null, score: 0.5 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test', ['playlist']);
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should filter by genre category when specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'genre-1', name: 'Rock', type: 'genre', visibility: 'public', albumType: null, score: 0.4 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test', ['genre']);
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should search all categories when no categories specified', async () => {
-      mockQueryRaw.mockResolvedValueOnce([
-        { id: 'artist-1', name: 'Artist', type: 'artist', visibility: 'private', albumType: null, score: 0.8 },
-        { id: 'album-1', name: 'Album', type: 'album', visibility: 'private', albumType: 'album', score: 0.7 },
-      ]);
-
-      await service.librarySearchSuggestions('user-123', 'test');
-
-      expect(mockQueryRaw).toHaveBeenCalled();
-    });
-
-    it('should return empty array when no results found', async () => {
+    it('should apply type filter when specified', async () => {
       mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
 
-      const result = await service.librarySearchSuggestions('user-123', 'nonexistent');
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { types: ['artist'] },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
 
-      expect(result).toEqual([]);
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply visibility filter when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { visibility: 'public' },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply artist verified filter when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { artist: { verified: true } },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply album type filter when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { album: { type: 'single' } },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply track explicit filter when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { track: { explicit: false } },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply playlist isPublic filter when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { playlist: { isPublic: true } },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should apply orderBy when specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        orderBy: { field: 'name', direction: 'desc' },
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should echo back filters and orderBy in the response', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        filters: { types: ['track'] },
+        orderBy: { field: 'duration', direction: 'desc' },
+        page: 1,
+        pageSize: 20,
+      };
+      const result = await service.search('user-123', searchQuery);
+
+      expect(result.filters).toEqual({ types: ['track'] });
+      expect(result.orderBy).toEqual({ field: 'duration', direction: 'desc' });
+    });
+
+    it('should return null filters and orderBy when not specified', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        page: 1,
+        pageSize: 20,
+      };
+      const result = await service.search('user-123', searchQuery);
+
+      expect(result.filters).toBeNull();
+      expect(result.orderBy).toBeNull();
+    });
+
+    it('should apply pagination with offset', async () => {
+      mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(100) }]);
+
+      const searchQuery: SearchQuery = {
+        query: 'test',
+        page: 3,
+        pageSize: 10,
+      };
+      await service.search('user-123', searchQuery);
+
+      expect(mockQueryRaw).toHaveBeenCalled();
+    });
+
+    it('should return empty data array when no results found', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]); // count query
+      mockQueryRaw.mockResolvedValueOnce([]);                       // results query
+
+      const searchQuery: SearchQuery = {
+        query: 'nonexistent',
+        page: 1,
+        pageSize: 20,
+      };
+      const result = await service.search('user-123', searchQuery);
+
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
     });
 
     it('should trim query before processing', async () => {
       mockQueryRaw.mockResolvedValueOnce([]);
+      mockQueryRaw.mockResolvedValueOnce([{ total: BigInt(0) }]);
 
-      await service.librarySearchSuggestions('user-123', '  test  ');
+      const searchQuery: SearchQuery = {
+        query: '  test  ',
+        page: 1,
+        pageSize: 20,
+      };
+      await service.search('user-123', searchQuery);
 
       expect(mockQueryRaw).toHaveBeenCalled();
     });

--- a/apps/api/src/features/search/services/search.service.ts
+++ b/apps/api/src/features/search/services/search.service.ts
@@ -189,10 +189,6 @@ export class SearchService {
       `);
     }
 
-    if (queryParts.length === 0) {
-      queryParts.push(Prisma.sql`SELECT NULL as id, NULL as name, NULL as type, NULL as visibility, NULL as "albumType", 0 as score WHERE 1=0`);
-    }
-
     const combinedQuery = Prisma.join(queryParts, '');
 
     const results = await this.prisma.extended.$queryRaw<RawSearchResult[]>`

--- a/apps/api/src/shared/guards/jwt-auth-for-search.guard.spec.ts
+++ b/apps/api/src/shared/guards/jwt-auth-for-search.guard.spec.ts
@@ -1,0 +1,43 @@
+import { JwtAuthGuardForSearch } from './jwt-auth-for-search.guard';
+
+describe('JwtAuthGuardForSearch', () => {
+  let guard: JwtAuthGuardForSearch;
+
+  beforeEach(() => {
+    guard = new JwtAuthGuardForSearch();
+  });
+
+  describe('handleRequest', () => {
+    it('should return null if there is an error', () => {
+      const err = new Error('some error');
+      const user = null;
+      expect(guard.handleRequest(err, user)).toBeNull();
+    });
+
+    it('should return null if there is no user', () => {
+      const err = null;
+      const user = undefined;
+      expect(guard.handleRequest(err, user)).toBeNull();
+    });
+
+    it('should return user if there is no error and user exists', () => {
+      const err = null;
+      const user = { id: 1, email: 'test@example.com' };
+      expect(guard.handleRequest(err, user)).toEqual(user);
+    });
+
+    it('should return null if error is present even when user exists', () => {
+      const err = new Error('some error');
+      const user = { id: 1 };
+      expect(guard.handleRequest(err, user)).toBeNull();
+    });
+
+    it('should return null for various falsy user values when no error', () => {
+      const err = null;
+      const falsyValues = [null, undefined, false, 0, '', NaN];
+      for (const userValue of falsyValues) {
+        expect(guard.handleRequest(err, userValue)).toBeNull();
+      }
+    });
+  });
+});

--- a/apps/api/src/shared/services/prisma.service.spec.ts
+++ b/apps/api/src/shared/services/prisma.service.spec.ts
@@ -1,6 +1,6 @@
 import { createMock, DeepMocked } from '@repo/testing/nestjs';
 import { Test, TestingModule } from '@nestjs/testing';
-import { createPrismaClient } from '@repo/db';
+import { createPrismaClient, createExtendedPrismaClient } from '@repo/db';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   TRANSACTION_CONTEXT,
@@ -14,6 +14,7 @@ vi.mock('@repo/db', async () => {
   return {
     ...actual,
     createPrismaClient: vi.fn(),
+    createExtendedPrismaClient: vi.fn(),
   };
 });
 
@@ -21,6 +22,7 @@ describe('PrismaService', () => {
   let service: PrismaService;
   let transactionContext: DeepMocked<ITransactionContext>;
   let mockPrismaClient: any;
+  let mockExtendedPrismaClient: any;
   const originalEnv = process.env;
 
   beforeEach(async () => {
@@ -34,7 +36,13 @@ describe('PrismaService', () => {
       $transaction: vi.fn().mockImplementation((cb) => cb('mock-tx')),
     };
 
+    mockExtendedPrismaClient = {
+      $connect: vi.fn().mockResolvedValue(undefined),
+      $disconnect: vi.fn().mockResolvedValue(undefined),
+    };
+
     (createPrismaClient as any).mockReturnValue(mockPrismaClient);
+    (createExtendedPrismaClient as any).mockReturnValue(mockExtendedPrismaClient);
     transactionContext = createMock<ITransactionContext>();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -61,21 +69,24 @@ describe('PrismaService', () => {
     );
   });
 
-  it('should call createPrismaClient with DATABASE_URL', () => {
+  it('should call createPrismaClient and createExtendedPrismaClient with DATABASE_URL', () => {
     expect(createPrismaClient).toHaveBeenCalledWith(process.env.DATABASE_URL);
+    expect(createExtendedPrismaClient).toHaveBeenCalledWith(process.env.DATABASE_URL);
   });
 
   describe('onModuleInit', () => {
-    it('should call prisma.$connect', async () => {
+    it('should call prisma.$connect on both clients', async () => {
       await service.onModuleInit();
       expect(mockPrismaClient.$connect).toHaveBeenCalled();
+      expect(mockExtendedPrismaClient.$connect).toHaveBeenCalled();
     });
   });
 
   describe('onModuleDestroy', () => {
-    it('should call prisma.$disconnect', async () => {
+    it('should call prisma.$disconnect on both clients', async () => {
       await service.onModuleDestroy();
       expect(mockPrismaClient.$disconnect).toHaveBeenCalled();
+      expect(mockExtendedPrismaClient.$disconnect).toHaveBeenCalled();
     });
   });
 
@@ -93,6 +104,12 @@ describe('PrismaService', () => {
 
       expect(service.client).toBe(mockPrismaClient);
       expect(transactionContext.getTransactionalClient).toHaveBeenCalled();
+    });
+  });
+
+  describe('extended', () => {
+    it('should return the extended prisma client', () => {
+      expect(service.extended).toBe(mockExtendedPrismaClient);
     });
   });
 

--- a/packages/contracts/src/search/index.ts
+++ b/packages/contracts/src/search/index.ts
@@ -1,4 +1,6 @@
 export * from "./request/search-suggestions-query.request";
 export * from "./request/library-search-suggestions-query.request";
+export * from "./request/search-query.request";
 export * from "./response/search-suggestions-results.response";
 export * from "./response/library-search-suggestions-results.response";
+export * from "./response/search-results.response";

--- a/packages/contracts/src/search/request/search-query.request.ts
+++ b/packages/contracts/src/search/request/search-query.request.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { Visibility, AlbumType } from "@repo/db";
+
+// ─── Entity type filter ───────────────────────────────────────────
+
+export const SearchTypeSchema = z.enum([
+  "artist",
+  "album",
+  "track",
+  "playlist",
+]);
+
+// ─── Visibility filter ────────────────────────────────────────────
+
+export const SearchVisibilitySchema = z.enum(Visibility);
+
+// ─── Order-by field ───────────────────────────────────────────────
+
+export const SearchOrderByFieldSchema = z.enum([
+  "relevance",
+  "name",
+  "createdAt",
+  "releaseDate",
+  "duration",
+  "listenedCount",
+  "isPublic",
+  "isCollaborative",
+]);
+
+export const SearchOrderByDirectionSchema = z.enum(["asc", "desc"]);
+
+export const SearchOrderBySchema = z.object({
+  field: SearchOrderByFieldSchema,
+  direction: SearchOrderByDirectionSchema.default("asc"),
+});
+
+// ─── Artist-specific filters ──────────────────────────────────────
+
+export const SearchArtistFiltersSchema = z.object({
+  verified: z.boolean().optional(),
+  isCommunity: z.boolean().optional(),
+});
+
+// ─── Album-specific filters ───────────────────────────────────────
+
+export const SearchAlbumFiltersSchema = z.object({
+  type: z.enum(AlbumType).optional(),
+  releaseDateFrom: z.string().datetime().optional(),
+  releaseDateTo: z.string().datetime().optional(),
+});
+
+// ─── Track-specific filters ───────────────────────────────────────
+
+export const SearchTrackFiltersSchema = z.object({
+  explicit: z.boolean().optional(),
+  durationFrom: z.coerce.number().int().nonnegative().optional(),
+  durationTo: z.coerce.number().int().nonnegative().optional(),
+  minListenedCount: z.coerce.number().int().nonnegative().optional(),
+});
+
+// ─── Playlist-specific filters ────────────────────────────────────
+
+export const SearchPlaylistFiltersSchema = z.object({
+  isPublic: z.boolean().optional(),
+  isCollaborative: z.boolean().optional(),
+});
+
+// ─── Top-level filters bag ────────────────────────────────────────
+
+export const SearchFiltersSchema = z.object({
+  types: z
+    .union([SearchTypeSchema, z.array(SearchTypeSchema)])
+    .transform((val) => (Array.isArray(val) ? val : val ? [val] : undefined))
+    .optional(),
+
+  visibility: SearchVisibilitySchema.optional(),
+
+  artist: SearchArtistFiltersSchema.optional(),
+  album: SearchAlbumFiltersSchema.optional(),
+  track: SearchTrackFiltersSchema.optional(),
+  playlist: SearchPlaylistFiltersSchema.optional(),
+});
+
+// ─── Main search query schema ─────────────────────────────────────
+
+export const SearchQuerySchema = z.object({
+  query: z
+    .string()
+    .min(3, "Query must be at least 3 characters long")
+    .optional(),
+
+  filters: SearchFiltersSchema.optional(),
+
+  orderBy: SearchOrderBySchema.optional(),
+
+  page: z.coerce.number().int().positive().default(1),
+
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export type SearchQuery = z.infer<typeof SearchQuerySchema>;
+export type SearchType = z.infer<typeof SearchTypeSchema>;
+export type SearchVisibility = z.infer<typeof SearchVisibilitySchema>;
+export type SearchOrderByField = z.infer<typeof SearchOrderByFieldSchema>;
+export type SearchOrderByDirection = z.infer<
+  typeof SearchOrderByDirectionSchema
+>;
+export type SearchOrderBy = z.infer<typeof SearchOrderBySchema>;
+export type SearchArtistFilters = z.infer<typeof SearchArtistFiltersSchema>;
+export type SearchAlbumFilters = z.infer<typeof SearchAlbumFiltersSchema>;
+export type SearchTrackFilters = z.infer<typeof SearchTrackFiltersSchema>;
+export type SearchPlaylistFilters = z.infer<typeof SearchPlaylistFiltersSchema>;
+export type SearchFilters = z.infer<typeof SearchFiltersSchema>;

--- a/packages/contracts/src/search/response/search-results.response.ts
+++ b/packages/contracts/src/search/response/search-results.response.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { Visibility, AlbumType } from "@repo/db";
+import {
+  SearchFiltersSchema,
+  SearchOrderBySchema,
+} from "../request/search-query.request";
+
+// ─── Base fields shared by every result item ───────────────────────
+// Mirrors SearchSuggestionResultSchema but adds `score` (relevance)
+// so the client can optionally re-sort client-side.
+
+export const SearchResultBaseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(), // discriminated at union level
+  visibility: z.enum(Visibility),
+  albumType: z.enum(AlbumType).nullable().optional(),
+  score: z.number(),
+});
+
+// ─── Per-entity result schemas ─────────────────────────────────────
+
+export const SearchArtistResultSchema = SearchResultBaseSchema.extend({
+  type: z.literal("artist"),
+  verified: z.boolean(),
+  isCommunity: z.boolean(),
+  description: z.string().nullable().optional(),
+  avatarUrl: z.string().nullable().optional(),
+});
+
+export const SearchAlbumResultSchema = SearchResultBaseSchema.extend({
+  type: z.literal("album"),
+  albumType: z.enum(AlbumType),
+  releaseDate: z.string().datetime().nullable().optional(),
+  totalTracks: z.number().int().nonnegative(),
+  totalDuration: z.number().int().nonnegative(),
+  description: z.string().nullable().optional(),
+  coverUrl: z.string().nullable().optional(),
+});
+
+export const SearchTrackResultSchema = SearchResultBaseSchema.extend({
+  type: z.literal("track"),
+  duration: z.number().int().nonnegative(),
+  trackNumber: z.number().int().nonnegative(),
+  diskNumber: z.number().int().nonnegative(),
+  explicit: z.boolean(),
+  listenedCount: z.number().int().nonnegative(),
+  albumId: z.string(),
+  lyrics: z.string().nullable().optional(),
+  coverUrl: z.string().nullable().optional(),
+});
+
+export const SearchPlaylistResultSchema = SearchResultBaseSchema.extend({
+  type: z.literal("playlist"),
+  isPublic: z.boolean(),
+  description: z.string().nullable().optional(),
+  trackCount: z.number().int().nonnegative().optional(),
+  coverUrl: z.string().nullable().optional(),
+});
+
+// ─── Discriminated union of all result types ───────────────────────
+
+export const SearchResultItemSchema = z.discriminatedUnion("type", [
+  SearchArtistResultSchema,
+  SearchAlbumResultSchema,
+  SearchTrackResultSchema,
+  SearchPlaylistResultSchema,
+]);
+
+// ─── Paginated search response ─────────────────────────────────────
+// `data` – flat array of mixed-type results (like suggestions)
+// Echoes back the active `filters` and `orderBy` so the client can
+// reconstruct the current UI state without reparsing the request.
+
+export const SearchResultsResponseSchema = z.object({
+  data: z.array(SearchResultItemSchema),
+
+  // ── pagination ────────────────────────────────────────────────
+  total: z.number().int().nonnegative(),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().positive(),
+
+  // ── echo of the request state ─────────────────────────────────
+  filters: SearchFiltersSchema.nullable(),
+  orderBy: SearchOrderBySchema.nullable(),
+});
+
+export type SearchResultItem = z.infer<typeof SearchResultItemSchema>;
+export type SearchArtistResult = z.infer<typeof SearchArtistResultSchema>;
+export type SearchAlbumResult = z.infer<typeof SearchAlbumResultSchema>;
+export type SearchTrackResult = z.infer<typeof SearchTrackResultSchema>;
+export type SearchPlaylistResult = z.infer<typeof SearchPlaylistResultSchema>;
+export type SearchResultsResponse = z.infer<typeof SearchResultsResponseSchema>;

--- a/packages/contracts/src/search/response/search-suggestions-results.response.ts
+++ b/packages/contracts/src/search/response/search-suggestions-results.response.ts
@@ -13,6 +13,8 @@ export const SearchSuggestionResultSchema = z.object({
   id: z.string(),
   name: z.string(),
   type: z.enum(SearchResultType),
+  coverURL: z.string().nullable().optional(),
+  avatarURL: z.string().nullable().optional(),
   visibility: z.enum(Visibility),
   albumType: z.enum(AlbumType).nullable().optional(),
 });

--- a/packages/contracts/src/search/response/search-suggestions-results.response.ts
+++ b/packages/contracts/src/search/response/search-suggestions-results.response.ts
@@ -6,6 +6,7 @@ export enum SearchResultType {
   Album = "album",
   Track = "track",
   Playlist = "playlist",
+  Genre = "genre",
 }
 
 export const SearchSuggestionResultSchema = z.object({


### PR DESCRIPTION
tests(apps/api): add tests for search suggestions

fix(apps/api): fix prisma client tests to work with new extended prisma client using pg extensions

fix(packages/contracts): fix search response schema

tests(apps/api): add tests for special auth guard for search

tests(apps/api): delete unreachable fallback in search service

tests(apps/api): add integration tests for search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search suggestions across artists, albums, tracks, playlists, and genres.
  * Advanced search with filtering, sorting, and pagination.
  * Library-scoped suggestions with category filtering.
  * Results may include cover and avatar URLs; genres added to suggestion/result types.

* **Tests**
  * Extensive integration and unit tests for search controllers, services, handlers, and auth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->