### PR TITLE
fix: improve logout reliability and standardize refresh error handling

### DIFF
--- a/apps/e2e/src/web/auth-edge-cases.spec.ts
+++ b/apps/e2e/src/web/auth-edge-cases.spec.ts
@@ -217,4 +217,176 @@ test.describe("Auth Edge Cases", () => {
     // Should be redirected to login
     await expect(page).toHaveURL(/\/auth\/login/);
   });
+
+  test("should clean up local session and redirect even if server logout fails", async ({
+    page,
+  }) => {
+    // 1. Create a user first to have a valid session
+    const timestamp = Date.now();
+    const user = {
+      username: `logout_fail_${timestamp}`,
+      email: `logout_fail_${timestamp}@example.com`,
+      password: "Password123!",
+    };
+
+    await registrationPage.goto();
+    await registrationPage.fillForm({
+      username: user.username,
+      firstName: "Logout",
+      lastName: "Tester",
+      email: user.email,
+      password: user.password,
+      confirmPassword: user.password,
+    });
+    await registrationPage.selectGender("Male");
+    await registrationPage.selectBirthDate(new Date(1990, 5, 15));
+    await registrationPage.submit();
+    await registrationPage.expectSuccess();
+
+    // Retrieve OTP and verify
+    const otpCode = await getOtpFromMailhog(user.email);
+    expect(otpCode).not.toBeNull();
+    await verifyEmailPage.fillOtpCode(otpCode!);
+    await verifyEmailPage.clickVerify();
+
+    // Verify redirected to app
+    await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+
+    // 2. Intercept logout API and force it to return a 500 error
+    await page.route("**/auth/logout", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Internal Server Error" }),
+      });
+    });
+
+    // 3. Trigger logout
+    await dashboardPage.logout();
+
+    // 4. Assert client still logs out and redirects to login
+    await expect(page).toHaveURL(/\/auth\/login/);
+
+    // 5. Try to navigate back to a protected route and verify we are redirected back to login
+    await page.goto("/app/library/overview");
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+
+  test("should clean up local session and redirect when manual logout fails with 401 Unauthorized", async ({
+    page,
+  }) => {
+    // 1. Create a user first to have a valid session
+    const timestamp = Date.now();
+    const user = {
+      username: `logout_401_${timestamp}`,
+      email: `logout_401_${timestamp}@example.com`,
+      password: "Password123!",
+    };
+
+    await registrationPage.goto();
+    await registrationPage.fillForm({
+      username: user.username,
+      firstName: "Logout",
+      lastName: "Tester",
+      email: user.email,
+      password: user.password,
+      confirmPassword: user.password,
+    });
+    await registrationPage.selectGender("Male");
+    await registrationPage.selectBirthDate(new Date(1990, 5, 15));
+    await registrationPage.submit();
+    await registrationPage.expectSuccess();
+
+    // Retrieve OTP and verify
+    const otpCode = await getOtpFromMailhog(user.email);
+    expect(otpCode).not.toBeNull();
+    await verifyEmailPage.fillOtpCode(otpCode!);
+    await verifyEmailPage.clickVerify();
+
+    // Verify redirected to app
+    await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+
+    // 2. Intercept logout API and force it to return a 401 error
+    await page.route("**/auth/logout", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "Session expired" } }),
+      });
+    });
+
+    // 3. Trigger logout
+    await dashboardPage.logout();
+
+    // 4. Assert client still logs out and redirects to login
+    await expect(page).toHaveURL(/\/auth\/login/);
+
+    // 5. Try to navigate back to a protected route and verify we are redirected back to login
+    await page.goto("/app/library/overview");
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+
+  test("should automatically log out and redirect to login when token refresh fails with 401", async ({
+    page,
+  }) => {
+    // 1. Create a user first to have a valid session
+    const timestamp = Date.now();
+    const user = {
+      username: `refresh_fail_${timestamp}`,
+      email: `refresh_fail_${timestamp}@example.com`,
+      password: "Password123!",
+    };
+
+    await registrationPage.goto();
+    await registrationPage.fillForm({
+      username: user.username,
+      firstName: "Refresh",
+      lastName: "Tester",
+      email: user.email,
+      password: user.password,
+      confirmPassword: user.password,
+    });
+    await registrationPage.selectGender("Female");
+    await registrationPage.selectBirthDate(new Date(1990, 5, 15));
+    await registrationPage.submit();
+    await registrationPage.expectSuccess();
+
+    // Retrieve OTP and verify
+    const otpCode = await getOtpFromMailhog(user.email);
+    expect(otpCode).not.toBeNull();
+    await verifyEmailPage.fillOtpCode(otpCode!);
+    await verifyEmailPage.clickVerify();
+
+    // Verify redirected to app
+    await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+
+    // 2. Mock 401 response on any API fetch to '/library'
+    await page.route("**/library", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "Unauthorized" } }),
+      });
+    });
+
+    // 3. Mock 401 response on token refresh endpoint
+    await page.route("**/auth/refresh", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "Session expired" } }),
+      });
+    });
+
+    // 4. Trigger the protected request by navigating to library overview
+    await dashboardPage.gotoLibraryOverview();
+
+    // 5. Assert we are automatically logged out and redirected to login page due to failed refresh
+    await expect(page).toHaveURL(/\/auth\/login/, { timeout: 15000 });
+
+    // 6. Assert "Session expired" Toast error is shown
+    const toast = page.locator("[data-sonner-toast]").first();
+    await expect(toast).toBeVisible({ timeout: 10000 });
+    await expect(toast).toHaveText(/Session expired/i);
+  });
 });

--- a/apps/web/src/components/app/Sidebar.tsx
+++ b/apps/web/src/components/app/Sidebar.tsx
@@ -46,12 +46,11 @@ export function AppSidebar() {
       await logoutHook({});
     } catch (err) {
       console.error('Failed to log out', err);
-      return;
+    } finally {
+      logout();
+      await router.invalidate();
+      await navigate({ to: '/auth/login' });
     }
-
-    logout();
-    await router.invalidate();
-    await navigate({ to: '/auth/login' });
   };
 
   return (

--- a/apps/web/src/hooks/api/auth/requests/forgotPassword.ts
+++ b/apps/web/src/hooks/api/auth/requests/forgotPassword.ts
@@ -7,5 +7,6 @@ export const forgotPassword = (data: ForgotPasswordRequest) => {
     method: 'POST',
     body: data,
     zodSchema: ForgotPasswordResponseSchema,
+    allowRefresh: false,
   });
 };

--- a/apps/web/src/hooks/api/auth/requests/login.ts
+++ b/apps/web/src/hooks/api/auth/requests/login.ts
@@ -7,5 +7,6 @@ export const login = (data: LoginRequest) => {
     method: 'POST',
     body: data,
     zodSchema: LoginResponseSchema,
+    allowRefresh: false,
   });
 };

--- a/apps/web/src/hooks/api/auth/requests/logout.ts
+++ b/apps/web/src/hooks/api/auth/requests/logout.ts
@@ -6,5 +6,6 @@ export const logout = (data: LogoutRequest) => {
   return apiClient<LogoutResponse>('auth/logout', {
     method: 'POST',
     body: data,
+    allowRefresh: false,
   });
 };

--- a/apps/web/src/hooks/api/auth/requests/recoverPassword.ts
+++ b/apps/web/src/hooks/api/auth/requests/recoverPassword.ts
@@ -7,5 +7,6 @@ export const recoverPassword = (data: RecoverPasswordRequest) => {
     method: 'POST',
     body: data,
     zodSchema: RecoverPasswordResponseSchema,
+    allowRefresh: false,
   });
 };

--- a/apps/web/src/hooks/api/auth/requests/register.ts
+++ b/apps/web/src/hooks/api/auth/requests/register.ts
@@ -6,5 +6,6 @@ export const register = (data: RegisterRequest) => {
   return apiClient<RegisterResponse>('auth/register', {
     body: data,
     zodSchema: RegisterResponseSchema,
+    allowRefresh: false,
   });
 };

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -314,7 +314,9 @@ describe('api-client', () => {
         const reason1 = (res1 as PromiseRejectedResult).reason;
         const reason2 = (res2 as PromiseRejectedResult).reason;
 
-        expect(reason1).toBe('String error');
+        expect(reason1).toBeInstanceOf(ApiError);
+        expect(reason1.status).toBe(401);
+        expect(reason1.message).toBe('Session expired');
 
         expect(reason2).toBeInstanceOf(ApiError);
         expect(reason2.status).toBe(401);

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -299,6 +299,16 @@ describe('api-client', () => {
 
       expect(res1.status).toBe('rejected');
       expect(res2.status).toBe('rejected');
+
+      const reason1 = (res1 as PromiseRejectedResult).reason;
+      const reason2 = (res2 as PromiseRejectedResult).reason;
+
+      expect(reason1).toBeInstanceOf(ApiError);
+      expect(reason1.status).toBe(401);
+
+      expect(reason2).toBeInstanceOf(ApiError);
+      expect(reason2.status).toBe(401);
+      expect(reason2.message).toBe('Session expired');
     });
 
     it('handles refresh response with missing token in queued requests', async () => {

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -265,6 +265,66 @@ describe('api-client', () => {
         logoutSpy.mockRestore();
       }
     });
+
+    it('logs out on refresh exception (ApiError)', async () => {
+      useAuthStore.getState().setAuth(mockUser, 'expired-token');
+      const logoutSpy = vi.spyOn(useAuthStore.getState(), 'logout');
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 401, statusText: '' }));
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 401, statusText: '' }));
+      mockFetch.mockRejectedValueOnce(
+        new ApiError(401, 'Custom Auth Error', { error: { message: 'Custom Auth Error message' } }),
+      );
+
+      try {
+        const [res1, res2] = await Promise.allSettled([api.request('req1'), api.request('req2')]);
+
+        expect(res1.status).toBe('rejected');
+        expect(res2.status).toBe('rejected');
+
+        const reason1 = (res1 as PromiseRejectedResult).reason;
+        const reason2 = (res2 as PromiseRejectedResult).reason;
+
+        expect(reason1).toBeInstanceOf(ApiError);
+        expect(reason1.message).toBe('Custom Auth Error message');
+
+        expect(reason2).toBeInstanceOf(ApiError);
+        expect(reason2.message).toBe('Custom Auth Error message');
+
+        expect(logoutSpy).toHaveBeenCalled();
+      } finally {
+        logoutSpy.mockRestore();
+      }
+    });
+
+    it('logs out on refresh exception (non-Error object)', async () => {
+      useAuthStore.getState().setAuth(mockUser, 'expired-token');
+      const logoutSpy = vi.spyOn(useAuthStore.getState(), 'logout');
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 401, statusText: '' }));
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 401, statusText: '' }));
+      mockFetch.mockRejectedValueOnce('String error');
+
+      try {
+        const [res1, res2] = await Promise.allSettled([api.request('req1'), api.request('req2')]);
+
+        expect(res1.status).toBe('rejected');
+        expect(res2.status).toBe('rejected');
+
+        const reason1 = (res1 as PromiseRejectedResult).reason;
+        const reason2 = (res2 as PromiseRejectedResult).reason;
+
+        expect(reason1).toBe('String error');
+
+        expect(reason2).toBeInstanceOf(ApiError);
+        expect(reason2.status).toBe(401);
+        expect(reason2.message).toBe('Session expired');
+
+        expect(logoutSpy).toHaveBeenCalled();
+      } finally {
+        logoutSpy.mockRestore();
+      }
+    });
   });
 
   describe('concurrent refresh', () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -130,9 +130,12 @@ class ApiClient {
             }
           }
         } catch (error) {
-          const refreshError = error instanceof ApiError ? error : new ApiError(401, 'Unauthorized', {
-            error: { message: error instanceof Error ? error.message : 'Session expired' },
-          });
+          const refreshError =
+            error instanceof ApiError
+              ? error
+              : new ApiError(401, 'Unauthorized', {
+                  error: { message: error instanceof Error ? error.message : 'Session expired' },
+                });
           this.processQueue(refreshError);
           if (useAuthStore.getState().isAuthenticated) {
             useAuthStore.getState().logout();

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from '@/stores/auth.store';
 import { ZodType } from 'zod';
 import { ApiError } from './api-error';
+import { toast } from 'sonner';
 
 /** Public configuration for API requests */
 export type ApiRequestConfig<T = unknown> = Omit<RequestInit, 'body'> & {
@@ -127,6 +128,7 @@ class ApiClient {
             this.processQueue(refreshError);
             if (useAuthStore.getState().isAuthenticated) {
               useAuthStore.getState().logout();
+              toast.error('Session expired');
             }
             throw refreshError;
           }
@@ -140,6 +142,7 @@ class ApiClient {
           this.processQueue(refreshError);
           if (useAuthStore.getState().isAuthenticated) {
             useAuthStore.getState().logout();
+            toast.error(refreshError.message);
           }
           throw refreshError;
         } finally {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -121,13 +121,19 @@ class ApiClient {
               _isRetry: true,
             });
           } else {
-            this.processQueue(new Error('Refresh failed'));
+            const refreshError = new ApiError(401, 'Unauthorized', {
+              error: { message: 'Session expired' },
+            });
+            this.processQueue(refreshError);
             if (useAuthStore.getState().isAuthenticated) {
               useAuthStore.getState().logout();
             }
           }
         } catch (error) {
-          this.processQueue(error);
+          const refreshError = error instanceof ApiError ? error : new ApiError(401, 'Unauthorized', {
+            error: { message: error instanceof Error ? error.message : 'Session expired' },
+          });
+          this.processQueue(refreshError);
           if (useAuthStore.getState().isAuthenticated) {
             useAuthStore.getState().logout();
           }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -128,6 +128,7 @@ class ApiClient {
             if (useAuthStore.getState().isAuthenticated) {
               useAuthStore.getState().logout();
             }
+            throw refreshError;
           }
         } catch (error) {
           const refreshError =
@@ -140,7 +141,7 @@ class ApiClient {
           if (useAuthStore.getState().isAuthenticated) {
             useAuthStore.getState().logout();
           }
-          throw error;
+          throw refreshError;
         } finally {
           this.isRefreshing = false;
         }

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -3,6 +3,8 @@ import { SidebarLayout } from '@/components/layout/sidebar-layout';
 import { Outlet, createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { useEffect } from 'react';
 
+import { useAuthStore } from '@/stores/auth.store';
+
 export const Route = createFileRoute('/app')({
   beforeLoad: ({ context, location }) => {
     if (!context.auth.isAuthenticated) {
@@ -18,14 +20,14 @@ export const Route = createFileRoute('/app')({
 });
 
 function AppLayout() {
-  const { auth } = Route.useRouteContext();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!auth.isAuthenticated) {
+    if (!isAuthenticated) {
       navigate({ to: '/auth/login' });
     }
-  }, [auth.isAuthenticated, navigate]);
+  }, [isAuthenticated, navigate]);
 
   return (
     <SidebarLayout>


### PR DESCRIPTION
fix(apps/web): enhance error handling for refresh token failures

- Updated the `ApiClient` to throw a structured `ApiError` with a 401 status and a 'Session expired' message when a refresh token fails.
- Improved the handling of errors during token refresh, ensuring consistent error processing in the request queue.
- Added unit tests to validate the new error handling behavior in the `api-client` tests.

fix(apps/web): improve logout error handling in AppSidebar component

- Refactored the logout process to ensure that the logout function and navigation to the login page are executed in a finally block, enhancing error handling during logout operations.
- This change ensures that the user is redirected to the login page even if an error occurs during the logout process.

fix(apps/web): improve error handling in ApiClient for unauthorized access

- Refactored error handling in the ApiClient to ensure consistent creation of ApiError instances when encountering unauthorized access.
- Enhanced readability by restructuring the error handling logic for better clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable logout and redirect to the login page when refresh or logout requests fail; ensures local cleanup always runs and shows a “Session expired” message when appropriate
  * Prevented unintended token refresh during certain auth requests

* **Tests**
  * Expanded coverage for session-expiration and concurrent refresh failure scenarios, including assertions on displayed error messaging and logout behavior

* **Refactor**
  * Moved login-redirect handling to client-side auth state monitoring for consistent navigation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hagrid862/playr/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->