### PR TITLE
test(apps/e2e): add shared web fixtures and test data helpers

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,20 @@
+name: Setup Playwright for CI
+description: Cache Playwright browsers and install Chromium on cache miss
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-chromium
+
+    - name: Install Playwright Chromium
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      timeout-minutes: 15
+      env:
+        DEBUG: pw:install
+      run: pnpm --filter @repo/e2e run ci:install-browsers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -494,6 +494,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: docker-build
     env:
       IMAGE_TAG: ci
@@ -536,8 +537,8 @@ jobs:
         with:
           name: build-outputs
 
-      - name: Install Playwright browsers
-        run: pnpm --filter @repo/e2e exec playwright install chromium --with-deps
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Debug - List Artifacts
         run: ls -R apps/api/dist apps/web/dist || echo "Artifacts missing"

--- a/.github/workflows/push-heavy.yml
+++ b/.github/workflows/push-heavy.yml
@@ -346,6 +346,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: docker-build
     env:
       IMAGE_TAG: ci
@@ -388,8 +389,8 @@ jobs:
         with:
           name: build-outputs
 
-      - name: Install Playwright browsers
-        run: pnpm --filter @repo/e2e exec playwright install chromium --with-deps
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Debug - List Artifacts
         run: ls -R apps/api/dist apps/web/dist || echo "Artifacts missing"

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -89,8 +89,36 @@ describe('AuthController (e2e)', () => {
 
 Playwright tests organized by app in subdirectories: `web/`, `admin/`, `artist/`, `api/`. Each maps to a Playwright project in `playwright.config.ts` with its own base URL.
 
+**Prerequisites:** Docker Compose stack running (web ~3000, API ~8000, MailHog ~8025). Do not use `pnpm dev` for E2E.
+
+**Shared helpers:**
+
+- `apps/e2e/src/web/fixtures/authenticated-user.helper.ts` — `createVerifiedUser()` (register + MailHog OTP + verify)
+- `apps/e2e/src/web/fixtures/authenticated-user.fixture.ts` — `test.extend` with `verifiedUser` for specs that only need a logged-in session
+- `apps/e2e/src/web/fixtures/library-content.helper.ts` — `ensureLibraryReady()`, `createArtist()`, `createAlbumWithTrack()`, etc.
+- `apps/e2e/src/web/test-data.helper.ts` — unique names, `TEST_AUDIO_PATH`, `TEST_IMAGE_PATH`
+
+**Web specs (`apps/e2e/src/web/`):**
+
+| File                                                           | Coverage                               |
+| -------------------------------------------------------------- | -------------------------------------- |
+| `auth.spec.ts`, `registration.spec.ts`, `verify-email.spec.ts` | Auth lifecycle                         |
+| `auth-edge-cases.spec.ts`, `password-reset.spec.ts`            | Session edge cases, password reset     |
+| `library.spec.ts`, `navigation.spec.ts`                        | Library bootstrap, sidebar navigation  |
+| `library-artists.spec.ts`                                      | Artist CRUD, detail controls           |
+| `library-albums.spec.ts`                                       | Album list, create, play, edit, delete |
+| `library-songs.spec.ts`                                        | Songs table, play, edit, delete        |
+| `library-genres.spec.ts`                                       | Genre list and detail                  |
+| `playlists.spec.ts`                                            | Playlists CRUD, pin, favorites         |
+| `playback.spec.ts`, `queue.spec.ts`                            | Player, queue, sync                    |
+| `listen-history.spec.ts`                                       | Listen history panel                   |
+| `smoke.spec.ts`                                                | Landing, placeholders                  |
+
+**API smoke (`apps/e2e/src/api/health.spec.ts`):** `GET /health`
+
 - CI: one worker, two retries, forbids `.only`
 - Local: four workers, no retries
+- Upload-heavy suites use `test.describe.configure({ mode: 'serial' })` and 120s timeouts
 
 ## Coverage
 

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "description": "",
   "scripts": {
+    "ci:install-browsers": "playwright install chromium",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
@@ -12,7 +13,7 @@
     "lint": "eslint . --fix"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.0",
+    "@playwright/test": "1.59.1",
     "@repo/configs": "workspace:*",
     "@types/node": "catalog:",
     "dotenv": "^17.2.3",

--- a/apps/e2e/src/api/health.spec.ts
+++ b/apps/e2e/src/api/health.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("API health", () => {
+  test("GET /health returns ok", async ({ request }) => {
+    const response = await request.get("/health");
+    expect(response.ok()).toBeTruthy();
+  });
+});

--- a/apps/e2e/src/web/dashboard.po.ts
+++ b/apps/e2e/src/web/dashboard.po.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from "@playwright/test";
+import { waitForAuthStorage } from "./fixtures/auth-storage.helper";
 
 export class DashboardPage {
   readonly page: Page;
@@ -22,8 +23,13 @@ export class DashboardPage {
   }
 
   async gotoLibraryOverview() {
-    await this.libraryOverviewLink.click();
-    await expect(this.page).toHaveURL(/\/app\/library\/overview/);
+    await waitForAuthStorage(this.page);
+    await this.page.goto("/app/library/overview", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(this.page).toHaveURL(/\/app\/library\/overview/, {
+      timeout: 15000,
+    });
   }
 
   async createLibrary() {

--- a/apps/e2e/src/web/example.spec.ts
+++ b/apps/e2e/src/web/example.spec.ts
@@ -1,9 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test("has title", async ({ page }) => {
-  await page.goto("/");
-
-  // Expect a title "to contain" a substring.
-  // Note: Adjust this expectation based on your actual app title
-  await expect(page).toHaveTitle(/Playr/);
-});

--- a/apps/e2e/src/web/fixtures/api.helper.ts
+++ b/apps/e2e/src/web/fixtures/api.helper.ts
@@ -1,0 +1,147 @@
+import type { Page } from "@playwright/test";
+
+type ApiEnvelope<T> = { data: T };
+
+type BrowserApiResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+function nodeApiBase(): string {
+  const raw = process.env.VITE_API_URL || "http://localhost:8000";
+  return raw
+    .replace(/^http:\/\/api(?=:|\/|$)/, "http://localhost")
+    .replace(/\/$/, "");
+}
+
+async function resolveApiBase(page: Page): Promise<string> {
+  try {
+    const fromApp = await page.evaluate(() => {
+      const env = (
+        import.meta as ImportMeta & { env?: { VITE_API_URL?: string } }
+      ).env?.VITE_API_URL;
+      return env?.replace(/\/$/, "") ?? null;
+    });
+    if (fromApp) return fromApp;
+  } catch {
+    // Page not on a Vite bundle yet.
+  }
+  return nodeApiBase();
+}
+
+async function browserApi<T>(
+  page: Page,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const apiBase = await resolveApiBase(page);
+  const result = await page.evaluate(
+    async ({ apiBase, method, path, body }): Promise<BrowserApiResult<T>> => {
+      const readToken = (): Promise<string | null> =>
+        new Promise((resolve) => {
+          const request = indexedDB.open("keyval-store");
+          request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction("keyval", "readonly");
+            const getReq = tx.objectStore("keyval").get("auth-storage");
+            getReq.onsuccess = () => {
+              db.close();
+              try {
+                const raw = getReq.result as
+                  | string
+                  | { state?: { accessToken?: string | null } };
+                const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+                resolve(parsed?.state?.accessToken ?? null);
+              } catch {
+                resolve(null);
+              }
+            };
+            getReq.onerror = () => {
+              db.close();
+              resolve(null);
+            };
+          };
+          request.onerror = () => resolve(null);
+        });
+
+      const token = await readToken();
+      if (!token) {
+        return { ok: false, error: "Missing access token in IndexedDB" };
+      }
+
+      const response = await fetch(`${apiBase}/${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `API ${method} ${path} failed (${response.status}): ${text}`,
+        };
+      }
+
+      try {
+        return {
+          ok: true,
+          data: (text ? JSON.parse(text) : {}) as T,
+        };
+      } catch {
+        return {
+          ok: false,
+          error: `API ${method} ${path} returned invalid JSON: ${text}`,
+        };
+      }
+    },
+    { apiBase, method, path, body },
+  );
+
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+export async function createLibraryGenreViaApi(
+  page: Page,
+  name: string,
+): Promise<string> {
+  const result = await browserApi<ApiEnvelope<{ id: string }>>(
+    page,
+    "POST",
+    "library/genres",
+    { name },
+  );
+  return result.data.id;
+}
+
+export async function attachGenresToAlbumViaApi(
+  page: Page,
+  albumId: string,
+  genreIds: string[],
+): Promise<void> {
+  await browserApi(page, "PATCH", `library/albums/${albumId}`, { genreIds });
+}
+
+export async function getAlbumTrackIdsViaApi(
+  page: Page,
+  albumId: string,
+): Promise<string[]> {
+  const result = await browserApi<ApiEnvelope<{ id: string }[]>>(
+    page,
+    "GET",
+    `library/albums/${albumId}/tracks`,
+  );
+  return result.data.map((track) => track.id);
+}
+
+export async function attachGenresToTrackViaApi(
+  page: Page,
+  trackId: string,
+  genreIds: string[],
+): Promise<void> {
+  await browserApi(page, "PATCH", `library/tracks/${trackId}`, { genreIds });
+}

--- a/apps/e2e/src/web/fixtures/api.helper.ts
+++ b/apps/e2e/src/web/fixtures/api.helper.ts
@@ -40,7 +40,19 @@ async function browserApi<T>(
           const request = indexedDB.open("keyval-store");
           request.onsuccess = () => {
             const db = request.result;
-            const tx = db.transaction("keyval", "readonly");
+            if (!db.objectStoreNames.contains("keyval")) {
+              db.close();
+              resolve(null);
+              return;
+            }
+            let tx: IDBTransaction;
+            try {
+              tx = db.transaction("keyval", "readonly");
+            } catch {
+              db.close();
+              resolve(null);
+              return;
+            }
             const getReq = tx.objectStore("keyval").get("auth-storage");
             getReq.onsuccess = () => {
               db.close();

--- a/apps/e2e/src/web/fixtures/auth-storage.helper.ts
+++ b/apps/e2e/src/web/fixtures/auth-storage.helper.ts
@@ -1,0 +1,38 @@
+import { type Page } from "@playwright/test";
+
+/** Waits until auth tokens are persisted in IndexedDB (idb-keyval). */
+export async function waitForAuthStorage(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      return new Promise<boolean>((resolve) => {
+        try {
+          const request = indexedDB.open("keyval-store");
+          request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction("keyval", "readonly");
+            const store = tx.objectStore("keyval");
+            const getReq = store.get("auth-storage");
+            getReq.onsuccess = () => {
+              db.close();
+              resolve(getReq.result != null && getReq.result !== undefined);
+            };
+            getReq.onerror = () => {
+              db.close();
+              resolve(false);
+            };
+          };
+          request.onerror = () => resolve(false);
+        } catch {
+          resolve(false);
+        }
+      });
+    },
+    { timeout: 15000 },
+  );
+}
+
+export async function gotoAppShell(page: Page): Promise<void> {
+  await page.goto("/app");
+  await page.waitForURL(/\/app/, { timeout: 15000 });
+  await waitForAuthStorage(page);
+}

--- a/apps/e2e/src/web/fixtures/auth-storage.helper.ts
+++ b/apps/e2e/src/web/fixtures/auth-storage.helper.ts
@@ -9,7 +9,19 @@ export async function waitForAuthStorage(page: Page): Promise<void> {
           const request = indexedDB.open("keyval-store");
           request.onsuccess = () => {
             const db = request.result;
-            const tx = db.transaction("keyval", "readonly");
+            if (!db.objectStoreNames.contains("keyval")) {
+              db.close();
+              resolve(false);
+              return;
+            }
+            let tx: IDBTransaction;
+            try {
+              tx = db.transaction("keyval", "readonly");
+            } catch {
+              db.close();
+              resolve(false);
+              return;
+            }
             const store = tx.objectStore("keyval");
             const getReq = store.get("auth-storage");
             getReq.onsuccess = () => {

--- a/apps/e2e/src/web/fixtures/authenticated-user.fixture.ts
+++ b/apps/e2e/src/web/fixtures/authenticated-user.fixture.ts
@@ -1,0 +1,21 @@
+import { test as base } from "@playwright/test";
+import {
+  createVerifiedUser,
+  type VerifiedUser,
+} from "./authenticated-user.helper";
+import { uniqueSuffix } from "../test-data.helper";
+
+type AuthFixtures = {
+  verifiedUser: VerifiedUser;
+};
+
+export const test = base.extend<AuthFixtures>({
+  verifiedUser: async ({ page }, use) => {
+    const user = await createVerifiedUser(page, {
+      prefix: `fixture_user_${uniqueSuffix()}`,
+    });
+    await use(user);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/e2e/src/web/fixtures/authenticated-user.helper.ts
+++ b/apps/e2e/src/web/fixtures/authenticated-user.helper.ts
@@ -1,0 +1,83 @@
+import { expect, type Page } from "@playwright/test";
+import { DashboardPage } from "../dashboard.po";
+import { RegistrationPage } from "../registration.po";
+import { VerifyEmailPage } from "../verify-email.po";
+import { getOtpFromMailhog } from "../mailhog.helper";
+import { gotoAppShell } from "./auth-storage.helper";
+import {
+  DEFAULT_TEST_PASSWORD,
+  uniqueEmail,
+  uniqueUsername,
+} from "../test-data.helper";
+
+export interface VerifiedUser {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export interface CreateVerifiedUserOptions {
+  prefix?: string;
+  logoutAfter?: boolean;
+  firstName?: string;
+  lastName?: string;
+  gender?: "Male" | "Female" | "Other";
+  birthDate?: Date;
+}
+
+/**
+ * Registers a new user, verifies email via MailHog, and lands on /app.
+ * Optionally logs out afterward (e.g. password-reset flows).
+ */
+export async function createVerifiedUser(
+  page: Page,
+  options: CreateVerifiedUserOptions = {},
+): Promise<VerifiedUser> {
+  const prefix = options.prefix ?? "e2e_user";
+  const username = uniqueUsername(prefix);
+  const email = uniqueEmail(prefix);
+  const password = DEFAULT_TEST_PASSWORD;
+
+  const registrationPage = new RegistrationPage(page);
+  const verifyEmailPage = new VerifyEmailPage(page);
+  const dashboardPage = new DashboardPage(page);
+
+  await registrationPage.goto();
+  await registrationPage.fillForm({
+    username,
+    firstName: options.firstName ?? "Test",
+    lastName: options.lastName ?? "User",
+    email,
+    password,
+    confirmPassword: password,
+  });
+  await registrationPage.selectGender(options.gender ?? "Male");
+  await registrationPage.selectBirthDate(
+    options.birthDate ?? new Date(2000, 0, 15),
+  );
+  await registrationPage.confirmPasswordInput.blur();
+  await expect(registrationPage.submitButton).toBeEnabled({
+    timeout: 30000,
+  });
+  await registrationPage.submit();
+  await registrationPage.expectSuccess();
+
+  await expect(page).toHaveURL(/\/auth\/verify-email/, { timeout: 15000 });
+  const otpCode = await getOtpFromMailhog(email);
+  expect(otpCode).not.toBeNull();
+  expect(otpCode).toMatch(/^\d{8}$/);
+
+  await verifyEmailPage.fillOtpCode(otpCode!);
+  await expect(verifyEmailPage.verifyButton).toBeEnabled();
+  await verifyEmailPage.clickVerify();
+  await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+
+  if (options.logoutAfter) {
+    await dashboardPage.logout();
+    await expect(page).toHaveURL(/\/auth\/login/);
+  } else {
+    await gotoAppShell(page);
+  }
+
+  return { username, email, password };
+}

--- a/apps/e2e/src/web/fixtures/library-content.helper.ts
+++ b/apps/e2e/src/web/fixtures/library-content.helper.ts
@@ -1,0 +1,190 @@
+import { expect, type Page } from "@playwright/test";
+import { DashboardPage } from "../dashboard.po";
+import { LibraryArtistsPage } from "../library-artists.po";
+import { TEST_AUDIO_PATH } from "../test-data.helper";
+
+export interface LibrarySeedResult {
+  artistName: string;
+  albumName: string;
+  trackName: string;
+  albumId: string;
+  artistId: string;
+}
+
+export async function addGenreOnAlbumForm(
+  page: Page,
+  genreName: string,
+): Promise<void> {
+  const metadata = page.getByRole("complementary").filter({
+    has: page.getByRole("heading", { name: "Album details" }),
+  });
+  const onEditLayout = (await metadata.count()) > 0;
+  const genreTrigger = onEditLayout
+    ? metadata.getByRole("button", { name: "Genres (optional)" })
+    : page.getByRole("button", { name: "Genres (optional)" });
+  await genreTrigger.scrollIntoViewIfNeeded();
+  await expect(genreTrigger).toBeEnabled({ timeout: 60000 });
+  if (onEditLayout) {
+    await genreTrigger.click();
+  } else {
+    await genreTrigger.click({ force: true });
+  }
+  await expect(genreTrigger).toHaveAttribute("aria-expanded", "true", {
+    timeout: 10000,
+  });
+
+  const listbox = page.getByRole("listbox", { name: "Genres" });
+  await expect(listbox).toBeVisible({ timeout: 15000 });
+  await listbox.getByRole("option", { name: "+ Create new genre…" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "New genre" })).toBeVisible({
+    timeout: 10000,
+  });
+  await dialog.getByLabel("Genre name").fill(genreName);
+  await dialog.getByRole("button", { name: "Add genre" }).click();
+  await expect(dialog).not.toBeVisible({ timeout: 10000 });
+  await expect(
+    page.getByRole("button", { name: `Remove ${genreName} (new)` }),
+  ).toBeVisible({ timeout: 10000 });
+}
+
+export async function ensurePrivateLibrary(page: Page): Promise<void> {
+  const dashboardPage = new DashboardPage(page);
+  await page.goto("/app/library/overview");
+
+  const libraryCreatedState = page.getByText("Your Private Library");
+  const libraryNotCreatedState = page.getByText(
+    "You don't have a private library yet.",
+  );
+
+  await expect(libraryCreatedState.or(libraryNotCreatedState)).toBeVisible();
+  if (await libraryNotCreatedState.isVisible()) {
+    await dashboardPage.createLibrary();
+  }
+}
+
+export async function ensurePrivateProfile(page: Page): Promise<void> {
+  await page.goto("/app/library/overview/private");
+
+  const lockedState = page.getByText("Private Library Locked");
+  const contentState = page.getByText("No content in your private library yet");
+
+  await expect(lockedState.or(contentState)).toBeVisible({ timeout: 10000 });
+  if (await lockedState.isVisible()) {
+    await page
+      .getByRole("button", { name: /Create Private Profile/ })
+      .last()
+      .click();
+    await expect(lockedState).not.toBeVisible({ timeout: 15000 });
+  }
+}
+
+export async function ensureLibraryReady(page: Page): Promise<void> {
+  await ensurePrivateLibrary(page);
+  await ensurePrivateProfile(page);
+}
+
+export async function createArtist(
+  page: Page,
+  artistName: string,
+): Promise<void> {
+  const artistsPage = new LibraryArtistsPage(page);
+  await artistsPage.gotoArtistsList();
+  await artistsPage.clickAddArtist();
+  await artistsPage.createArtist({
+    name: artistName,
+    description: "E2E test artist",
+  });
+}
+
+export async function createAlbumWithTrack(
+  page: Page,
+  options: {
+    artistName: string;
+    albumName: string;
+    trackName: string;
+    genreName?: string;
+  },
+): Promise<{ albumId: string; artistId: string }> {
+  const artistsPage = new LibraryArtistsPage(page);
+  await artistsPage.gotoArtistsList();
+  await artistsPage.expectArtistInList(options.artistName);
+  await artistsPage.clickArtistCard(options.artistName);
+
+  const artistUrl = new URL(page.url());
+  const artistPath = artistUrl.pathname.replace(/\/+$/, "");
+  const artistId = artistPath.split("/").pop();
+  expect(artistId).toBeTruthy();
+
+  await page.goto(`/app/library/artists/${artistId}/add-content`);
+  await page.getByLabel("Album title").waitFor({ state: "visible" });
+  await page.getByLabel("Album title").fill(options.albumName);
+
+  if (options.genreName) {
+    await page
+      .locator("form")
+      .first()
+      .evaluate((el) => el.scrollIntoView({ block: "start" }));
+    await addGenreOnAlbumForm(page, options.genreName);
+  }
+
+  await page
+    .locator('input[type="file"][accept="audio/*"]')
+    .setInputFiles(TEST_AUDIO_PATH);
+  await page.waitForTimeout(500);
+  await expect(page.getByText(/Scanning metadata/)).toBeHidden({
+    timeout: 20000,
+  });
+  await page.getByLabel("Track Title").fill(options.trackName);
+
+  await page.getByRole("button", { name: /Create album & upload/ }).click();
+  await page.waitForURL(/\/app\/library\/albums\/[^/]+$/, {
+    timeout: 60000,
+  });
+
+  const albumUrl = page.url().split("?")[0];
+  const albumId = albumUrl.split("/").filter(Boolean).pop();
+  expect(albumId).toBeTruthy();
+
+  return { albumId: albumId!, artistId: artistId! };
+}
+
+export async function seedLibraryWithAlbumAndTrack(
+  page: Page,
+  names: { artistName: string; albumName: string; trackName: string },
+  genreName?: string,
+): Promise<LibrarySeedResult> {
+  await ensureLibraryReady(page);
+  await createArtist(page, names.artistName);
+  const { albumId, artistId } = await createAlbumWithTrack(page, {
+    ...names,
+    genreName,
+  });
+  return { ...names, albumId, artistId };
+}
+
+export async function addSecondTrackToAlbum(
+  page: Page,
+  albumId: string,
+  trackName: string,
+): Promise<void> {
+  await page.goto(`/app/library/albums/${albumId}/add-content`);
+  await page.setInputFiles('input[type="file"]', TEST_AUDIO_PATH);
+  await page.waitForTimeout(500);
+  await expect(
+    page.getByText(
+      /Scanning metadata|Scanning tracks for cover art|Scanning metadata and cover art/,
+    ),
+  ).toBeHidden({ timeout: 20000 });
+  await page.getByLabel("Track Title").fill(trackName);
+  const uploadTracks = page.getByRole("button", {
+    name: /Upload \d+ tracks?/,
+  });
+  await expect(uploadTracks).toBeEnabled({ timeout: 30000 });
+  await uploadTracks.click();
+  await page.waitForURL(/\/app\/library\/albums\/[^/]+$/, {
+    timeout: 30000,
+  });
+  await expect(page.getByText(trackName)).toBeVisible({ timeout: 30000 });
+}

--- a/apps/e2e/src/web/fixtures/library-content.helper.ts
+++ b/apps/e2e/src/web/fixtures/library-content.helper.ts
@@ -170,7 +170,9 @@ export async function addSecondTrackToAlbum(
   trackName: string,
 ): Promise<void> {
   await page.goto(`/app/library/albums/${albumId}/add-content`);
-  await page.setInputFiles('input[type="file"]', TEST_AUDIO_PATH);
+  await page
+    .locator('input[type="file"][accept="audio/*"]')
+    .setInputFiles(TEST_AUDIO_PATH);
   await page.waitForTimeout(500);
   await expect(
     page.getByText(

--- a/apps/e2e/src/web/library-albums.po.ts
+++ b/apps/e2e/src/web/library-albums.po.ts
@@ -1,0 +1,108 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+import { TEST_AUDIO_PATH, TEST_IMAGE_PATH } from "./test-data.helper";
+
+export class LibraryAlbumsPage {
+  readonly page: Page;
+  readonly emptyStateHeading: Locator;
+  readonly addAlbumLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emptyStateHeading = page.getByRole("heading", {
+      name: "No albums found",
+    });
+    this.addAlbumLink = page.getByRole("link", { name: /add album/i });
+  }
+
+  async gotoAlbumsList() {
+    await this.page.goto("/app/library/albums");
+  }
+
+  async gotoCreateAlbum() {
+    await this.page.goto("/app/library/albums/create");
+  }
+
+  async expectEmptyState() {
+    await expect(this.emptyStateHeading).toBeVisible({ timeout: 10000 });
+  }
+
+  async createAlbumFromCreatePage(options: { trackName: string }) {
+    await this.page.getByLabel("Album title").waitFor({ state: "visible" });
+    await this.page
+      .locator('input[type="file"][accept="audio/*"]')
+      .setInputFiles(TEST_AUDIO_PATH);
+    await this.page.waitForTimeout(500);
+    await expect(this.page.getByText(/Scanning metadata/)).toBeHidden({
+      timeout: 20000,
+    });
+    await this.page.getByLabel("Track Title").fill(options.trackName);
+    await this.page
+      .getByRole("button", { name: /Create album & upload/ })
+      .click();
+    await this.page.waitForURL(/\/app\/library\/albums\/[^/]+$/, {
+      timeout: 60000,
+    });
+  }
+
+  async playTrackOnDetail(trackName: string) {
+    const trackRow = this.page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: trackName });
+    await trackRow.scrollIntoViewIfNeeded();
+    await trackRow.hover();
+    await trackRow.click();
+  }
+
+  async gotoEditFromMenu() {
+    await this.openAlbumMoreMenu();
+    await this.page.getByRole("menuitem", { name: "Edit" }).click();
+    await expect(this.page).toHaveURL(/\/edit/, { timeout: 10000 });
+  }
+
+  async openAlbumMoreMenu() {
+    await this.page
+      .locator("div.flex.items-center.gap-1.ml-2")
+      .getByRole("button")
+      .last()
+      .click();
+  }
+
+  async deleteAlbumFromMenu() {
+    await this.openAlbumMoreMenu();
+    await this.page.getByRole("menuitem", { name: "Delete" }).click();
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete Album" }).click();
+    await expect(this.page).toHaveURL(/\/app\/library\/albums\/?$/, {
+      timeout: 15000,
+    });
+  }
+
+  async uploadCoverOnEdit() {
+    const coverInput = this.page
+      .locator('input[type="file"][accept="image/*"]')
+      .first();
+    await coverInput.setInputFiles(TEST_IMAGE_PATH);
+  }
+
+  async saveAlbumEdit() {
+    await this.page.getByRole("button", { name: /save changes/i }).click();
+    await expect(this.page).toHaveURL(/\/app\/library\/albums\/[^/]+\/?$/, {
+      timeout: 60000,
+    });
+  }
+
+  async expectAlbumInList(albumName: string) {
+    await expect(
+      this.page
+        .locator("a")
+        .filter({ has: this.page.getByRole("heading", { name: albumName }) }),
+    ).toBeVisible({ timeout: 10000 });
+  }
+
+  async expectAlbumNotInList(albumName: string) {
+    await expect(
+      this.page.getByRole("heading", { name: albumName, exact: true }),
+    ).not.toBeVisible({ timeout: 5000 });
+  }
+}

--- a/apps/e2e/src/web/library-albums.spec.ts
+++ b/apps/e2e/src/web/library-albums.spec.ts
@@ -1,0 +1,127 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import {
+  createAlbumWithTrack,
+  createArtist,
+  ensureLibraryReady,
+} from "./fixtures/library-content.helper";
+import { LibraryAlbumsPage } from "./library-albums.po";
+import { LibraryArtistsPage } from "./library-artists.po";
+import { PlayerPage } from "./player.po";
+import { uniqueLabel } from "./test-data.helper";
+
+test.describe("Library Albums Workflow", () => {
+  let page: Page;
+  let albumsPage: LibraryAlbumsPage;
+  let artistsPage: LibraryArtistsPage;
+  let playerPage: PlayerPage;
+
+  const artistName = uniqueLabel("Albums Artist");
+  const albumName = uniqueLabel("Albums Album");
+  const trackName = uniqueLabel("Albums Track");
+  const createPageAlbum = uniqueLabel("Create Page Album");
+  const createPageTrack = uniqueLabel("Create Page Track");
+  let artistId: string;
+
+  test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    albumsPage = new LibraryAlbumsPage(page);
+    artistsPage = new LibraryArtistsPage(page);
+    playerPage = new PlayerPage(page);
+
+    await createVerifiedUser(page, { prefix: "albums_user" });
+    await ensureLibraryReady(page);
+    await createArtist(page, artistName);
+    await artistsPage.gotoArtistsList();
+    await artistsPage.clickArtistCard(artistName);
+    artistId = new URL(page.url()).pathname
+      .replace(/\/+$/, "")
+      .split("/")
+      .pop()!;
+    expect(artistId).toBeTruthy();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("should show empty albums list initially", async () => {
+    await albumsPage.gotoAlbumsList();
+    await albumsPage.expectEmptyState();
+  });
+
+  test("should create album via artist add-content and play track", async () => {
+    const { albumId } = await createAlbumWithTrack(page, {
+      artistName,
+      albumName,
+      trackName,
+    });
+
+    await page.goto(`/app/library/albums/${albumId}`);
+    await expect(page.locator("h2").filter({ hasText: albumName })).toBeVisible(
+      { timeout: 10000 },
+    );
+    await albumsPage.playTrackOnDetail(trackName);
+    await expect(playerPage.trackTitle).toHaveText(trackName, {
+      timeout: 10000,
+    });
+  });
+
+  test("should list created album", async () => {
+    await albumsPage.gotoAlbumsList();
+    await albumsPage.expectAlbumInList(albumName);
+  });
+
+  test("should create album via standalone create page", async () => {
+    await page.goto(`/app/library/albums/create?artistId=${artistId}`);
+    await page.getByLabel("Album title").fill(createPageAlbum);
+
+    await albumsPage.createAlbumFromCreatePage({
+      trackName: createPageTrack,
+    });
+    await expect(page.getByText(createPageTrack)).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test("should edit album metadata on edit page", async () => {
+    await albumsPage.gotoAlbumsList();
+    await albumsPage.expectAlbumInList(createPageAlbum);
+    await page
+      .locator("a")
+      .filter({ has: page.getByRole("heading", { name: createPageAlbum }) })
+      .click();
+    await expect(page).toHaveURL(/\/app\/library\/albums\/[^/]+$/);
+
+    const editedName = `${createPageAlbum} Edited`;
+    await albumsPage.gotoEditFromMenu();
+    await page.getByLabel(/album title/i).clear();
+    await page.getByLabel(/album title/i).fill(editedName);
+    await albumsPage.saveAlbumEdit();
+    await expect(
+      page.locator("h2").filter({ hasText: editedName }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("should delete album from detail menu", async () => {
+    await albumsPage.gotoAlbumsList();
+    const editedName = `${createPageAlbum} Edited`;
+    await page
+      .locator("a")
+      .filter({ has: page.getByRole("heading", { name: editedName }) })
+      .click();
+    await albumsPage.deleteAlbumFromMenu();
+    await albumsPage.gotoAlbumsList();
+    await albumsPage.expectAlbumNotInList(editedName);
+  });
+
+  test("should reach add-content from artist detail", async () => {
+    await artistsPage.gotoArtistsList();
+    await artistsPage.clickArtistCard(artistName);
+    await page.getByRole("link", { name: "Add Content" }).click();
+    await expect(page).toHaveURL(/\/add-content/);
+    await expect(page.getByLabel("Album title")).toBeVisible();
+  });
+});

--- a/apps/e2e/src/web/library-artists.po.ts
+++ b/apps/e2e/src/web/library-artists.po.ts
@@ -45,10 +45,17 @@ export class LibraryArtistsPage {
     });
     this.createArtistCancelButton = page.getByRole("link", { name: "Cancel" });
 
-    // Artist detail
+    // Artist detail — hero actions (avoid player bar "Play")
+    const artistHeroActions = page.locator("div.px-2.mt-12").first();
     this.artistDetailName = page.locator("h2.text-2xl.font-bold");
-    this.playButton = page.getByRole("button", { name: "Play" });
-    this.shuffleButton = page.getByRole("button", { name: "Shuffle" });
+    this.playButton = artistHeroActions.getByRole("button", {
+      name: "Play",
+      exact: true,
+    });
+    this.shuffleButton = artistHeroActions.getByRole("button", {
+      name: "Shuffle",
+      exact: true,
+    });
     // The menu trigger in detail page
     this.moreOptionsButton = page.getByRole("button", { name: "More options" });
 

--- a/apps/e2e/src/web/library-artists.spec.ts
+++ b/apps/e2e/src/web/library-artists.spec.ts
@@ -191,6 +191,15 @@ test.describe("Library Artist CRUD Workflow", () => {
     await expect(heartButton).toBeVisible();
   });
 
+  test("should show play and shuffle on artist detail", async () => {
+    const name = `E2E Artist ${timestamp}`;
+    await artistsPage.gotoArtistsList();
+    await artistsPage.clickArtistCard(name);
+    await artistsPage.expectArtistDetailPage(name);
+    await expect(artistsPage.playButton).toBeVisible();
+    await expect(artistsPage.shuffleButton).toBeVisible();
+  });
+
   test("should validate max length for description", async () => {
     const name = `E2E Artist ${timestamp}`;
     await artistsPage.gotoArtistsList();

--- a/apps/e2e/src/web/library-genres.spec.ts
+++ b/apps/e2e/src/web/library-genres.spec.ts
@@ -1,0 +1,68 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import {
+  attachGenresToAlbumViaApi,
+  attachGenresToTrackViaApi,
+  createLibraryGenreViaApi,
+  getAlbumTrackIdsViaApi,
+} from "./fixtures/api.helper";
+import { waitForAuthStorage } from "./fixtures/auth-storage.helper";
+import {
+  createAlbumWithTrack,
+  createArtist,
+  ensureLibraryReady,
+} from "./fixtures/library-content.helper";
+import { uniqueLabel } from "./test-data.helper";
+
+test.describe("Library Genres Workflow", () => {
+  let page: Page;
+
+  const artistName = uniqueLabel("Genre Artist");
+  const albumName = uniqueLabel("Genre Album");
+  const trackName = uniqueLabel("Genre Track");
+  const genreName = uniqueLabel("E2E Genre");
+  let albumId: string;
+
+  test.describe.configure({ mode: "serial", timeout: 180_000 });
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(180_000);
+    page = await browser.newPage();
+    await createVerifiedUser(page, { prefix: "genres_user" });
+    await ensureLibraryReady(page);
+    await createArtist(page, artistName);
+    const seed = await createAlbumWithTrack(page, {
+      artistName,
+      albumName,
+      trackName,
+    });
+    albumId = seed.albumId;
+  });
+
+  test.afterAll(async () => {
+    if (page) await page.close();
+  });
+
+  test("should list genre and open detail with album and track", async () => {
+    await waitForAuthStorage(page);
+    const genreId = await createLibraryGenreViaApi(page, genreName);
+    await attachGenresToAlbumViaApi(page, albumId, [genreId]);
+    const trackIds = await getAlbumTrackIdsViaApi(page, albumId);
+    expect(trackIds.length).toBeGreaterThan(0);
+    await attachGenresToTrackViaApi(page, trackIds[0]!, [genreId]);
+
+    await page.goto("/app/library/genres");
+    await expect(page.getByRole("heading", { name: "Genres" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole("link", { name: genreName })).toBeVisible({
+      timeout: 15000,
+    });
+    await page.getByRole("link", { name: genreName }).click();
+    await expect(page).toHaveURL(/\/app\/library\/genres\/[^/]+/);
+    await expect(
+      page.getByRole("heading", { name: albumName, exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(trackName)).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/apps/e2e/src/web/library-songs.po.ts
+++ b/apps/e2e/src/web/library-songs.po.ts
@@ -1,0 +1,42 @@
+import { type Page, expect } from "@playwright/test";
+
+export class LibrarySongsPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async gotoSongsList() {
+    await this.page.goto("/app/library/songs");
+  }
+
+  async expectTrackVisible(title: string) {
+    await expect(this.page.getByText(title).first()).toBeVisible({
+      timeout: 15000,
+    });
+  }
+
+  async playTrackFromRow(title: string) {
+    const row = this.page.getByRole("row").filter({ hasText: title });
+    await row.click();
+  }
+
+  async openTrackContextMenu(title: string) {
+    const row = this.page.getByRole("row").filter({ hasText: title });
+    await row.click({ button: "right" });
+  }
+
+  async editTrackFromContextMenu(title: string) {
+    await this.openTrackContextMenu(title);
+    await this.page.getByRole("menuitem", { name: "Edit" }).click();
+  }
+
+  async deleteTrackFromContextMenu(title: string) {
+    await this.openTrackContextMenu(title);
+    await this.page.getByRole("menuitem", { name: "Delete" }).click();
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete Track" }).click();
+  }
+}

--- a/apps/e2e/src/web/library-songs.po.ts
+++ b/apps/e2e/src/web/library-songs.po.ts
@@ -1,29 +1,35 @@
-import { type Page, expect } from "@playwright/test";
+import { type Locator, type Page, expect } from "@playwright/test";
 
 export class LibrarySongsPage {
   readonly page: Page;
+  readonly songsTable: Locator;
 
   constructor(page: Page) {
     this.page = page;
+    this.songsTable = page.getByRole("table");
   }
 
   async gotoSongsList() {
     await this.page.goto("/app/library/songs");
   }
 
+  private trackRow(title: string) {
+    return this.songsTable.getByRole("row").filter({ hasText: title });
+  }
+
   async expectTrackVisible(title: string) {
-    await expect(this.page.getByText(title).first()).toBeVisible({
+    await expect(this.trackRow(title).first()).toBeVisible({
       timeout: 15000,
     });
   }
 
   async playTrackFromRow(title: string) {
-    const row = this.page.getByRole("row").filter({ hasText: title });
+    const row = this.trackRow(title);
     await row.click();
   }
 
   async openTrackContextMenu(title: string) {
-    const row = this.page.getByRole("row").filter({ hasText: title });
+    const row = this.trackRow(title);
     await row.click({ button: "right" });
   }
 

--- a/apps/e2e/src/web/library-songs.spec.ts
+++ b/apps/e2e/src/web/library-songs.spec.ts
@@ -37,7 +37,7 @@ test.describe("Library Songs Workflow", () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    if (page) await page.close();
   });
 
   test("should list uploaded tracks on songs page", async () => {
@@ -71,7 +71,9 @@ test.describe("Library Songs Workflow", () => {
     await songsPage.gotoSongsList();
     await songsPage.deleteTrackFromContextMenu(editedTrackName);
     await expect(
-      page.getByRole("row").filter({ hasText: editedTrackName }),
+      songsPage.songsTable
+        .getByRole("row")
+        .filter({ hasText: editedTrackName }),
     ).not.toBeVisible({ timeout: 10000 });
   });
 });

--- a/apps/e2e/src/web/library-songs.spec.ts
+++ b/apps/e2e/src/web/library-songs.spec.ts
@@ -1,0 +1,77 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import {
+  createAlbumWithTrack,
+  createArtist,
+  ensureLibraryReady,
+} from "./fixtures/library-content.helper";
+import { LibrarySongsPage } from "./library-songs.po";
+import { PlayerPage } from "./player.po";
+import { uniqueLabel } from "./test-data.helper";
+
+test.describe("Library Songs Workflow", () => {
+  let page: Page;
+  let songsPage: LibrarySongsPage;
+  let playerPage: PlayerPage;
+
+  const artistName = uniqueLabel("Songs Artist");
+  const albumName = uniqueLabel("Songs Album");
+  const trackName = uniqueLabel("Songs Track");
+  const editedTrackName = `${trackName} Edited`;
+
+  test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    songsPage = new LibrarySongsPage(page);
+    playerPage = new PlayerPage(page);
+
+    await createVerifiedUser(page, { prefix: "songs_user" });
+    await ensureLibraryReady(page);
+    await createArtist(page, artistName);
+    await createAlbumWithTrack(page, {
+      artistName,
+      albumName,
+      trackName,
+    });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("should list uploaded tracks on songs page", async () => {
+    await songsPage.gotoSongsList();
+    await songsPage.expectTrackVisible(trackName);
+  });
+
+  test("should play track from songs table", async () => {
+    await songsPage.gotoSongsList();
+    await songsPage.playTrackFromRow(trackName);
+    await expect(playerPage.trackTitle).toHaveText(trackName, {
+      timeout: 15000,
+    });
+  });
+
+  test("should edit track metadata", async () => {
+    await songsPage.gotoSongsList();
+    await songsPage.editTrackFromContextMenu(trackName);
+    await expect(page).toHaveURL(/\/edit/);
+    await page.getByLabel("Track Title").clear();
+    await page.getByLabel("Track Title").fill(editedTrackName);
+    await page.getByRole("button", { name: /save changes/i }).click();
+    await expect(page).toHaveURL(/\/app\/library\/albums\/[^/]+$/, {
+      timeout: 30000,
+    });
+    await songsPage.gotoSongsList();
+    await songsPage.expectTrackVisible(editedTrackName);
+  });
+
+  test("should delete track from songs page", async () => {
+    await songsPage.gotoSongsList();
+    await songsPage.deleteTrackFromContextMenu(editedTrackName);
+    await expect(
+      page.getByRole("row").filter({ hasText: editedTrackName }),
+    ).not.toBeVisible({ timeout: 10000 });
+  });
+});

--- a/apps/e2e/src/web/library.spec.ts
+++ b/apps/e2e/src/web/library.spec.ts
@@ -9,7 +9,7 @@ test.describe("Library Management Workflow", () => {
     await dashboardPage.gotoLibraryOverview();
 
     const libraryNotCreated = page.getByText(
-      "You don't have a private library yet.",
+      /You don't have a private library yet\.?/i,
     );
     const libraryCreated = page.getByText("Your Private Library");
     await expect(libraryNotCreated.or(libraryCreated)).toBeVisible({

--- a/apps/e2e/src/web/library.spec.ts
+++ b/apps/e2e/src/web/library.spec.ts
@@ -1,77 +1,29 @@
-import { expect, test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { DashboardPage } from "./dashboard.po";
-import { RegistrationPage } from "./registration.po";
-import { getOtpFromMailhog } from "./mailhog.helper";
-import { VerifyEmailPage } from "./verify-email.po";
-
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
 test.describe("Library Management Workflow", () => {
-  let verifyEmailPage: VerifyEmailPage;
-  let registrationPage: RegistrationPage;
-  let dashboardPage: DashboardPage;
-
-  const timestamp = Date.now();
-  const testUserData = {
-    username: `lib_user_${timestamp}`,
-    email: `lib_${timestamp}@example.com`,
-    password: "Password123!",
-  };
-
-  test.beforeEach(async ({ page }) => {
-    verifyEmailPage = new VerifyEmailPage(page);
-    registrationPage = new RegistrationPage(page);
-    dashboardPage = new DashboardPage(page);
-
-    // Setup: Register and Login
-    await registrationPage.goto();
-    await registrationPage.fillForm({
-      username: testUserData.username,
-      firstName: "Library",
-      lastName: "User",
-      email: testUserData.email,
-      password: testUserData.password,
-      confirmPassword: testUserData.password,
-    });
-    await registrationPage.selectGender("Female");
-    await registrationPage.selectBirthDate(new Date(1990, 0, 1));
-    await registrationPage.submit();
-    await registrationPage.expectSuccess();
-
-    // 1. Should redirect to the email verification page with the user's email
-    await expect(page).toHaveURL(/\/auth\/verify-email/, { timeout: 15000 });
-    await expect(verifyEmailPage.pageTitle).toBeVisible();
-    await verifyEmailPage.expectEmailDisplayed(testUserData.email);
-
-    // 2. Retrieve the OTP code sent via email (MailHog intercepts in dev/test)
-    const otpCode = await getOtpFromMailhog(testUserData.email);
-    expect(otpCode).not.toBeNull();
-    expect(otpCode).toMatch(/^\d{8}$/);
-
-    // 3. Enter the OTP and submit verification
-    await verifyEmailPage.fillOtpCode(otpCode!);
-    await expect(verifyEmailPage.verifyButton).toBeEnabled();
-    await verifyEmailPage.clickVerify();
-
-    // 4. Should redirect to the dashboard after email verification
-    await expect(page).toHaveURL(/\/app/);
-  });
-
   test("should create and view a private library", async ({ page }) => {
-    // 1. Navigate to Library Overview
+    await createVerifiedUser(page, { prefix: "lib_user" });
+
+    const dashboardPage = new DashboardPage(page);
     await dashboardPage.gotoLibraryOverview();
 
-    // 2. Verify empty state
-    await expect(
-      page.getByText("You don't have a private library yet."),
-    ).toBeVisible();
+    const libraryNotCreated = page.getByText(
+      "You don't have a private library yet.",
+    );
+    const libraryCreated = page.getByText("Your Private Library");
+    await expect(libraryNotCreated.or(libraryCreated)).toBeVisible({
+      timeout: 15000,
+    });
+    if (!(await libraryCreated.isVisible())) {
+      await dashboardPage.createLibrary();
+    }
 
-    // 3. Create Library
-    await dashboardPage.createLibrary();
-
-    // 4. Verify Success state
-    await expect(page.getByText("Your Private Library")).toBeVisible();
+    await expect(page.getByText("Your Private Library")).toBeVisible({
+      timeout: 15000,
+    });
     await expect(page.getByText("Library ID:")).toBeVisible();
 
-    // 5. Navigate away and back to ensure persistence
     await page.goto("/app");
     await dashboardPage.gotoLibraryOverview();
     await expect(page.getByText("Your Private Library")).toBeVisible();

--- a/apps/e2e/src/web/listen-history.spec.ts
+++ b/apps/e2e/src/web/listen-history.spec.ts
@@ -1,0 +1,83 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import {
+  createAlbumWithTrack,
+  createArtist,
+  ensureLibraryReady,
+} from "./fixtures/library-content.helper";
+import { LibraryAlbumsPage } from "./library-albums.po";
+import { PlayerPage } from "./player.po";
+import { QueuePage } from "./queue.po";
+import { uniqueLabel } from "./test-data.helper";
+
+test.describe("Listen History Workflow", () => {
+  let page: Page;
+  let albumsPage: LibraryAlbumsPage;
+  let playerPage: PlayerPage;
+  let queuePage: QueuePage;
+
+  const artistName = uniqueLabel("History Artist");
+  const albumName = uniqueLabel("History Album");
+  const trackName = uniqueLabel("History Track");
+
+  test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    albumsPage = new LibraryAlbumsPage(page);
+    playerPage = new PlayerPage(page);
+    queuePage = new QueuePage(page);
+
+    await createVerifiedUser(page, { prefix: "history_user" });
+    await ensureLibraryReady(page);
+    await createArtist(page, artistName);
+    const { albumId } = await createAlbumWithTrack(page, {
+      artistName,
+      albumName,
+      trackName,
+    });
+    await page.goto(`/app/library/albums/${albumId}`);
+    await albumsPage.playTrackOnDetail(trackName);
+    await expect(playerPage.trackTitle).toHaveText(trackName, {
+      timeout: 10000,
+    });
+    await playerPage.expectPlaying();
+    await page.waitForTimeout(3000);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("should show played track in history", async () => {
+    await page.getByRole("button", { name: "Queue", exact: true }).click();
+    await queuePage.openHistory();
+    await expect(
+      page.getByRole("heading", { name: "History", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: new RegExp(`Play ${trackName}`, "i"),
+      }),
+    ).toBeVisible({ timeout: 20000 });
+  });
+
+  test("should clear listen history", async () => {
+    await page.goto("/app/library/overview");
+    const queueButton = page.getByRole("button", {
+      name: "Queue",
+      exact: true,
+    });
+    await queueButton.scrollIntoViewIfNeeded();
+    await queueButton.click({ timeout: 15000 });
+    await queuePage.openHistory();
+    await page.getByRole("button", { name: "Clear" }).click();
+    await page
+      .getByRole("button", { name: "Clear", exact: true })
+      .last()
+      .click();
+    await expect(page.getByText("No listening history")).toBeVisible({
+      timeout: 15000,
+    });
+  });
+});

--- a/apps/e2e/src/web/listen-history.spec.ts
+++ b/apps/e2e/src/web/listen-history.spec.ts
@@ -46,7 +46,7 @@ test.describe("Listen History Workflow", () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    if (page) await page.close();
   });
 
   test("should show played track in history", async () => {

--- a/apps/e2e/src/web/navigation.spec.ts
+++ b/apps/e2e/src/web/navigation.spec.ts
@@ -1,97 +1,51 @@
-import { expect, test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { DashboardPage } from "./dashboard.po";
 import { LibraryArtistsPage } from "./library-artists.po";
-import { RegistrationPage } from "./registration.po";
-import { getOtpFromMailhog } from "./mailhog.helper";
-import { VerifyEmailPage } from "./verify-email.po";
-
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import { waitForAuthStorage } from "./fixtures/auth-storage.helper";
 test.describe("Navigation Flow", () => {
-  let verifyEmailPage: VerifyEmailPage;
-  let registrationPage: RegistrationPage;
-  let dashboardPage: DashboardPage;
-  let artistsPage: LibraryArtistsPage;
-
-  let testUserData: {
-    username: string;
-    email: string;
-    password: string;
-  };
-
   test.beforeEach(async ({ page }) => {
-    verifyEmailPage = new VerifyEmailPage(page);
-    registrationPage = new RegistrationPage(page);
-    dashboardPage = new DashboardPage(page);
-    artistsPage = new LibraryArtistsPage(page);
-
-    const timestamp = Math.floor(Math.random() * 1000000);
-    testUserData = {
-      username: `nav_user_${timestamp}`,
-      email: `nav_${timestamp}@example.com`,
-      password: "Password123!",
-    };
-
-    // Setup: Register and Login
-    await registrationPage.goto();
-    await registrationPage.fillForm({
-      username: testUserData.username,
-      firstName: "Nav",
-      lastName: "User",
-      email: testUserData.email,
-      password: testUserData.password,
-      confirmPassword: testUserData.password,
-    });
-    await registrationPage.selectGender("Other");
-    await registrationPage.selectBirthDate(new Date(1992, 1, 1));
-    await registrationPage.submit();
-    await registrationPage.expectSuccess();
-
-    // 1. Should redirect to the email verification page with the user's email
-    await expect(page).toHaveURL(/\/auth\/verify-email/, { timeout: 15000 });
-    await expect(verifyEmailPage.pageTitle).toBeVisible();
-    await verifyEmailPage.expectEmailDisplayed(testUserData.email);
-
-    // 2. Retrieve the OTP code sent via email (MailHog intercepts in dev/test)
-    const otpCode = await getOtpFromMailhog(testUserData.email);
-    expect(otpCode).not.toBeNull();
-    expect(otpCode).toMatch(/^\d{8}$/);
-
-    // 3. Enter the OTP and submit verification
-    await verifyEmailPage.fillOtpCode(otpCode!);
-    await expect(verifyEmailPage.verifyButton).toBeEnabled();
-    await verifyEmailPage.clickVerify();
-
-    // 4. Should redirect to the dashboard after email verification
-    await expect(page).toHaveURL(/\/app/);
+    await createVerifiedUser(page, { prefix: "nav_user" });
   });
 
   test("should navigate through all main sidebar items", async ({ page }) => {
-    // 1. Dashboard (Default)
-    await expect(page).toHaveURL(/\/app/);
+    const dashboardPage = new DashboardPage(page);
+    const artistsPage = new LibraryArtistsPage(page);
 
-    // 2. Library Overview
+    await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+
     await dashboardPage.gotoLibraryOverview();
     await expect(page).toHaveURL(/\/app\/library\/overview/);
 
-    // 3. Artists
+    await page.getByRole("link", { name: "Artists" }).click();
+    await expect(page).toHaveURL(/\/app\/library\/artists/);
+
+    await page.getByRole("link", { name: "Albums" }).click();
+    await expect(page).toHaveURL(/\/app\/library\/albums/);
+
+    await page.getByRole("link", { name: "Songs" }).click();
+    await expect(page).toHaveURL(/\/app\/library\/songs/);
+
+    await page.getByRole("link", { name: "Genres" }).click();
+    await expect(page).toHaveURL(/\/app\/library\/genres/);
+
+    await page.getByRole("link", { name: "Playlists" }).click();
+    await expect(page).toHaveURL(/\/app\/playlists/);
+
     await artistsPage.gotoArtistsList();
     await expect(page).toHaveURL(/\/app\/library\/artists/);
 
-    // 4. Albums (Direct navigation as PO might not exist yet)
-    await page.goto("/app/library/albums");
-    await expect(page).toHaveURL(/\/app\/library\/albums/);
-
-    // 5. Search
     await page.goto("/app/search");
     await expect(page).toHaveURL(/\/app\/search/);
   });
 
   test("should persist authentication state on reload", async ({ page }) => {
-    await page.goto("/app/library/overview");
-    // Verify we are on Library Overview
+    const dashboardPage = new DashboardPage(page);
+
+    await waitForAuthStorage(page);
+    await dashboardPage.gotoLibraryOverview();
     await expect(page).toHaveURL(/\/app\/library\/overview/);
 
-    // Check if we are in mobile view - if sidebar trigger is visible, sidebar might be hidden
-    // Note: There are two sidebar triggers (mobile and desktop), so we use .first() to avoid strict mode violation
     const sidebarTrigger = page
       .locator('button[data-sidebar="trigger"]')
       .first();
@@ -101,79 +55,11 @@ test.describe("Navigation Flow", () => {
       await expect(dashboardPage.sidebar).toBeVisible({ timeout: 15000 });
     }
 
-    // Wait for auth state to be persisted in IndexedDB (auth store uses idb-keyval, not localStorage)
-    await page.waitForFunction(
-      () => {
-        return new Promise<boolean>((resolve) => {
-          try {
-            const request = indexedDB.open("keyval-store");
-            request.onsuccess = () => {
-              const db = request.result;
-              const tx = db.transaction("keyval", "readonly");
-              const store = tx.objectStore("keyval");
-              const getReq = store.get("auth-storage");
-              getReq.onsuccess = () => {
-                db.close();
-                resolve(getReq.result != null && getReq.result !== undefined);
-              };
-              getReq.onerror = () => {
-                db.close();
-                resolve(false);
-              };
-            };
-            request.onerror = () => resolve(false);
-          } catch {
-            resolve(false);
-          }
-        });
-      },
-      { timeout: 15000 },
-    );
-
+    await waitForAuthStorage(page);
     await page.reload();
-
-    // Check if we were redirected to login
-    let currentUrl = page.url();
-    const idbAuth = await page.evaluate(async () => {
-      return new Promise<unknown>((resolve) => {
-        try {
-          const request = indexedDB.open("keyval-store");
-          request.onsuccess = () => {
-            const db = request.result;
-            const tx = db.transaction("keyval", "readonly");
-            const store = tx.objectStore("keyval");
-            const getReq = store.get("auth-storage");
-            getReq.onsuccess = () => {
-              db.close();
-              resolve(getReq.result);
-            };
-            getReq.onerror = () => {
-              db.close();
-              resolve(null);
-            };
-          };
-          request.onerror = () => resolve(null);
-        } catch {
-          resolve(null);
-        }
-      });
+    await expect(page).toHaveURL(/\/app\/library\/overview/, {
+      timeout: 15000,
     });
-    console.log(`URL after reload: ${currentUrl}`);
-
-    if (currentUrl.includes("/auth/login")) {
-      console.log("Redirected to login, attempting recovery...");
-      await page.waitForTimeout(2000);
-      await page.goto("/app/library/overview");
-      currentUrl = page.url();
-    }
-
-    if (currentUrl.includes("/auth/login")) {
-      throw new Error(
-        `Session lost after reload: redirected to ${currentUrl}. IndexedDB auth: ${JSON.stringify(idbAuth)}`,
-      );
-    }
-
-    await expect(page).toHaveURL(/\/app\/library\/overview/);
     await expect(dashboardPage.sidebar).toBeVisible({ timeout: 15000 });
   });
 });

--- a/apps/e2e/src/web/navigation.spec.ts
+++ b/apps/e2e/src/web/navigation.spec.ts
@@ -60,6 +60,10 @@ test.describe("Navigation Flow", () => {
     await expect(page).toHaveURL(/\/app\/library\/overview/, {
       timeout: 15000,
     });
-    await expect(dashboardPage.sidebar).toBeVisible({ timeout: 15000 });
+    if (isMobile) {
+      await expect(sidebarTrigger).toBeVisible({ timeout: 15000 });
+    } else {
+      await expect(dashboardPage.sidebar).toBeVisible({ timeout: 15000 });
+    }
   });
 });

--- a/apps/e2e/src/web/password-reset.spec.ts
+++ b/apps/e2e/src/web/password-reset.spec.ts
@@ -1,56 +1,9 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { ForgotPasswordPage } from "./forgot-password.po";
 import { LoginPage } from "./login.po";
-import { RegistrationPage } from "./registration.po";
-import { VerifyEmailPage } from "./verify-email.po";
 import { DashboardPage } from "./dashboard.po";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
 import { getOtpFromMailhog } from "./mailhog.helper";
-
-interface VerifiedUser {
-  username: string;
-  email: string;
-  password: string;
-}
-
-async function createVerifiedUser(
-  page: Page,
-  username: string,
-  email: string,
-  password: string,
-): Promise<VerifiedUser> {
-  const registrationPage = new RegistrationPage(page);
-  const verifyEmailPage = new VerifyEmailPage(page);
-  const dashboardPage = new DashboardPage(page);
-
-  await registrationPage.goto();
-  await registrationPage.fillForm({
-    username,
-    firstName: "Test",
-    lastName: "User",
-    email,
-    password,
-    confirmPassword: password,
-  });
-  await registrationPage.selectGender("Male");
-  await registrationPage.selectBirthDate(new Date(1990, 5, 15));
-  await expect(registrationPage.submitButton).toBeEnabled({ timeout: 10000 });
-  await registrationPage.submit();
-  await registrationPage.expectSuccess();
-
-  await expect(page).toHaveURL(/\/auth\/verify-email/, { timeout: 15000 });
-  const otpCode = await getOtpFromMailhog(email);
-  expect(otpCode).not.toBeNull();
-
-  await verifyEmailPage.fillOtpCode(otpCode!);
-  await expect(verifyEmailPage.verifyButton).toBeEnabled();
-  await verifyEmailPage.clickVerify();
-  await expect(page).toHaveURL(/\/app/);
-
-  await dashboardPage.logout();
-  await expect(page).toHaveURL(/\/auth\/login/);
-
-  return { username, email, password };
-}
 
 test.describe("Password Reset Workflow", () => {
   let forgotPasswordPage: ForgotPasswordPage;
@@ -70,13 +23,10 @@ test.describe("Password Reset Workflow", () => {
   test("should reset password via full flow and login with new password", async ({
     page,
   }) => {
-    const t = Date.now();
-    const user = await createVerifiedUser(
-      page,
-      `reset_user_${t}`,
-      `reset_${t}@example.com`,
-      "OriginalPass123!",
-    );
+    const user = await createVerifiedUser(page, {
+      prefix: "reset_user",
+      logoutAfter: true,
+    });
     const newPassword = "NewPass456!";
 
     // ─── 1. Navigate to forgot password ────────────────────────
@@ -124,13 +74,10 @@ test.describe("Password Reset Workflow", () => {
   });
 
   test("should validate recover password form fields", async ({ page }) => {
-    const t = Date.now();
-    const user = await createVerifiedUser(
-      page,
-      `validate_user_${t}`,
-      `validate_${t}@example.com`,
-      "OriginalPass123!",
-    );
+    const user = await createVerifiedUser(page, {
+      prefix: "validate_user",
+      logoutAfter: true,
+    });
 
     await forgotPasswordPage.goto();
     await forgotPasswordPage.fillEmail(user.email);
@@ -154,13 +101,10 @@ test.describe("Password Reset Workflow", () => {
   test("should allow going back from recover to forgot card", async ({
     page,
   }) => {
-    const t = Date.now();
-    const user = await createVerifiedUser(
-      page,
-      `goback_user_${t}`,
-      `goback_${t}@example.com`,
-      "OriginalPass123!",
-    );
+    const user = await createVerifiedUser(page, {
+      prefix: "goback_user",
+      logoutAfter: true,
+    });
 
     await forgotPasswordPage.goto();
     await forgotPasswordPage.fillEmail(user.email);
@@ -179,13 +123,10 @@ test.describe("Password Reset Workflow", () => {
   });
 
   test("should resend reset code", async ({ page }) => {
-    const t = Date.now();
-    const user = await createVerifiedUser(
-      page,
-      `resend_user_${t}`,
-      `resend_${t}@example.com`,
-      "OriginalPass123!",
-    );
+    const user = await createVerifiedUser(page, {
+      prefix: "resend_user",
+      logoutAfter: true,
+    });
 
     await forgotPasswordPage.goto();
     await forgotPasswordPage.fillEmail(user.email);
@@ -201,13 +142,10 @@ test.describe("Password Reset Workflow", () => {
   });
 
   test("should show error for invalid reset code", async ({ page }) => {
-    const t = Date.now();
-    const user = await createVerifiedUser(
-      page,
-      `invalid_user_${t}`,
-      `invalid_${t}@example.com`,
-      "OriginalPass123!",
-    );
+    const user = await createVerifiedUser(page, {
+      prefix: "invalid_user",
+      logoutAfter: true,
+    });
 
     await forgotPasswordPage.goto();
     await forgotPasswordPage.fillEmail(user.email);

--- a/apps/e2e/src/web/playback.spec.ts
+++ b/apps/e2e/src/web/playback.spec.ts
@@ -27,6 +27,8 @@ test.describe("Playback Functionality", () => {
   const artistName = `Playback Artist ${timestamp}`;
   const albumName = `Playback Album ${timestamp}`;
   const trackName = `Playback Track ${timestamp}`;
+  const initialTrackName = "Initial Track";
+  let albumId: string;
 
   test.describe.configure({ mode: "serial", timeout: 120_000 });
 
@@ -133,7 +135,7 @@ test.describe("Playback Functionality", () => {
     await test.step("Add Track", async () => {
       await expect(page).toHaveURL(/\/app\/library\/albums\/[^/]+/);
       const albumUrl = page.url().split("?")[0];
-      const albumId = albumUrl.split("/").filter(Boolean).pop();
+      albumId = albumUrl.split("/").filter(Boolean).pop()!;
       expect(albumId).toBeTruthy();
 
       await page.goto(`/app/library/albums/${albumId}/add-content`);
@@ -211,15 +213,102 @@ test.describe("Playback Functionality", () => {
   });
 
   test("should check audio quality menu", async () => {
-    // We only check that the quality menu opens and "Auto" is available.
-    // Specific qualities might be disabled depending on backend processing latency.
     await playerPage.moreActionsButton.click();
     await playerPage.audioQualityMenuTrigger.click();
     await expect(
       page.getByRole("menuitemcheckbox", { name: "Auto" }),
     ).toBeVisible();
-    // Close menu
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
+  });
+
+  test("should toggle shuffle and repeat", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    const trackRow = page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: initialTrackName });
+    await trackRow.click();
+
+    await playerPage.toggleShuffle();
+    await expect(playerPage.shuffleButton).toHaveClass(/text-emerald-500/);
+
+    await playerPage.toggleRepeat();
+    await expect(playerPage.repeatButton).toHaveClass(/text-emerald-500/);
+  });
+
+  test("should skip between tracks", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    await expect(page.getByText(trackName)).toBeVisible({ timeout: 30000 });
+
+    const initialRow = page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: initialTrackName });
+    await initialRow.click();
+    await expect(playerPage.trackTitle).toHaveText(initialTrackName, {
+      timeout: 10000,
+    });
+
+    await playerPage.skipForward();
+    await expect(playerPage.trackTitle).not.toHaveText(initialTrackName, {
+      timeout: 15000,
+    });
+
+    const afterSkip = await playerPage.trackTitle.textContent();
+    await playerPage.skipBackward();
+    await expect(playerPage.trackTitle).toHaveText(initialTrackName, {
+      timeout: 10000,
+    });
+    expect(afterSkip).not.toBe(initialTrackName);
+  });
+
+  test("should seek within track", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    const trackRow = page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: initialTrackName });
+    await trackRow.click();
+    await playerPage.expectPlaying(initialTrackName);
+
+    const before = Number(
+      (await playerPage.progressSlider.getAttribute("aria-valuenow")) ?? "0",
+    );
+    await playerPage.seek(75);
+    await expect
+      .poll(async () =>
+        Number(
+          (await playerPage.progressSlider.getAttribute("aria-valuenow")) ??
+            "0",
+        ),
+      )
+      .toBeGreaterThan(before);
+  });
+
+  test("should open audio quality menu and select when enabled", async () => {
+    await playerPage.moreActionsButton.click();
+    await playerPage.audioQualityMenuTrigger.click();
+    await expect(
+      page.getByRole("menuitemcheckbox", { name: "Auto" }),
+    ).toBeVisible();
+    const highOption = page.getByRole("menuitemcheckbox", { name: "High" });
+    if (await highOption.isVisible()) {
+      await highOption.click({ force: true });
+    }
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+  });
+
+  test("should favorite track from player", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    const trackRow = page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: initialTrackName });
+    await trackRow.click();
+
+    const favButton = page.getByRole("button", {
+      name: "Favorite",
+      exact: true,
+    });
+    await favButton.click();
+    await expect(favButton).toBeVisible();
   });
 });

--- a/apps/e2e/src/web/playback.spec.ts
+++ b/apps/e2e/src/web/playback.spec.ts
@@ -291,7 +291,8 @@ test.describe("Playback Functionality", () => {
     ).toBeVisible();
     const highOption = page.getByRole("menuitemcheckbox", { name: "High" });
     if (await highOption.isVisible()) {
-      await highOption.click({ force: true });
+      await expect(highOption).toBeEnabled();
+      await highOption.click();
     }
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
@@ -309,6 +310,6 @@ test.describe("Playback Functionality", () => {
       exact: true,
     });
     await favButton.click();
-    await expect(favButton).toBeVisible();
+    await expect(favButton).toHaveClass(/text-emerald/);
   });
 });

--- a/apps/e2e/src/web/player.po.ts
+++ b/apps/e2e/src/web/player.po.ts
@@ -11,6 +11,7 @@ export class PlayerPage {
   readonly volumeSlider: Locator;
   readonly progressSlider: Locator;
   readonly moreActionsButton: Locator;
+  readonly favoriteButton: Locator;
   readonly trackTitle: Locator;
   readonly trackArtist: Locator;
   readonly audioQualityMenuTrigger: Locator;
@@ -37,6 +38,10 @@ export class PlayerPage {
 
     this.moreActionsButton = page.getByRole("button", {
       name: "More Player Actions",
+    });
+    this.favoriteButton = page.getByRole("button", {
+      name: "Favorite",
+      exact: true,
     });
     this.volumeButton = page.getByRole("button", { name: "Volume" });
     this.volumeSlider = page.locator('div[role="slider"]').last();

--- a/apps/e2e/src/web/playlists.po.ts
+++ b/apps/e2e/src/web/playlists.po.ts
@@ -93,18 +93,20 @@ export class PlaylistsPage {
     await this.page.getByRole("button", { name: "Shuffle" }).click();
   }
 
+  private playlistDetailActionsButton() {
+    return this.page
+      .locator("div.flex.items-center.gap-1.ml-2")
+      .getByRole("button");
+  }
+
   async openEditFromMenu() {
-    await this.page.getByRole("button", { name: /more/i }).click();
-    await this.page.getByRole("menuitem", { name: "Edit playlist" }).click();
+    await this.playlistDetailActionsButton().click();
+    await this.page.getByRole("menuitem", { name: "Edit" }).click();
     await expect(this.page).toHaveURL(/\/edit/, { timeout: 10000 });
   }
 
   async deletePlaylistFromDetail() {
-    const menuButton = this.page
-      .locator("button")
-      .filter({ has: this.page.locator("svg") })
-      .last();
-    await menuButton.click();
+    await this.playlistDetailActionsButton().click();
     await this.page.getByRole("menuitem", { name: /delete/i }).click();
     const dialog = this.page.getByRole("dialog");
     await expect(dialog).toBeVisible();

--- a/apps/e2e/src/web/playlists.po.ts
+++ b/apps/e2e/src/web/playlists.po.ts
@@ -1,0 +1,127 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+export class PlaylistsPage {
+  readonly page: Page;
+  readonly emptyStateHeading: Locator;
+  readonly newPlaylistLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emptyStateHeading = page.getByRole("heading", {
+      name: "No playlists yet",
+    });
+    this.newPlaylistLink = page.getByRole("link", { name: "New playlist" });
+  }
+
+  async gotoPlaylistsList() {
+    await this.page.goto("/app/playlists");
+  }
+
+  async gotoCreatePlaylist() {
+    await this.page.goto("/app/playlists/create");
+  }
+
+  async expectPlaylistsIndexLoaded() {
+    await expect(
+      this.page.getByRole("heading", { name: "All Playlists" }),
+    ).toBeVisible({ timeout: 10000 });
+    const empty = this.emptyStateHeading;
+    const hasCards = this.page.locator("div.group\\/playlist");
+    await expect(empty.or(hasCards.first())).toBeVisible({ timeout: 10000 });
+  }
+
+  async createPlaylist(name: string) {
+    await this.page.getByLabel("Name").fill(name);
+    await this.page.getByRole("button", { name: "Create playlist" }).click();
+    await this.page.waitForURL(/\/app\/playlists\/[^/]+$/, {
+      timeout: 15000,
+    });
+  }
+
+  async openPlaylistCard(name: string) {
+    await this.page.getByRole("heading", { name, exact: true }).click();
+    await this.page.waitForURL(/\/app\/playlists\/[^/]+$/, { timeout: 10000 });
+  }
+
+  async addTrackToPlaylistFromContextMenu(
+    trackTitle: string,
+    playlistName: string,
+  ) {
+    const trackRow = this.page
+      .locator("div.group.cursor-pointer")
+      .filter({ hasText: trackTitle });
+    await trackRow.click({ button: "right" });
+    await this.page.getByRole("menuitem", { name: "Add to playlist" }).hover();
+    await this.page
+      .getByRole("menuitem", { name: playlistName, exact: true })
+      .click();
+  }
+
+  private playlistCard(playlistName: string) {
+    return this.page.locator("div.group\\/playlist").filter({
+      has: this.page.getByRole("heading", { name: playlistName, exact: true }),
+    });
+  }
+
+  async pinPlaylistFromContextMenu(playlistName: string) {
+    const card = this.playlistCard(playlistName);
+    await expect(card).toBeVisible({ timeout: 15000 });
+    await card.click({ button: "right" });
+    await this.page.getByRole("menuitem", { name: "Pin to sidebar" }).click();
+    await expect(
+      this.page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: "Pinned to sidebar" }),
+    ).toBeVisible({ timeout: 15000 });
+    // Context menu items call preventDefault() so the menu stays open and blocks the card.
+    await this.page.keyboard.press("Escape");
+    await this.expectPlaylistPinnedInSidebar(playlistName);
+  }
+
+  async expectPlaylistPinnedInSidebar(playlistName: string) {
+    const sidebar = this.page.locator('[data-sidebar="sidebar"]');
+    await expect(
+      sidebar.getByRole("link", { name: playlistName, exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+  }
+
+  async playPlaylist() {
+    await this.page.getByRole("button", { name: "Play" }).first().click();
+  }
+
+  async shufflePlaylist() {
+    await this.page.getByRole("button", { name: "Shuffle" }).click();
+  }
+
+  async openEditFromMenu() {
+    await this.page.getByRole("button", { name: /more/i }).click();
+    await this.page.getByRole("menuitem", { name: "Edit playlist" }).click();
+    await expect(this.page).toHaveURL(/\/edit/, { timeout: 10000 });
+  }
+
+  async deletePlaylistFromDetail() {
+    const menuButton = this.page
+      .locator("button")
+      .filter({ has: this.page.locator("svg") })
+      .last();
+    await menuButton.click();
+    await this.page.getByRole("menuitem", { name: /delete/i }).click();
+    const dialog = this.page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: /delete/i }).click();
+    await expect(this.page).toHaveURL(/\/app\/playlists\/?$/, {
+      timeout: 15000,
+    });
+  }
+
+  async deletePlaylistFromCardContext(playlistName: string) {
+    const card = this.page
+      .locator("div.group\\/playlist")
+      .filter({ has: this.page.getByRole("heading", { name: playlistName }) });
+    await card.click({ button: "right" });
+    await this.page.getByRole("menuitem", { name: /delete playlist/i }).click();
+    const dialog = this.page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: /delete/i }).click();
+  }
+}

--- a/apps/e2e/src/web/playlists.spec.ts
+++ b/apps/e2e/src/web/playlists.spec.ts
@@ -96,12 +96,7 @@ test.describe("Playlists Workflow", () => {
     await playlistsPage.gotoPlaylistsList();
     await playlistsPage.openPlaylistCard(playlistName);
 
-    await page
-      .locator("div.flex.items-center.gap-1.ml-2")
-      .getByRole("button")
-      .last()
-      .click();
-    await page.getByRole("menuitem", { name: "Edit" }).click();
+    await playlistsPage.openEditFromMenu();
     await expect(page).toHaveURL(/\/edit/);
 
     const titleInput = page.getByLabel("Title");
@@ -125,7 +120,7 @@ test.describe("Playlists Workflow", () => {
     });
 
     await playerPage.favoriteButton.click();
-    await page.waitForTimeout(1000);
+    await expect(playerPage.favoriteButton).toHaveClass(/text-emerald/);
 
     await playlistsPage.gotoPlaylistsList();
     await playlistsPage.openPlaylistCard("Favorite songs");

--- a/apps/e2e/src/web/playlists.spec.ts
+++ b/apps/e2e/src/web/playlists.spec.ts
@@ -1,0 +1,143 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+import {
+  createAlbumWithTrack,
+  createArtist,
+  ensureLibraryReady,
+} from "./fixtures/library-content.helper";
+import { LibraryAlbumsPage } from "./library-albums.po";
+import { PlayerPage } from "./player.po";
+import { PlaylistsPage } from "./playlists.po";
+import { uniqueLabel } from "./test-data.helper";
+
+test.describe("Playlists Workflow", () => {
+  let page: Page;
+  let playlistsPage: PlaylistsPage;
+  let albumsPage: LibraryAlbumsPage;
+  let playerPage: PlayerPage;
+
+  const artistName = uniqueLabel("Playlist Artist");
+  const albumName = uniqueLabel("Playlist Album");
+  const trackName = uniqueLabel("Playlist Track");
+  const playlistName = uniqueLabel("E2E Playlist");
+  let albumId: string;
+
+  test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    playlistsPage = new PlaylistsPage(page);
+    albumsPage = new LibraryAlbumsPage(page);
+    playerPage = new PlayerPage(page);
+
+    await createVerifiedUser(page, { prefix: "playlists_user" });
+    await ensureLibraryReady(page);
+    await createArtist(page, artistName);
+    const seed = await createAlbumWithTrack(page, {
+      artistName,
+      albumName,
+      trackName,
+    });
+    albumId = seed.albumId;
+  });
+
+  test.afterAll(async () => {
+    if (page) await page.close();
+  });
+
+  test("should load playlists index", async () => {
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.expectPlaylistsIndexLoaded();
+  });
+
+  test("should create a playlist", async () => {
+    await playlistsPage.gotoCreatePlaylist();
+    await playlistsPage.createPlaylist(playlistName);
+    await expect(
+      page.locator("h2").filter({ hasText: playlistName }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should add track via context menu from album", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    await playlistsPage.addTrackToPlaylistFromContextMenu(
+      trackName,
+      playlistName,
+    );
+    await expect(page.locator("[data-sonner-toast]").first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("should show track on playlist detail and play", async () => {
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.openPlaylistCard(playlistName);
+    await expect(page.getByText(trackName)).toBeVisible({ timeout: 10000 });
+    await playlistsPage.playPlaylist();
+    await expect(playerPage.trackTitle).toHaveText(trackName, {
+      timeout: 15000,
+    });
+  });
+
+  test("should shuffle playlist", async () => {
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.openPlaylistCard(playlistName);
+    await playlistsPage.shufflePlaylist();
+    await expect(playerPage.trackTitle).toBeVisible({ timeout: 15000 });
+  });
+
+  test("should pin playlist to sidebar", async () => {
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.pinPlaylistFromContextMenu(playlistName);
+  });
+
+  test("should edit playlist name", async () => {
+    const editedName = `${playlistName} Edited`;
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.openPlaylistCard(playlistName);
+
+    await page
+      .locator("div.flex.items-center.gap-1.ml-2")
+      .getByRole("button")
+      .last()
+      .click();
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+    await expect(page).toHaveURL(/\/edit/);
+
+    const titleInput = page.getByLabel("Title");
+    await titleInput.waitFor({ state: "visible", timeout: 15000 });
+    await titleInput.clear();
+    await titleInput.fill(editedName);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page).toHaveURL(/\/app\/playlists\/[^/]+$/, {
+      timeout: 15000,
+    });
+    await expect(
+      page.locator("h2").filter({ hasText: editedName }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should favorite track from player and show in Favorites playlist", async () => {
+    await page.goto(`/app/library/albums/${albumId}`);
+    await albumsPage.playTrackOnDetail(trackName);
+    await expect(playerPage.trackTitle).toHaveText(trackName, {
+      timeout: 10000,
+    });
+
+    await playerPage.favoriteButton.click();
+    await page.waitForTimeout(1000);
+
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.openPlaylistCard("Favorite songs");
+    await expect(page.getByText(trackName)).toBeVisible({ timeout: 15000 });
+  });
+
+  test("should delete custom playlist", async () => {
+    const editedName = `${playlistName} Edited`;
+    await playlistsPage.gotoPlaylistsList();
+    await playlistsPage.deletePlaylistFromCardContext(editedName);
+    await expect(
+      page.getByRole("heading", { name: editedName, exact: true }),
+    ).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/apps/e2e/src/web/queue.po.ts
+++ b/apps/e2e/src/web/queue.po.ts
@@ -24,12 +24,13 @@ export class QueuePage {
     await track.click();
   }
 
-  async removeTrackFromQueue(index: number) {
-    const track = this.nextUpList
-      .locator('[data-testid="queue-item"]')
-      .nth(index);
-    await track.hover();
-    await track.locator('button[aria-label="Remove from queue"]').click();
+  async removeTrackFromQueueByTitle(title: string) {
+    const row = this.nextUpList
+      .locator("div.group")
+      .filter({ has: this.page.getByText(title, { exact: true }) })
+      .first();
+    await row.hover();
+    await row.locator("button").last().click();
   }
 
   async expectTrackInQueue(title: string) {

--- a/apps/e2e/src/web/queue.po.ts
+++ b/apps/e2e/src/web/queue.po.ts
@@ -29,6 +29,10 @@ export class QueuePage {
       .locator("div.group")
       .filter({ has: this.page.getByText(title, { exact: true }) })
       .first();
+    await expect(
+      row,
+      `Expected queue row for "${title}" in Next Up`,
+    ).toBeVisible({ timeout: 10000 });
     await row.hover();
     await row.locator("button").last().click();
   }

--- a/apps/e2e/src/web/queue.spec.ts
+++ b/apps/e2e/src/web/queue.spec.ts
@@ -341,11 +341,7 @@ test.describe("Queue Management", () => {
     const countBefore = await queueRows.count();
     expect(countBefore).toBeGreaterThan(0);
 
-    const queueRow = queueRows
-      .filter({ has: page.getByText(track2, { exact: true }) })
-      .first();
-    await queueRow.hover();
-    await queueRow.locator("button").last().click({ force: true });
+    await queuePage.removeTrackFromQueueByTitle(track2);
 
     await expect(queueRows).toHaveCount(countBefore - 1, { timeout: 10000 });
     await page.keyboard.press("Escape");

--- a/apps/e2e/src/web/queue.spec.ts
+++ b/apps/e2e/src/web/queue.spec.ts
@@ -326,4 +326,28 @@ test.describe("Queue Management", () => {
 
     await newContext.close();
   });
+
+  test("should remove track from queue", async () => {
+    await playTrackFromAlbum(page, playerPage, track1);
+
+    const track2Card = await getUniqueAlbumTrackCard(page, track2);
+    await track2Card.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Add to Queue" }).click();
+
+    await page.getByRole("button", { name: "Queue", exact: true }).click();
+    await queuePage.expectTrackInQueue(track2);
+
+    const queueRows = queuePage.nextUpList.locator("div.group");
+    const countBefore = await queueRows.count();
+    expect(countBefore).toBeGreaterThan(0);
+
+    const queueRow = queueRows
+      .filter({ has: page.getByText(track2, { exact: true }) })
+      .first();
+    await queueRow.hover();
+    await queueRow.locator("button").last().click({ force: true });
+
+    await expect(queueRows).toHaveCount(countBefore - 1, { timeout: 10000 });
+    await page.keyboard.press("Escape");
+  });
 });

--- a/apps/e2e/src/web/smoke.spec.ts
+++ b/apps/e2e/src/web/smoke.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { createVerifiedUser } from "./fixtures/authenticated-user.helper";
+
+test.describe("Smoke tests", () => {
+  test("landing page shows Playr title when logged out", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Playr/);
+  });
+
+  test("logged-in user visiting landing redirects to app", async ({ page }) => {
+    await createVerifiedUser(page, { prefix: "smoke_user" });
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
+  });
+
+  test("placeholder app routes render expected copy", async ({ page }) => {
+    await createVerifiedUser(page, { prefix: "smoke_routes" });
+
+    await page.goto("/app");
+    await expect(
+      page.getByRole("heading", { name: "Dashboard" }),
+    ).toBeVisible();
+
+    await page.goto("/app/search");
+    await expect(page.getByRole("heading", { name: "Search" })).toBeVisible();
+
+    await page.goto("/app/new");
+    await expect(page.getByRole("heading", { name: "New" })).toBeVisible();
+  });
+});

--- a/apps/e2e/src/web/test-data.helper.ts
+++ b/apps/e2e/src/web/test-data.helper.ts
@@ -29,7 +29,13 @@ export function uniqueUsername(prefix: string): string {
 }
 
 export function uniqueEmail(prefix: string): string {
-  return `${prefix}_${uniqueSuffix()}@example.com`;
+  const sanitized =
+    prefix
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]/g, "")
+      .slice(0, 32) || "user";
+  return `${sanitized}_${uniqueSuffix()}@example.com`;
 }
 
 export function uniqueLabel(prefix: string): string {

--- a/apps/e2e/src/web/test-data.helper.ts
+++ b/apps/e2e/src/web/test-data.helper.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_TEST_PASSWORD = "Password123!";
+
+export const TEST_AUDIO_PATH = path.resolve(
+  __dirname,
+  "../../ui-tests/assets/test-audio.mp3",
+);
+
+export const TEST_IMAGE_PATH = path.resolve(
+  __dirname,
+  "../../ui-tests/assets/test-image.jpg",
+);
+
+export function uniqueSuffix(): number {
+  return Date.now() + Math.floor(Math.random() * 100_000);
+}
+
+export function uniqueUsername(prefix: string): string {
+  const base = prefix
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "")
+    .slice(0, 12);
+  const id = String(uniqueSuffix() % 1_000_000_000);
+  return `${base}_${id}`.slice(0, 32);
+}
+
+export function uniqueEmail(prefix: string): string {
+  return `${prefix}_${uniqueSuffix()}@example.com`;
+}
+
+export function uniqueLabel(prefix: string): string {
+  return `${prefix} ${uniqueSuffix()}`;
+}

--- a/apps/e2e/src/web/unit.spec.ts
+++ b/apps/e2e/src/web/unit.spec.ts
@@ -1,5 +1,0 @@
-import { test, expect } from "@playwright/test";
-
-test("basic environment check", async () => {
-  expect(1 + 1).toBe(2);
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,7 +546,7 @@ importers:
   apps/e2e:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.0
+        specifier: 1.59.1
         version: 1.59.1
       '@repo/configs':
         specifier: workspace:*


### PR DESCRIPTION
test(apps/e2e): add shared web fixtures and test data helpers

Extract authenticated-user, API, library seeding, and auth-storage helpers so web specs can share setup without duplicating registration flows.

Co-authored-by: Cursor <cursoragent@cursor.com>

test(apps/e2e): add API health check spec

Verify the API responds on the configured base URL before web flows depend on backend availability.

Co-authored-by: Cursor <cursoragent@cursor.com>

test(apps/e2e): add playlists workflow e2e coverage

Exercise playlist create, track add, playback, shuffle, sidebar pin, edit, favorites, and delete; scope player favorite control to avoid album action collisions.

Co-authored-by: Cursor <cursoragent@cursor.com>

test(apps/e2e): add library albums, genres, and songs workflows

Cover album CRUD and playback, genre detail with linked content, and songs list interactions using shared library fixtures.

Co-authored-by: Cursor <cursoragent@cursor.com>

test(apps/e2e): add listen history and smoke specs

Add a focused listen-history flow and a minimal smoke path for quick regression of core app routes.

Co-authored-by: Cursor <cursoragent@cursor.com>

test(apps/e2e): refactor existing web specs to shared fixtures

Reuse authenticated-user and library helpers across library, navigation, auth, playback, and queue tests; remove placeholder example and unit specs.

Co-authored-by: Cursor <cursoragent@cursor.com>

docs: document e2e test layout and run commands

Describe how to run web and API Playwright suites and where shared fixtures live.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad E2E coverage added: albums, songs, genres, playlists, listen history, playback, queue, and API health checks; favoriting tested.

* **Documentation**
  * Expanded E2E testing guide with Docker prerequisites, helper/fixture references, spec mapping, API smoke note, and CI vs local guidance.

* **Bug Fixes**
  * Scoped Play/Shuffle selectors on artist pages; queue removal now targets track title.

* **Tests**
  * Added shared auth, API and library helpers, page objects, and many feature-specific E2E suites.

* **Chores**
  * Streamlined CI Playwright setup and increased timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->